### PR TITLE
feat: allow disabling frontend edit per user or group via UserTSconfig

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -25,4 +25,5 @@ class Configuration
     final public const EXT_NAME = 'XimaTypo3FrontendEdit';
     final public const PLUGIN_NAME = 'FrontendEdit';
     final public const UC_KEY_DISABLED = 'frontendEditDisabled';
+    final public const USER_TSCONFIG_DISABLED = 'tx_ximatypo3frontendedit.disabled';
 }

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -25,5 +25,6 @@ class Configuration
     final public const EXT_NAME = 'XimaTypo3FrontendEdit';
     final public const PLUGIN_NAME = 'FrontendEdit';
     final public const UC_KEY_DISABLED = 'frontendEditDisabled';
-    final public const USER_TSCONFIG_DISABLED = 'tx_ximatypo3frontendedit.disabled';
+    final public const USER_TSCONFIG_KEY = 'tx_ximatypo3frontendedit.';
+    final public const USER_TSCONFIG_DISABLED = 'disabled';
 }

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -47,6 +47,10 @@ readonly class AjaxController
      */
     public function toggleAction(): JsonResponse
     {
+        if (!$this->backendUserService->isFrontendEditAllowed()) {
+            return new JsonResponse(['success' => false, 'error' => 'Frontend edit is not allowed'], 403);
+        }
+
         $backendUser = $this->getBackendUser();
 
         if (null === $backendUser || null === $backendUser->user) {
@@ -78,6 +82,10 @@ readonly class AjaxController
      */
     public function editInformationAction(ServerRequestInterface $request): JsonResponse
     {
+        if (!$this->backendUserService->isFrontendEditAllowed()) {
+            return new JsonResponse([]);
+        }
+
         $backendUser = $this->backendUserService->getBackendUser();
         if (null === $backendUser || null === $backendUser->user) {
             return new JsonResponse([]);

--- a/Classes/Middleware/ToolRendererMiddleware.php
+++ b/Classes/Middleware/ToolRendererMiddleware.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use Psr\Http\Server\{MiddlewareInterface, RequestHandlerInterface};
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Http\Stream;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{FlashMessageService, ResourceRendererService};
 
@@ -35,6 +36,7 @@ class ToolRendererMiddleware implements MiddlewareInterface
         private readonly ResourceRendererService $resourceRendererService,
         private readonly SettingsService $settingsService,
         private readonly FlashMessageService $flashMessageService,
+        private readonly BackendUserService $backendUserService,
     ) {}
 
     /**
@@ -50,12 +52,15 @@ class ToolRendererMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        // Only check if backend user is logged in - the sticky toolbar must be visible
-        // even when frontend edit is disabled so the user can re-enable it
         if (
             null === $GLOBALS['BE_USER']
             || !is_array($GLOBALS['BE_USER']->user)
         ) {
+            return $response;
+        }
+
+        // When disabled via UserTSconfig, hide everything including the sticky toolbar
+        if (!$this->backendUserService->isFrontendEditAllowed()) {
             return $response;
         }
 

--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -112,8 +112,9 @@ final class BackendUserService
         }
 
         $tsConfig = $backendUser->getTSConfig();
+        $extConfig = $tsConfig[Configuration::USER_TSCONFIG_KEY] ?? [];
 
-        return !((bool) ($tsConfig[Configuration::USER_TSCONFIG_DISABLED] ?? false));
+        return !((bool) ($extConfig[Configuration::USER_TSCONFIG_DISABLED] ?? false));
     }
 
     private function initializeBackendUser(): void

--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -76,6 +76,12 @@ final class BackendUserService
         return $backendUser->recordEditAccessInternals($table, $record);
     }
 
+    /**
+     * Check if frontend edit is disabled by the user's toggle (UC state).
+     *
+     * This reflects the user's personal on/off toggle and can be changed
+     * via the sticky toolbar. The toolbar remains visible when this is true.
+     */
     public function isFrontendEditDisabled(): bool
     {
         $backendUser = $this->getBackendUser();
@@ -85,6 +91,29 @@ final class BackendUserService
         }
 
         return (bool) ($backendUser->uc[Configuration::UC_KEY_DISABLED] ?? false);
+    }
+
+    /**
+     * Check if frontend edit is allowed for the current backend user via UserTSconfig.
+     *
+     * When disabled via UserTSconfig, the entire frontend edit feature is hidden
+     * including the sticky toolbar — the user cannot re-enable it themselves.
+     *
+     * UserTSconfig: tx_ximatypo3frontendedit.disabled = 1
+     *
+     * Default: allowed (enabled) for all backend users.
+     */
+    public function isFrontendEditAllowed(): bool
+    {
+        $backendUser = $this->getBackendUser();
+
+        if (null === $backendUser || null === $backendUser->user) {
+            return false;
+        }
+
+        $tsConfig = $backendUser->getTSConfig();
+
+        return !((bool) ($tsConfig[Configuration::USER_TSCONFIG_DISABLED] ?? false));
     }
 
     private function initializeBackendUser(): void

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -16,4 +16,5 @@ Learn what configuration options are available on the following pages:
     :maxdepth: 3
 
     SiteSettings
+    UserTSconfig
     ExtensionConfiguration

--- a/Documentation/Configuration/UserTSconfig.rst
+++ b/Documentation/Configuration/UserTSconfig.rst
@@ -1,0 +1,71 @@
+..  include:: /Includes.rst.txt
+
+..  _user-tsconfig:
+
+============
+UserTSconfig
+============
+
+..  versionadded:: 2.1.0
+
+You can disable the frontend editing feature for specific backend users or
+backend user groups via UserTSconfig.
+
+When disabled via UserTSconfig, the entire frontend editing feature is hidden —
+including the sticky toolbar. The user cannot re-enable it via the toggle button.
+
+This is useful for restricting frontend editing to certain editor groups while
+keeping other backend users unaffected.
+
+..  note::
+    This setting is different from the per-user toggle in the sticky toolbar.
+    The toggle allows users to temporarily hide the editing UI themselves.
+    The UserTSconfig setting is an administrative control that completely
+    prevents access to the feature.
+
+Disable frontend editing
+========================
+
+..  confval:: tx_ximatypo3frontendedit.disabled
+
+    :type: bool
+    :Default: false
+
+    Set to ``1`` to disable frontend editing for the affected backend users.
+
+    ..  code-block:: typoscript
+
+        tx_ximatypo3frontendedit.disabled = 1
+
+By default, frontend editing is **enabled** for all backend users.
+
+Examples
+========
+
+Disable for a specific backend user group
+------------------------------------------
+
+In the **TSconfig** field of a backend user group record:
+
+..  code-block:: typoscript
+
+    tx_ximatypo3frontendedit.disabled = 1
+
+All users in this group will no longer see the frontend editing UI.
+
+Disable for a specific backend user
+------------------------------------
+
+In the **TSconfig** field of a backend user record:
+
+..  code-block:: typoscript
+
+    tx_ximatypo3frontendedit.disabled = 1
+
+Disable globally via Page TSconfig
+-----------------------------------
+
+You can also set this in Page TSconfig (e.g. via
+:file:`Configuration/page.tsconfig`), which will then apply to all backend
+users on the affected pages. However, **UserTSconfig is recommended** as it
+targets users directly regardless of which page they visit.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The extension has been developed to provide a simple and lightweight solution to
 - **Dark/Light Mode** - Automatic or manual color scheme selection
 - **Configurable Position** - 12 toolbar positions available
 - **Save & Close** - Quick return to frontend after editing
+- **UserTSconfig** - Disable frontend editing per user or user group
 
 ## 🔥 Installation
 

--- a/Tests/Unit/ConfigurationTest.php
+++ b/Tests/Unit/ConfigurationTest.php
@@ -51,9 +51,15 @@ final class ConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function userTsconfigKeyConstantHasCorrectValue(): void
+    {
+        self::assertSame('tx_ximatypo3frontendedit.', Configuration::USER_TSCONFIG_KEY);
+    }
+
+    #[Test]
     public function userTsconfigDisabledConstantHasCorrectValue(): void
     {
-        self::assertSame('tx_ximatypo3frontendedit.disabled', Configuration::USER_TSCONFIG_DISABLED);
+        self::assertSame('disabled', Configuration::USER_TSCONFIG_DISABLED);
     }
 
     #[Test]
@@ -63,6 +69,7 @@ final class ConfigurationTest extends TestCase
         self::assertNotEmpty(Configuration::EXT_NAME);
         self::assertNotEmpty(Configuration::PLUGIN_NAME);
         self::assertNotEmpty(Configuration::UC_KEY_DISABLED);
+        self::assertNotEmpty(Configuration::USER_TSCONFIG_KEY);
         self::assertNotEmpty(Configuration::USER_TSCONFIG_DISABLED);
     }
 }

