### PR TITLE
feat: extend UrlUtility for dynamic URL building with redirect option

### DIFF
--- a/Classes/Service/MenuGenerator.php
+++ b/Classes/Service/MenuGenerator.php
@@ -18,6 +18,7 @@ use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDropdownModifyEvent;
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
 use Xima\XimaTypo3FrontendEdit\Utility\ContentUtility;
+use Xima\XimaTypo3FrontendEdit\Utility\UrlUtility;
 
 final class MenuGenerator
 {
@@ -130,7 +131,7 @@ final class MenuGenerator
                     'edit',
                     ButtonType::Link,
                     label: $contentElement['CType'] === 'list' ? 'LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang.xlf:edit_plugin' : 'LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang.xlf:edit_content_element',
-                    url: GeneralUtility::makeInstance(UriBuilder::class)->buildUriFromRoute(
+                    url: UrlUtility::buildUrl(
                         'record_edit',
                         [
                             'edit' => [
@@ -140,9 +141,9 @@ final class MenuGenerator
                                 'language' => $languageUid,
                             ],
                             'returnUrl' => $returnUrlAnchor,
+                            'token' => 0,
                         ]
-                    )->__toString()
-                    . '&tx_ximatypo3frontendedit', // add custom parameter to identify the request and render the save and close button in the edit form
+                    ) . '&tx_ximatypo3frontendedit', // add custom parameter to identify the request and render the save and close button in the edit form
                     icon: $contentElement['CType'] === 'list' ? 'content-plugin' : 'content-textpic'
                 );
                 $this->processNewButton(

--- a/Classes/Utility/UrlUtility.php
+++ b/Classes/Utility/UrlUtility.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Utility;
 
+use TYPO3\CMS\Backend\Routing\RouteRedirect;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use Xima\XimaTypo3FrontendEdit\Configuration;
 
 class UrlUtility
 {
@@ -24,5 +28,20 @@ class UrlUtility
         ];
 
         return $contentObjectRenderer->typoLink_URL($typolinkConfiguration);
+    }
+
+    public static function buildUrl(string $route, array $parameters): string
+    {
+        $useRedirect = false;
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        if (isset($extensionConfiguration->get(Configuration::EXT_KEY)['useRedirect']) && $extensionConfiguration->get(Configuration::EXT_KEY)['useRedirect']) {
+            $useRedirect = true;
+        }
+
+        if ($useRedirect) {
+            return GeneralUtility::makeInstance(UriBuilder::class)->buildUriWithRedirect('main', [], RouteRedirect::create($route, $parameters))->__toString();
+        }
+
+        return GeneralUtility::makeInstance(UriBuilder::class)->buildUriFromRoute($route, $parameters)->__toString();
     }
 }

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -42,3 +42,11 @@ The extension currently provides the following configuration options:
     :Default: 0
 
     This mode will disable the menu dropdown and use the edit icon button directly as edit link instead
+
+..  _extconf-useRedirect:
+
+..  confval:: Redirect
+    :type: boolean
+    :Default: 0
+
+    Use the redirect option to redirect the edit links, so the full TYPO3 backend is loaded instead of only the edit form

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,3 +6,5 @@ forceReturnUrlGeneration = 0
 linkTargetBlank = 0
 # cat=basic//103; type=boolean; label=Simple mode: This mode will disable the menu dropdown and use the edit icon button directly as edit link instead
 simpleMode = 0
+# cat=basic//104; type=boolean; label=Redirect: Use the redirect option to redirect the edit links, so the full TYPO3 backend is loaded instead of only the edit form
+useRedirect = 0


### PR DESCRIPTION
Fixes #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to control whether edit links redirect to the full TYPO3 backend or only load the edit form.

- **Documentation**
  - Updated extension documentation to describe the new "Redirect" configuration option.

- **Chores**
  - Updated configuration templates to include the new redirect option for edit links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->