### PR TITLE
refactor: TYPO3 v14.2 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,5 +9,5 @@ jobs:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests.yml@main
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
-      typo3-versions: '["13.4", "14.1"]'
+      typo3-versions: '["13.4", "14.2"]'
       dependencies: '["highest", "lowest"]'

--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\BackendUserUtility;
 
 /**
  * BackendUserService.
@@ -73,7 +74,7 @@ final class BackendUserService
             return false;
         }
 
-        return $backendUser->recordEditAccessInternals($table, $record);
+        return BackendUserUtility::hasRecordEditAccess($backendUser, $table, $record);
     }
 
     /**

--- a/Classes/Service/Content/ContentElementFilter.php
+++ b/Classes/Service/Content/ContentElementFilter.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\BackendUserUtility;
 
 use function in_array;
 
@@ -93,7 +94,7 @@ final readonly class ContentElementFilter
         array $ignoredUids,
     ): bool {
         // Check edit permissions
-        if (!$backendUser->recordEditAccessInternals('tt_content', $contentElement)) {
+        if (!BackendUserUtility::hasRecordEditAccess($backendUser, 'tt_content', $contentElement)) {
             return false;
         }
 

--- a/Classes/Utility/Compatibility/BackendUserUtility.php
+++ b/Classes/Utility/Compatibility/BackendUserUtility.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Utility\Compatibility;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * BackendUserUtility.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class BackendUserUtility
+{
+    /**
+     * Check if a backend user has edit access to a record.
+     *
+     * Uses checkRecordEditAccess() on TYPO3 v14.2+ (where recordEditAccessInternals is deprecated)
+     * and falls back to recordEditAccessInternals() on older versions.
+     *
+     * @param array<string, mixed> $record
+     *
+     * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Deprecation-108568-BackendUserAuthenticationRecordEditAccessInternalsAndErrorMsg.html
+     */
+    public static function hasRecordEditAccess(BackendUserAuthentication $backendUser, string $table, array $record): bool
+    {
+        if (method_exists($backendUser, 'checkRecordEditAccess')) {
+            return $backendUser->checkRecordEditAccess($table, $record)->isAllowed;
+        }
+
+        return $backendUser->recordEditAccessInternals($table, $record);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 		"GPL-2.0-or-later"
 	],
 	"type": "typo3-cms-extension",
+	"version": "2.1.0",
 	"authors": [
 		{
 			"name": "Konrad Michalik",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae0925f23beb55c0369473d46d31c97b",
+    "content-hash": "eccf319bf511b312acfee3b13adb4938",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

- Migrate deprecated `recordEditAccessInternals()` to `checkRecordEditAccess()` (Deprecation #108568)
- Add `version` field to `composer.json` (Deprecation #108345)
- Bump CI matrix to TYPO3 14.2

## Changes

- `Classes/Utility/Compatibility/BackendUserUtility.php` - New compat wrapper using `method_exists()` guard for v13/v14.0-v14.1 backward compatibility
- `Classes/Service/Authentication/BackendUserService.php` - Delegate to `BackendUserUtility`
- `Classes/Service/Content/ContentElementFilter.php` - Delegate to `BackendUserUtility`
- `composer.json` / `composer.lock` - Add `version: 2.1.0`
- `.github/workflows/tests.yml` - Bump TYPO3 test matrix to 14.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 2.1.0
  * Updated test compatibility with TYPO3 version 14.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->