### PR TITLE
fix: broken json response because of null value

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -26,7 +26,7 @@ final class EditController extends ActionController
         $returnUrl = $this->request->getHeaderLine('Referer');
         $languageUid = $this->request->getQueryParams()['language_uid'] ?? 0;
 
-        $data = json_decode($this->request->getBody()->getContents(), true);
+        $data = json_decode($this->request->getBody()->getContents(), true) ?? [];
 
         if (!$this->checkBackendUserPageAccess((int)$pid)) {
             return new JsonResponse([]);


### PR DESCRIPTION
In some cases an empty or broken request body leads to an error response. This PR ensures the `$data` variable contains an array.