### PR TITLE
feat(a11y): ARIA attributes, keyboard navigation, focus management

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -838,6 +838,28 @@
     opacity: 1;
 }
 
+.frontend-edit__sidebar-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.1);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: inherit;
+    padding: 0;
+}
+
+.frontend-edit__sidebar-close:hover {
+    background: rgba(0, 0, 0, 0.2);
+}
+
 @media (prefers-reduced-motion: reduce) {
     .frontend-edit__notification,
     .frontend-edit__notification--visible,

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -839,8 +839,18 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .frontend-edit__notification,
+    .frontend-edit__notification--visible,
+    .frontend-edit__notification--hiding,
     .frontend-edit__sidebar,
-    .frontend-edit__sidebar-backdrop {
-        transition: none;
+    .frontend-edit__sidebar--open,
+    .frontend-edit__sidebar-backdrop,
+    .frontend-edit__sidebar-backdrop--visible,
+    .frontend-edit__overlay,
+    .frontend-edit__overlay--active,
+    .frontend-edit__tooltip,
+    .frontend-edit__tooltip--visible {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
     }
 }

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -842,7 +842,7 @@
     position: absolute;
     top: 8px;
     right: 8px;
-    z-index: 2;
+    z-index: 10006;
     width: 32px;
     height: 32px;
     display: flex;
@@ -868,11 +868,17 @@
     .frontend-edit__sidebar--open,
     .frontend-edit__sidebar-backdrop,
     .frontend-edit__sidebar-backdrop--visible,
+    .frontend-edit__sidebar-loader,
+    .frontend-edit__sidebar-iframe,
     .frontend-edit__overlay,
     .frontend-edit__overlay--active,
     .frontend-edit__tooltip,
     .frontend-edit__tooltip--visible {
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
+    }
+
+    .frontend-edit__sidebar-spinner {
+        animation: none !important;
     }
 }

--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -87,7 +87,6 @@
       closeButton.className = 'frontend-edit__sidebar-close';
       closeButton.setAttribute('aria-label', 'Close editor');
       closeButton.innerHTML = CLOSE_ICON;
-      closeButton.style.cssText = 'position:absolute;top:8px;right:8px;z-index:2;width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.1);border:none;border-radius:4px;cursor:pointer;color:inherit;padding:0;';
       closeButton.addEventListener('click', this.requestClose.bind(this));
       this.sidebar.appendChild(closeButton);
 

--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -81,6 +81,16 @@
       this.sidebar.setAttribute('aria-modal', 'true');
       this.sidebar.setAttribute('aria-label', 'Edit content');
 
+      // Close button
+      var closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'frontend-edit__sidebar-close';
+      closeButton.setAttribute('aria-label', 'Close editor');
+      closeButton.innerHTML = CLOSE_ICON;
+      closeButton.style.cssText = 'position:absolute;top:8px;right:8px;z-index:2;width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.1);border:none;border-radius:4px;cursor:pointer;color:inherit;padding:0;';
+      closeButton.addEventListener('click', this.requestClose.bind(this));
+      this.sidebar.appendChild(closeButton);
+
       // Loading spinner
       this.loader = document.createElement('div');
       this.loader.className = 'frontend-edit__sidebar-loader';
@@ -92,6 +102,27 @@
       this.iframe.className = 'frontend-edit__sidebar-iframe';
       this.iframe.setAttribute('title', 'Edit content');
       this.sidebar.appendChild(this.iframe);
+
+      // Focus trap
+      var sidebar = this.sidebar;
+      sidebar.addEventListener('keydown', function (e) {
+        if (e.key !== 'Tab') return;
+        var focusable = sidebar.querySelectorAll('button, [href], iframe, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+        var first = focusable[0];
+        var last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      });
 
       document.body.appendChild(this.backdrop);
       document.body.appendChild(this.sidebar);
@@ -133,6 +164,7 @@
 
     open: function (contextualUrl, uid, targetBlank) {
       log('Opening contextual edit for uid ' + uid);
+      this._triggerElement = document.activeElement;
       clearTimeout(this.resetTimeout);
       this.hasSaved = false;
       this.savedRecordTitle = null;
@@ -161,6 +193,10 @@
         setTimeout(function () { window.location.reload(); }, 2000);
       } else {
         document.body.classList.remove('frontend-edit__sidebar-active');
+      }
+      if (this._triggerElement && this._triggerElement.focus) {
+        this._triggerElement.focus();
+        this._triggerElement = null;
       }
     },
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -140,12 +140,20 @@
       document.querySelectorAll('.frontend-edit__dropdown').forEach(d => {
         d.style.display = 'none';
       });
+      document.querySelectorAll('.frontend-edit__btn--kebab').forEach(btn => {
+        btn.setAttribute('aria-expanded', 'false');
+      });
     },
 
     setupGlobalHandler() {
       document.addEventListener('click', (e) => {
         if (!e.target.closest('.frontend-edit__btn--kebab') &&
             !e.target.closest('.frontend-edit__dropdown')) {
+          this.closeAll();
+        }
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
           this.closeAll();
         }
       });
