### PR TITLE
docs: add delineation page comparing related extensions

### DIFF
--- a/Documentation/Delineation/Index.rst
+++ b/Documentation/Delineation/Index.rst
@@ -1,0 +1,58 @@
+..  include:: /Includes.rst.txt
+
+..  _delineation:
+
+============
+Delineation
+============
+
+There are several TYPO3 extensions that aim to improve the editing experience
+between frontend and backend. This page provides an overview of related
+extensions and how they differ from **xima_typo3_frontend_edit**.
+
+..  _delineation-visual-editor:
+
+visual_editor (FriendsOfTYPO3)
+==============================
+
+`visual_editor <https://github.com/FriendsOfTYPO3/visual_editor>`__ provides
+inline WYSIWYG editing using Web Components and CKEditor 5. Editors can modify
+text fields in place, reorder content elements via drag-and-drop, and save
+changes without leaving the page. It runs exclusively within a dedicated
+backend module that embeds the frontend page in an iframe — it does not inject
+editing capabilities into the regular frontend. It also requires ViewHelper
+integration in Fluid templates. In contrast, this extension works directly in
+the frontend, requires no template changes, and links to standard backend forms
+for editing.
+
+..  _delineation-feedit:
+
+feedit
+======
+
+`feedit <https://extensions.typo3.org/extension/feedit>`__ was the original
+TYPO3 core extension for frontend editing. It injected edit icons directly into
+the rendered HTML on the server side. The core integration it relied on has
+since been removed. This extension uses a different approach with PSR-15
+middleware and client-side AJAX menus.
+
+..  _delineation-frontend-editing:
+
+frontend_editing
+================
+
+`frontend_editing <https://extensions.typo3.org/extension/frontend_editing>`__
+is an older extension that provided frontend editing capabilities for TYPO3.
+This extension is **not** a further development of frontend_editing. While the
+general goal is similar, the technical approach is entirely different — this
+extension uses lightweight JavaScript injection and links to backend forms.
+
+..  _delineation-content-preview:
+
+content_preview
+===============
+
+`content_preview <https://github.com/T3-UX/content_preview>`__ provides a
+split-view with a live frontend preview within the TYPO3 backend Page module.
+It enhances the **backend** interface, while this extension enhances the
+**frontend**. Both approaches can be used together.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -84,6 +84,13 @@ This extension provides an edit menu for editors within the frontend regarding c
         ..  card-footer::   :ref:`Extend the functionalities <developer-corner>`
             :button-style: btn btn-secondary stretched-link
 
+    ..  card::  Delineation
+
+        How this extension compares to similar extensions like visual_editor, feedit, and others.
+
+        ..  card-footer::   :ref:`View comparison <delineation>`
+            :button-style: btn btn-secondary stretched-link
+
     ..  card::  FAQ
 
         A collection of frequently asked questions.
@@ -108,6 +115,7 @@ This extension provides an edit menu for editors within the frontend regarding c
     Configuration/Index
     Usage/Index
     DeveloperCorner/Index
+    Delineation/Index
     FAQ/Index
     Migration/Index
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -31,9 +31,7 @@ Features
 - :ref:`Save & Close <extconf-enableSaveAndCloseButton>` - Quick return to frontend after editing
 
 ..  note::
-    This is **not** a further development of the "original" extension `frontend_editing <https://extensions.typo3.org/extension/frontend_editing>`_. It is similar in some ways to the realisation of the `feedit <https://extensions.typo3.org/extension/feedit>`_ extension. This extension is an independent implementation with a different approach.
-
-    Unlike `content_preview <https://github.com/T3-UX/content_preview>`_, which provides a split-view with live frontend preview within the backend Page module, this extension works directly in the frontend and does not modify the backend interface.
+    This is **not** a further development of the "original" extension `frontend_editing <https://extensions.typo3.org/extension/frontend_editing>`_. It is similar in some ways to the realisation of the `feedit <https://extensions.typo3.org/extension/feedit>`_ extension. This extension is an independent implementation with a different approach. See :ref:`Delineation <delineation>` for a detailed comparison with related extensions like `visual_editor <https://github.com/FriendsOfTYPO3/visual_editor>`_ and `content_preview <https://github.com/T3-UX/content_preview>`_.
 
 ..  _support:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ This extension provides an edit menu for editors within the frontend regarding c
 ![Frontend Edit](./Documentation/Images/screenshot.jpg)
 
 > [!NOTE]
-> **Delineation and classification**: This is **not** a further development of the "original" extension [frontend_editing](https://extensions.typo3.org/extension/frontend_editing). It is similar in some ways to the realisation of the [feedit](https://extensions.typo3.org/extension/feedit) extension. This extension is an independent implementation with a different approach.
->
-> Unlike [content_preview](https://github.com/T3-UX/content_preview), which provides a split-view with live frontend preview within the backend Page module, this extension works directly in the frontend and does not modify the backend interface.
+> **Delineation and classification**: This is **not** a further development of the "original" extension [frontend_editing](https://extensions.typo3.org/extension/frontend_editing). It is similar in some ways to the realisation of the [feedit](https://extensions.typo3.org/extension/feedit) extension. This extension is an independent implementation with a different approach. See the [Delineation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Delineation/Index.html) page in the documentation for a detailed comparison with related extensions like [visual_editor](https://github.com/FriendsOfTYPO3/visual_editor) and [content_preview](https://github.com/T3-UX/content_preview).
 
 The extension has been developed to provide a simple and lightweight solution to easily start the editing of content elements from the frontend and thus reduce the gap between frontend and backend. Therefore, a simple javascript is injected into the frontend, which generates action links to the TYPO3 backend with the corresponding edit views.
 


### PR DESCRIPTION
## Summary

- Add new documentation page `Documentation/Delineation/Index.rst` comparing this extension with related TYPO3 extensions: visual_editor, feedit, frontend_editing, and content_preview
- Consolidate delineation notes in README and Introduction to a short paragraph with link to the new detail page

## Changes

- `Documentation/Delineation/Index.rst` - New page with one paragraph per related extension
- `Documentation/Index.rst` - Add card and toctree entry for Delineation
- `Documentation/Introduction/Index.rst` - Consolidate note, add ref to Delineation page
- `README.md` - Consolidate note, add link to Delineation page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Delineation page providing a comprehensive comparison of this extension with related TYPO3 frontend editing extensions (visual_editor, feedit, frontend_editing, and content_preview).
  * Updated introduction and README to reference the new comparison documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->