--- a/Tests/Unit/ConfigurationTest.php
+++ b/Tests/Unit/ConfigurationTest.php
@@ -51,11 +51,18 @@ final class ConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function userTsconfigDisabledConstantHasCorrectValue(): void
+    {
+        self::assertSame('tx_ximatypo3frontendedit.disabled', Configuration::USER_TSCONFIG_DISABLED);
+    }
+
+    #[Test]
     public function allConstantsAreNonEmpty(): void
     {
         self::assertNotEmpty(Configuration::EXT_KEY);
         self::assertNotEmpty(Configuration::EXT_NAME);
         self::assertNotEmpty(Configuration::PLUGIN_NAME);
         self::assertNotEmpty(Configuration::UC_KEY_DISABLED);
+        self::assertNotEmpty(Configuration::USER_TSCONFIG_DISABLED);
     }
 }


### PR DESCRIPTION
## Summary

- Add `tx_ximatypo3frontendedit.disabled = 1` UserTSconfig option to disable frontend editing per backend user or user group
- When disabled via UserTSconfig, the entire UI is hidden (including sticky toolbar) — users cannot re-enable it themselves
- Guard both AJAX endpoints (`toggleAction`, `editInformationAction`) against unauthorized access
- Default: enabled for all backend users (no breaking change)

## Changes

- `Classes/Configuration.php` — New `USER_TSCONFIG_DISABLED` constant
- `Classes/Service/Authentication/BackendUserService.php` — New `isFrontendEditAllowed()` method reading UserTSconfig
- `Classes/Middleware/ToolRendererMiddleware.php` — Skip resource injection when UserTSconfig disables feature
- `Classes/Controller/AjaxController.php` — Guard both endpoints with `isFrontendEditAllowed()` check
- `Tests/Unit/ConfigurationTest.php` — Tests for new constant
- `Documentation/Configuration/UserTSconfig.rst` — New documentation page with examples
- `Documentation/Configuration/Index.rst` — Add UserTSconfig to toctree
- `README.md` — Add feature to feature list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UserTSconfig option to disable frontend editing for specific backend users or groups; when disabled it hides the frontend editing UI (including sticky toolbar) and cannot be re-enabled via the UI.

* **Improvements**
  * Frontend editing UI and related actions now respect the UserTSconfig disable setting, returning appropriate errors or hiding controls when disabled.

* **Documentation**
  * Added UserTSconfig docs with setup examples.

* **Tests**
  * Unit tests added for the UserTSconfig settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->