### PR TITLE
fix: exclude ext_emconf.php from PHP CS Fixer configuration

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -30,5 +30,9 @@ return Config::create()
             DocBlockHeader::fromComposer()->__toArray(),
         ),
     )
-    ->withFinder(static fn (Finder $finder) => $finder->in(__DIR__))
+    ->withFinder(
+        static fn (Finder $finder) => $finder
+            ->in(__DIR__)
+            ->notPath(['ext_emconf.php']),
+    )
 ;

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
  *


### PR DESCRIPTION
Regarding the TYPO3 documentation and to prevent TER upload issues, the `ext_emconf.php` should not be fixed with a `declare(strict_types=1);` header.

See https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/FileStructure/ExtEmconf.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code style scanning configuration to exclude specific configuration files from analysis.
  * Modified PHP type-strictness settings in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->