### PR TITLE
fix: paragraph font size in dropdown menu

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -72,6 +72,8 @@
 .xima-typo3-frontend-edit--dropdown-menu-inner p {
     margin-top: 10px;
     margin-bottom: 0;
+    font-size: 14px;
+    line-height: 1;
 }
 
 .xima-typo3-frontend-edit--dropdown-menu-inner div.xima-typo3-frontend-edit--divider {


### PR DESCRIPTION
Global styles for the `p` element overrule the paragraph in the dropdown menu:

![Screenshot 2024-09-05 at 16 07 43](https://github.com/user-attachments/assets/6e66cafa-296b-4cf3-8145-152c36715330)

This PR adds `font-size` and `line-height` for the element.