### PR TITLE
fix: improve clarity of extension version description in bug report YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      description: What version of EXT:solver are you using?
+      description: What version of the extension are you using?
       placeholder: 'e.g. 0.1.0'
     validations:
       required: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Bug Report template’s extension-version field description to reference “the extension” generically rather than “EXT:solver.”
  - Ensures consistent wording across projects using the template.
  - No changes to the template’s structure, fields, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->