@@ -187,6 +195,8 @@
       if (!this.container) {
         this.container = document.createElement('div');
         this.container.className = 'frontend-edit__notification-container';
+        this.container.setAttribute('role', 'status');
+        this.container.setAttribute('aria-live', 'polite');
         document.body.appendChild(this.container);
       }
       return this.container;
@@ -220,6 +230,9 @@
       const notification = document.createElement('div');
       notification.className = 'frontend-edit__notification';
       notification.classList.add(`frontend-edit__notification--${message.severity.toLowerCase()}`);
+      if (message.severity.toLowerCase() === 'error') {
+        notification.setAttribute('role', 'alert');
+      }
 
       // Create icon
       const iconEl = document.createElement('span');
@@ -252,6 +265,7 @@
       closeBtn.className = 'frontend-edit__notification-close';
       closeBtn.type = 'button';
       closeBtn.innerHTML = ICONS.close;
+      closeBtn.setAttribute('aria-label', 'Dismiss notification');
       closeBtn.addEventListener('click', () => this.dismiss(notification));
       notification.appendChild(closeBtn);
 
@@ -490,9 +504,29 @@
       const toolbar = document.createElement('div');
       toolbar.className = 'frontend-edit__toolbar';
       toolbar.dataset.cid = uid;
+      toolbar.setAttribute('role', 'toolbar');
+      toolbar.setAttribute('aria-label', 'Edit content element ' + uid);
 
       toolbar.appendChild(this.createLabel(uid, contentElement));
       toolbar.appendChild(this.createActions(uid, contentElement, showContextMenu));
+
+      const buttons = toolbar.querySelectorAll('.frontend-edit__btn');
+      buttons.forEach((btn, i) => {
+        btn.setAttribute('tabindex', i === 0 ? '0' : '-1');
+      });
+      toolbar.addEventListener('keydown', (e) => {
+        if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+        const btns = Array.from(toolbar.querySelectorAll('.frontend-edit__btn'));
+        const idx = btns.indexOf(document.activeElement);
+        if (idx === -1) return;
+        e.preventDefault();
+        const next = e.key === 'ArrowRight'
+          ? (idx + 1) % btns.length
+          : (idx - 1 + btns.length) % btns.length;
+        btns[idx].setAttribute('tabindex', '-1');
+        btns[next].setAttribute('tabindex', '0');
+        btns[next].focus();
+      });
 
       return toolbar;
     },
@@ -543,6 +577,8 @@
       btn.className = 'frontend-edit__btn frontend-edit__btn--edit';
       btn.dataset.tooltip = 'Edit';
       btn.innerHTML = ICONS.edit;
+      const ctypeLabel = contentElement.element.ctypeLabel || contentElement.element.CType || 'Content';
+      btn.setAttribute('aria-label', 'Edit ' + ctypeLabel + ' ' + (contentElement.element.uid || ''));
 
       const editAction = contentElement.menu.children?.edit;
       if (editAction?.url && this.isValidUrl(editAction.url)) {
@@ -587,6 +623,9 @@
       btn.type = 'button';
       btn.dataset.cid = uid;
       btn.innerHTML = ICONS.kebab;
+      btn.setAttribute('aria-haspopup', 'menu');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-label', 'More actions for ' + uid);
       return btn;
     },
 
@@ -594,6 +633,7 @@
       const dropdown = document.createElement('div');
       dropdown.className = 'frontend-edit__dropdown';
       dropdown.dataset.cid = uid;
+      dropdown.setAttribute('role', 'menu');
 
       const skipActions = ['header'];
 
