### PR TITLE
feat: implement scroll-to-element functionality in Page Layout module

### DIFF
--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -15,6 +15,7 @@ namespace Xima\XimaTypo3FrontendEdit\EventListener;
 
 use TYPO3\CMS\Backend\Template\Components\{ButtonBar, ModifyButtonBarEvent};
 use TYPO3\CMS\Backend\Template\Components\Buttons\InputButton;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Configuration\Exception\{ExtensionConfigurationExtensionNotConfiguredException, ExtensionConfigurationPathDoesNotExistException};
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\{IconFactory, IconSize};
@@ -32,6 +33,7 @@ use function array_key_exists;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[AsEventListener(identifier: 'xima-typo3-frontend-edit/backend/modify-button-bar')]
 final class ModifyButtonBarEventListener
 {
     /** @var array<string, mixed> */

--- a/Classes/EventListener/PageLayoutScrollEventListener.php
+++ b/Classes/EventListener/PageLayoutScrollEventListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2025 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\EventListener;
+
+use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function array_key_exists;
+
+/**
+ * PageLayoutScrollEventListener.
+ *
+ * @see https://forge.typo3.org/issues/89678 - Related TYPO3 Core issue
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[AsEventListener(identifier: 'xima-typo3-frontend-edit/backend/page-layout-scroll')]
+final class PageLayoutScrollEventListener
+{
+    public function __invoke(ModifyButtonBarEvent $event): void
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if (null === $request) {
+            return;
+        }
+
+        $queryParams = $request->getQueryParams();
+
+        // Only load on Page Layout module when scrollToElement is present
+        if (!array_key_exists('scrollToElement', $queryParams)) {
+            return;
+        }
+
+        // Verify we're on the web_layout route
+        $route = $request->getAttribute('route');
+        if (null === $route || 'web_layout' !== $route->getOption('_identifier')) {
+            return;
+        }
+
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->loadJavaScriptModule('@xima/ximatypo3frontendedit/scroll_to_element.js');
+    }
+}

--- a/Classes/Service/Menu/MenuButtonBuilder.php
+++ b/Classes/Service/Menu/MenuButtonBuilder.php
@@ -129,8 +129,13 @@ final readonly class MenuButtonBuilder
 
         $this->addButton($menuButton, 'edit', ButtonType::Link, $editLabel, $editUrl, $editIcon);
 
-        // Edit page button
-        $pageUrl = $this->urlBuilderService->buildPageLayoutUrl($pid, $languageUid, $returnUrlAnchor);
+        // Edit page button (with anchor to scroll to content element)
+        $pageUrl = $this->urlBuilderService->buildPageLayoutUrl(
+            $pid,
+            $languageUid,
+            $returnUrlAnchor,
+            (int) $contentElement['uid'],
+        );
         $this->addButton($menuButton, 'edit_page', ButtonType::Link, url: $pageUrl, icon: 'apps-pagetree-page-default');
     }
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -52,16 +52,23 @@ final readonly class UrlBuilderService
     /**
      * @throws RouteNotFoundException
      */
-    public function buildPageLayoutUrl(int $pageId, int $languageUid, string $returnUrl): string
-    {
-        return $this->uriBuilder->buildUriFromRoute(
-            'web_layout',
-            [
-                'id' => $pageId,
-                'language' => $languageUid,
-                'returnUrl' => $returnUrl,
-            ],
-        )->__toString();
+    public function buildPageLayoutUrl(
+        int $pageId,
+        int $languageUid,
+        string $returnUrl,
+        ?int $contentElementUid = null,
+    ): string {
+        $parameters = [
+            'id' => $pageId,
+            'language' => $languageUid,
+            'returnUrl' => $returnUrl,
+        ];
+
+        if (null !== $contentElementUid) {
+            $parameters['scrollToElement'] = $contentElementUid;
+        }
+
+        return $this->uriBuilder->buildUriFromRoute('web_layout', $parameters)->__toString();
     }
 
     /**

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -18,5 +18,6 @@ return [
     ],
     'imports' => [
         '@xima/ximatypo3frontendedit/save_close.js' => 'EXT:xima_typo3_frontend_edit/Resources/Public/JavaScript/save_close.js',
+        '@xima/ximatypo3frontendedit/scroll_to_element.js' => 'EXT:xima_typo3_frontend_edit/Resources/Public/JavaScript/scroll_to_element.js',
     ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,8 +7,3 @@ services:
     Xima\XimaTypo3FrontendEdit\:
         resource: '../Classes/*'
         exclude: '../Classes/Domain/Model/*'
-
-    Xima\XimaTypo3FrontendEdit\EventListener\ModifyButtonBarEventListener:
-      tags:
-        - name: event.listener
-          identifier: 'xima-typo3-frontend-edit/backend/modify-button-bar'

--- a/Resources/Public/JavaScript/scroll_to_element.js
+++ b/Resources/Public/JavaScript/scroll_to_element.js
@@ -1,0 +1,55 @@
+/**
+ * Scroll to content element in Page Layout module.
+ *
+ * This module reads the scrollToElement parameter from the URL
+ * and scrolls to the corresponding content element.
+ *
+ * WORKAROUND: This is necessary because the TYPO3 backend uses an iframe
+ * architecture. URL fragments (e.g. #element-tt_content-123) are applied
+ * to the outer document, not the iframe content. When navigating from the
+ * frontend to the Page Layout module, the fragment is lost because the
+ * iframe is loaded separately without preserving the fragment.
+ *
+ * Native TYPO3 scroll-to-element works after editing because the redirect
+ * happens WITHIN the iframe context, preserving the fragment.
+ *
+ * @see https://forge.typo3.org/issues/89678 - Related TYPO3 Core issue
+ */
+class ScrollToElement {
+  constructor() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const elementUid = urlParams.get('scrollToElement');
+
+    if (!elementUid) {
+      return;
+    }
+
+    const elementId = `element-tt_content-${elementUid}`;
+    this.scrollToElement(elementId);
+  }
+
+  scrollToElement(elementId) {
+    // Wait for DOM to be fully loaded
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.performScroll(elementId));
+    } else {
+      // Small delay to ensure all dynamic content is rendered
+      setTimeout(() => this.performScroll(elementId), 100);
+    }
+  }
+
+  performScroll(elementId) {
+    const element = document.getElementById(elementId);
+
+    if (!element) {
+      return;
+    }
+
+    element.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center'
+    });
+  }
+}
+
+export default new ScrollToElement();


### PR DESCRIPTION
#87 

**WORKAROUND**: This is necessary because the TYPO3 backend uses an iframe architecture. URL fragments (e.g. #element-tt_content-123) are applied to the outer document, not the iframe content. When navigating from the frontend to the Page Layout module, the fragment is lost because the iframe is loaded separately without preserving the fragment.

Native TYPO3 scroll-to-element works after editing because the redirect happens WITHIN the iframe context, preserving the fragment.

See https://forge.typo3.org/issues/89678 - Related TYPO3 Core issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic scroll-to-element functionality that scrolls editors directly to the relevant content element when accessing the page layout edit interface, improving editing efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->