### PR TITLE
fix: save and close functionality for v13

### DIFF
--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -8,7 +8,9 @@ use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 
@@ -44,6 +46,18 @@ final class ModifyButtonBarEventListener
                 ->setTitle($this->getLanguageService()->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:rm.saveCloseDoc'))
                 ->setIcon($iconFactory->getIcon('actions-document-save-close', Icon::SIZE_SMALL))
                 ->setShowLabelText(true);
+
+            $typo3Version = GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion();
+            if ($typo3Version >= 13) {
+                $saveCloseButton->setDataAttributes([
+                    'js' => 'save-close',
+                ]);
+
+                /** @var PageRenderer $pageRenderer */
+                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+                $pageRenderer->loadJavaScriptModule('@xima/ximatypo3frontendedit/save_close.js');
+            }
+
             $buttons[ButtonBar::BUTTON_POSITION_LEFT][2][] = $saveCloseButton;
         }
         $event->setButtons($buttons);

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'dependencies' => [
+        'backend',
+        'core',
+    ],
+    'imports' => [
+        '@xima/ximatypo3frontendedit/save_close.js' => 'EXT:xima_typo3_frontend_edit/Resources/Public/JavaScript/save_close.js',
+    ],
+];

--- a/Resources/Public/JavaScript/save_close.js
+++ b/Resources/Public/JavaScript/save_close.js
@@ -1,0 +1,16 @@
+import FormEngine from '@typo3/backend/form-engine.js'
+
+class SaveClose {
+  constructor() {
+    const saveCloseButton = document.querySelector('[data-js="save-close"]');
+    if (!saveCloseButton) {
+      return;
+    }
+    saveCloseButton.addEventListener('click', (e) => {
+      e.preventDefault()
+      FormEngine.saveAndCloseDocument()
+    });
+  }
+}
+
+export default new SaveClose()


### PR DESCRIPTION
In v13 its necessary to run the save and close functionality via the JS form engine.

Fixes #16 