### PR TITLE
fix: save and close button in simple mode

### DIFF
--- a/Classes/Service/Menu/MenuButtonBuilder.php
+++ b/Classes/Service/Menu/MenuButtonBuilder.php
@@ -56,7 +56,7 @@ final class MenuButtonBuilder
             'tt_content',
             $languageUid,
             $returnUrlAnchor
-        );
+        ) . '&tx_ximatypo3frontendedit';
 
         return new Button(
             'LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang.xlf:edit_menu',


### PR DESCRIPTION
This PR adds the `tx_ximatypo3frontendedit` parameter to the edit url used in simple mode. This parameter is needed to make the "save & close" button work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edit button links now reliably open the frontend editor by including the required parameter, preventing redirects to non-edit views and ensuring consistent behavior across pages.
  * Improves stability of in-place editing workflows, reducing failed loads and better preserving edit mode when returning from edited content for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->