### PR TITLE
Only render js if typoscript is included

### DIFF
--- a/Classes/Middleware/ToolRendererMiddleware.php
+++ b/Classes/Middleware/ToolRendererMiddleware.php
@@ -13,15 +13,19 @@ use Xima\XimaTypo3FrontendEdit\Utility\ResourceRenderer;
 
 class ToolRendererMiddleware implements MiddlewareInterface
 {
-    public function __construct(protected readonly ResourceRenderer $resourceRenderer)
+    public function __construct(protected ResourceRenderer $resourceRenderer)
     {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
+        $typoScriptConfig = $request->getAttribute('frontend.typoscript')->getConfigArray();
+
         if (
-            $GLOBALS['BE_USER']
+            array_key_exists('tx_ximatypo3frontendedit_enable', $typoScriptConfig)
+            && $typoScriptConfig['tx_ximatypo3frontendedit_enable']
+            && $GLOBALS['BE_USER']
             && (!array_key_exists('tx_ximatypo3frontendedit_disable', $GLOBALS['BE_USER']->user) || !$GLOBALS['BE_USER']->user['tx_ximatypo3frontendedit_disable'])
         ) {
             $body = $response->getBody();

--- a/Classes/Middleware/ToolRendererMiddleware.php
+++ b/Classes/Middleware/ToolRendererMiddleware.php
@@ -20,7 +20,7 @@ class ToolRendererMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
-        $typoScriptConfig = $request->getAttribute('frontend.typoscript')->getConfigArray();
+        $typoScriptConfig = $GLOBALS['TSFE']->config['config'];
 
         if (
             array_key_exists('tx_ximatypo3frontendedit_enable', $typoScriptConfig)

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -15,3 +15,6 @@ tx_ximatypo3frontendedit_editinformationen {
     no_cache = 1
   }
 }
+
+# This config is set to control the ToolRendererMiddleware depending on whether the typoscript is included on the current site or not.
+config.tx_ximatypo3frontendedit_enable = 1


### PR DESCRIPTION
This fixes an issue, that for a second site, e.g. the manual, a typenum error occurs (when the ajax request is executed), if the typoscript is not included for this site. 