### PR TITLE
fix: enhance TypoScript setup retrieval for cached pages in SettingsService

### DIFF
--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Service;
 
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\TypoScriptAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
@@ -51,17 +54,54 @@ final class SettingsService
         if (!empty($this->configuration)) {
             return $this->configuration;
         }
-        $request = $GLOBALS['TYPO3_REQUEST'];
 
         if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0.0', '<')) {
-            $fullTypoScript = $GLOBALS['TSFE']->tmpl->setup;
+            $fullTypoScript = $this->getTypoScriptSetupArrayV11();
         } else {
-            $fullTypoScript = $request->getAttribute('frontend.typoscript')->getSetupArray();
+            $fullTypoScript = $this->getTypoScriptSetupArrayV12($GLOBALS['TYPO3_REQUEST']);
         }
 
         $settings = $fullTypoScript['plugin.']['tx_ximatypo3frontendedit.']['settings.'] ?? [];
         $this->configuration = GeneralUtility::removeDotsFromTS($settings);
 
         return $this->configuration;
+    }
+
+    /**
+    * These methods need to handle the case that the TypoScript setup array is not available within full cached setup.
+    * I used this workaround from https://github.com/derhansen/fe_change_pwd to ensure that the TypoScript setup is available.
+    *
+    * @return array
+    */
+    private function getTypoScriptSetupArrayV11(): array
+    {
+        // Ensure, TSFE setup is loaded for cached pages
+        if ($GLOBALS['TSFE']->tmpl === null || ($GLOBALS['TSFE']->tmpl && empty($GLOBALS['TSFE']->tmpl->setup))) {
+            GeneralUtility::makeInstance(Context::class)
+                ->setAspect('typoscript', GeneralUtility::makeInstance(TypoScriptAspect::class, true));
+            $GLOBALS['TSFE']->getConfigArray();
+        }
+        return $GLOBALS['TSFE']->tmpl->setup;
+    }
+
+    private function getTypoScriptSetupArrayV12(ServerRequestInterface $request): array
+    {
+        try {
+            $fullTypoScript = $request->getAttribute('frontend.typoscript')->getSetupArray();
+        } catch (\Exception $e) {
+            // An exception is thrown, when TypoScript setup array is not available. This is usually the case,
+            // when the current page request is cached. Therefore, the TSFE TypoScript parsing is forced here.
+
+            // Set a TypoScriptAspect which forces template parsing
+            GeneralUtility::makeInstance(Context::class)
+                ->setAspect('typoscript', GeneralUtility::makeInstance(TypoScriptAspect::class, true));
+            $tsfe = $request->getAttribute('frontend.controller');
+            $requestWithFullTypoScript = $tsfe->getFromCache($request);
+
+            // Call TSFE getFromCache, which re-processes TypoScript respecting $forcedTemplateParsing property
+            // from TypoScriptAspect
+            $fullTypoScript = $requestWithFullTypoScript->getAttribute('frontend.typoscript')->getSetupArray();
+        }
+        return $fullTypoScript;
     }
 }


### PR DESCRIPTION
Fixes #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability in retrieving TypoScript configuration across different TYPO3 versions, ensuring settings are correctly loaded even on cached pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->