@@ -603,13 +643,11 @@
         const el = document.createElement(action.type === 'link' ? 'a' : 'div');
 
         if (action.type === 'link') {
-          // Validate URL to prevent javascript: protocol attacks
           if (action.url && this.isValidUrl(action.url)) {
             el.href = action.url;
           }
           if (action.targetBlank) el.target = '_blank';
 
-          // Contextual editing for the edit link in dropdown
           if (name === 'edit' && action.contextualUrl && UI.isValidUrl(action.contextualUrl)) {
             const contextualUrl = action.contextualUrl;
             const ceUid = contentElement.element?.uid;
@@ -625,19 +663,21 @@
 
         if (action.type === 'divider') {
           el.className = 'frontend-edit__divider';
+          el.setAttribute('role', 'separator');
+        } else {
+          el.setAttribute('role', 'menuitem');
+          el.setAttribute('tabindex', '-1');
         }
 
         if (action.type === 'info') {
           el.className = 'frontend-edit__info';
         }
 
-        // Sanitize class name to prevent injection
         const safeName = this.escapeClassName(name);
         if (safeName) {
           el.classList.add(safeName);
         }
 
-        // Icons are trusted HTML from TYPO3 backend (IconFactory)
         if (action.icon) {
           const iconWrapper = document.createElement('span');
           iconWrapper.innerHTML = action.icon;
@@ -654,6 +694,35 @@
 
         dropdown.appendChild(el);
       }
+
+      dropdown.addEventListener('keydown', (e) => {
+        const items = Array.from(dropdown.querySelectorAll('[role="menuitem"]'));
+        const idx = items.indexOf(document.activeElement);
+
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          const next = idx < items.length - 1 ? idx + 1 : 0;
+          items[next].focus();
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          const prev = idx > 0 ? idx - 1 : items.length - 1;
+          items[prev].focus();
+        } else if (e.key === 'Home') {
+          e.preventDefault();
+          items[0]?.focus();
+        } else if (e.key === 'End') {
+          e.preventDefault();
+          items[items.length - 1]?.focus();
+        } else if (e.key === 'Enter') {
+          if (document.activeElement && document.activeElement.click) {
+            document.activeElement.click();
+          }
+        } else if (e.key === 'Escape') {
+          Dropdown.closeAll();
+          const kebab = document.querySelector('.frontend-edit__btn--kebab[data-cid="' + uid + '"]');
+          if (kebab) kebab.focus();
+        }
+      });
 
       return dropdown;
     },
@@ -883,7 +952,10 @@
 
         if (!isVisible) {
           dropdown.style.display = 'block';
+          kebabBtn.setAttribute('aria-expanded', 'true');
           await Dropdown.position(kebabBtn, dropdown);
+          const firstItem = dropdown.querySelector('[role="menuitem"]');
+          if (firstItem) firstItem.focus();
         }
       });
     },

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -664,13 +664,12 @@
         if (action.type === 'divider') {
           el.className = 'frontend-edit__divider';
           el.setAttribute('role', 'separator');
+        } else if (action.type === 'info') {
+          el.className = 'frontend-edit__info';
+          el.setAttribute('role', 'presentation');
         } else {
           el.setAttribute('role', 'menuitem');
           el.setAttribute('tabindex', '-1');
-        }
-
-        if (action.type === 'info') {
-          el.className = 'frontend-edit__info';
         }
 
         const safeName = this.escapeClassName(name);
@@ -714,6 +713,7 @@
           e.preventDefault();
           items[items.length - 1]?.focus();
         } else if (e.key === 'Enter') {
+          e.preventDefault();
           if (document.activeElement && document.activeElement.click) {
             document.activeElement.click();
           }
@@ -972,7 +972,7 @@
         if (toolbar?.contains(e.relatedTarget)) return;
 
         OverlayManager.setActive(targetElement, false);
-        if (dropdown) dropdown.style.display = 'none';
+        if (dropdown) Dropdown.closeAll();
       });
 
       // Keep active when hovering toolbar
@@ -987,7 +987,7 @@
           if (dropdown?.contains(e.relatedTarget)) return;
 
           OverlayManager.setActive(targetElement, false);
-          if (dropdown) dropdown.style.display = 'none';
+          if (dropdown) Dropdown.closeAll();
         });
       }
 
@@ -996,7 +996,7 @@
           if (targetElement.contains(e.relatedTarget)) return;
           if (toolbar?.contains(e.relatedTarget)) return;
 
-          dropdown.style.display = 'none';
+          Dropdown.closeAll();
           OverlayManager.setActive(targetElement, false);
         });
       }


### PR DESCRIPTION
## Summary

- Add ARIA semantics (`role="toolbar"`, `role="menu"`, `aria-label`, `aria-expanded`, `aria-haspopup`) to toolbars, buttons, and dropdown menus
- Implement keyboard navigation: roving tabindex on toolbar buttons (Arrow Left/Right), dropdown menu navigation (Arrow Up/Down, Home/End, Enter, Escape)
- Add focus management for contextual editing sidebar: focus trap, focus return to trigger element on close, visible close button
- Add `aria-live="polite"` on notification container, `role="alert"` on error notifications
- Add `prefers-reduced-motion: reduce` media query for all animated elements

## Test plan

- [ ] Verify Tab navigates between content element toolbars
- [ ] Verify Arrow Left/Right moves focus between Edit and Kebab buttons within a toolbar
- [ ] Verify Arrow Down/Up, Home, End navigate dropdown menu items
- [ ] Verify Escape closes dropdown and returns focus to kebab button
- [ ] Verify sidebar traps focus and returns focus on close
- [ ] Verify close button in sidebar is visible and functional
- [ ] Verify notifications are announced by screen readers
- [ ] Verify animations are disabled with `prefers-reduced-motion: reduce`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close button to the sidebar for convenient dismissal
  * Enhanced keyboard navigation with focus trapping and restoration
  * Implemented keyboard shortcuts for menu control (Tab, Escape, Arrow keys)
  * Improved accessibility with screen reader support and better keyboard interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->