### PR TITLE
fix: missing nonce feature in v11

### DIFF
--- a/Classes/Utility/ResourceRenderer.php
+++ b/Classes/Utility/ResourceRenderer.php
@@ -11,10 +11,6 @@ use Xima\XimaTypo3FrontendEdit\Configuration;
 
 class ResourceRenderer
 {
-    public function __construct(private readonly RequestId $requestId)
-    {
-    }
-
     public function render(): string
     {
         $view = GeneralUtility::makeInstance(StandaloneView::class);
@@ -23,7 +19,12 @@ class ResourceRenderer
         $view->setPartialRootPaths(['EXT:' . Configuration::EXT_KEY . '/Resources/Private/Partials']);
         $view->setLayoutRootPaths(['EXT:' . Configuration::EXT_KEY . '/Resources/Private/Layouts']);
 
-        $view->assign('resources', ResourceUtility::getResources(['nonce' => $this->requestId->nonce]));
+        $view->assign('resources', ResourceUtility::getResources(['nonce' => $this->resolveNonceValue()]));
         return $view->render();
+    }
+
+    private function resolveNonceValue(): string
+    {
+        return GeneralUtility::makeInstance(RequestId::class)->nonce ? GeneralUtility::makeInstance(RequestId::class)->nonce->consume() : '';
     }
 }

--- a/Classes/Utility/ResourceRenderer.php
+++ b/Classes/Utility/ResourceRenderer.php
@@ -25,6 +25,6 @@ class ResourceRenderer
 
     private function resolveNonceValue(): string
     {
-        return GeneralUtility::makeInstance(RequestId::class)->nonce ? GeneralUtility::makeInstance(RequestId::class)->nonce->consume() : '';
+        return property_exists(RequestId::class, 'nonce') ? GeneralUtility::makeInstance(RequestId::class)->nonce->consume() : '';
     }
 }


### PR DESCRIPTION
Adjust dependency injection for the RequestId to get the nonce for the resource rendering regarding TYPO3 v11 not supporting this feature. 