### PR TITLE
feat(hardening): service unit tests and defensive error handling

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -93,12 +93,18 @@ readonly class AjaxController
 
         $params = $request->getQueryParams();
 
-        $pid = (int) ($params['pid'] ?? 0);
-        if (0 === $pid) {
-            return new JsonResponse(['error' => 'Missing required parameter: pid'], 400);
+        $pidParam = $params['pid'] ?? null;
+        $pid = filter_var($pidParam, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if (false === $pid) {
+            return new JsonResponse(['error' => 'Missing or invalid parameter: pid must be a positive integer'], 400);
         }
 
-        $languageUid = (int) ($params['language'] ?? 0);
+        $languageParam = $params['language'] ?? 0;
+        $languageUid = filter_var($languageParam, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if (false === $languageUid) {
+            return new JsonResponse(['error' => 'Invalid parameter: language must be a non-negative integer'], 400);
+        }
+
         $returnUrl = (string) ($params['returnUrl'] ?? '');
         if ('' === $returnUrl) {
             return new JsonResponse(['error' => 'Missing required parameter: returnUrl'], 400);

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -819,7 +819,7 @@
       let failed = 0;
 
       for (let [uid, contentElement] of Object.entries(jsonResponse)) {
-        if (!contentElement.menu || !contentElement.element) {
+        if (!contentElement || !contentElement.menu || !contentElement.element) {
           Logger.log(`Skipping content element c${uid}: missing menu or element data`, null, 'warn');
           failed++;
           continue;

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -703,6 +703,7 @@
    */
   const DataService = {
     getClosestContentElement(element) {
+      if (!element) return null;
       while (element && !element.id.match(/c\d+/)) {
         element = element.parentElement;
       }
@@ -765,7 +766,8 @@
     async fetchContentElements(dataItems) {
       const config = document.getElementById('frontend-edit-toolbar-config');
       if (!config) {
-        throw new Error('Frontend edit configuration not found');
+        Logger.log('Frontend edit configuration element not found', null, 'warn');
+        return {};
       }
 
       const editInfoUrl = config.dataset.editInfoUrl;
@@ -780,21 +782,27 @@
 
       Logger.log('Sending request to backend', { url: url.toString() });
 
-      const response = await fetch(url.toString(), {
-        cache: 'no-cache',
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(dataItems)
-      });
+      try {
+        const response = await fetch(url.toString(), {
+          cache: 'no-cache',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(dataItems)
+        });
 
-      if (!response.ok) {
-        throw new Error('Failed to fetch content elements');
+        if (!response.ok) {
+          throw new Error('Failed to fetch content elements');
+        }
+
+        const data = await response.json();
+        Logger.log(`Backend response received with ${Object.keys(data).length} content element(s)`);
+
+        return data;
+      } catch (error) {
+        Notification.show({ title: 'Frontend Edit', message: 'Failed to load edit information', severity: 'error' });
+        Logger.log('Failed to fetch content elements', { error: error.message }, 'error');
+        return {};
       }
-
-      const data = await response.json();
-      Logger.log(`Backend response received with ${Object.keys(data).length} content element(s)`);
-
-      return data;
     }
   };
 
@@ -811,6 +819,12 @@
       let failed = 0;
 
       for (let [uid, contentElement] of Object.entries(jsonResponse)) {
+        if (!contentElement.menu || !contentElement.element) {
+          Logger.log(`Skipping content element c${uid}: missing menu or element data`, null, 'warn');
+          failed++;
+          continue;
+        }
+
         let idElement = document.querySelector(`#c${uid}`);
 
         // Handle translation mapping
@@ -993,6 +1007,7 @@
           error: error.message,
           stack: error.stack
         }, 'error');
+        Notification.show({ title: 'Frontend Edit', message: 'Initialization error', severity: 'warning' });
       }
     },
 

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -31,7 +31,6 @@ final class BackendUserServiceTest extends TestCase
     protected function tearDown(): void
     {
         unset($GLOBALS['BE_USER']);
-        parent::tearDown();
     }
 
     #[Test]

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Authentication;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+
+/**
+ * BackendUserServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(BackendUserService::class)]
+final class BackendUserServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getBackendUserReturnsNullWhenNotSet(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertNull($service->getBackendUser());
+    }
+
+    #[Test]
+    public function getBackendUserReturnsBackendUserFromGlobals(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertSame($backendUser, $service->getBackendUser());
+    }
+
+    #[Test]
+    public function getBackendUserCachesResult(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        $first = $service->getBackendUser();
+        $second = $service->getBackendUser();
+
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function hasPageAccessReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageAccess(1));
+    }
+
+    #[Test]
+    public function hasPageAccessReturnsFalseWhenUserDataIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageAccess(1));
+    }
+
+    #[Test]
+    public function hasRecordEditAccessReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasRecordEditAccess('tt_content', ['uid' => 1]));
+    }
+
+    #[Test]
+    public function hasRecordEditAccessReturnsFalseWhenUserDataIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasRecordEditAccess('tt_content', ['uid' => 1]));
+    }
+
+    #[Test]
+    public function isFrontendEditDisabledReturnsTrueWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->isFrontendEditDisabled());
+    }
+
+    #[Test]
+    public function isFrontendEditDisabledReturnsTrueWhenUserDataIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->isFrontendEditDisabled());
+    }
+
+    #[Test]
+    public function isFrontendEditDisabledReturnsFalseByDefault(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = [];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->isFrontendEditDisabled());
+    }
+
+    #[Test]
+    public function isFrontendEditDisabledReturnsTrueWhenUcKeyIsSet(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = [Configuration::UC_KEY_DISABLED => true];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->isFrontendEditDisabled());
+    }
+
+    #[Test]
+    public function isFrontendEditAllowedReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->isFrontendEditAllowed());
+    }
+
+    #[Test]
+    public function isFrontendEditAllowedReturnsFalseWhenUserDataIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->isFrontendEditAllowed());
+    }
+
+    #[Test]
+    public function isFrontendEditAllowedReturnsTrueByDefault(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getTSConfig')->willReturn([]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->isFrontendEditAllowed());
+    }
+
+    #[Test]
+    public function isFrontendEditAllowedReturnsFalseWhenDisabledViaTsConfig(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getTSConfig')->willReturn([
+            Configuration::USER_TSCONFIG_KEY => [
+                Configuration::USER_TSCONFIG_DISABLED => '1',
+            ],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->isFrontendEditAllowed());
+    }
+
+    #[Test]
+    public function isFrontendEditAllowedReturnsTrueWhenExplicitlyEnabled(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getTSConfig')->willReturn([
+            Configuration::USER_TSCONFIG_KEY => [
+                Configuration::USER_TSCONFIG_DISABLED => '0',
+            ],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->isFrontendEditAllowed());
+    }
+}

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -53,6 +53,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
+        unset($GLOBALS['LANG']);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -39,8 +39,6 @@ final class ContentElementButtonBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $iconMock = $this->createMock(Icon::class);
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($iconMock);
@@ -55,7 +53,6 @@ final class ContentElementButtonBuilderTest extends TestCase
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        parent::tearDown();
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory, IconSize};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementButtonBuilder;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+
+/**
+ * ContentElementButtonBuilderTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ContentElementButtonBuilder::class)]
+final class ContentElementButtonBuilderTest extends TestCase
+{
+    private IconService $iconService;
+    private UrlBuilderService $urlBuilderService;
+    private UriBuilder $uriBuilderMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $iconMock = $this->createMock(Icon::class);
+        $iconFactoryMock = $this->createMock(IconFactory::class);
+        $iconFactoryMock->method('getIcon')->willReturn($iconMock);
+        $this->iconService = new IconService($iconFactoryMock);
+
+        $this->uriBuilderMock = $this->createMock(UriBuilder::class);
+        $this->uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/record/edit'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $this->uriBuilderMock);
+        $this->urlBuilderService = new UrlBuilderService();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function createSimpleEditButtonReturnsLinkButton(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+
+        $button = $builder->createSimpleEditButton(
+            ['uid' => 1, 'CType' => 'text'],
+            0,
+            '/return',
+            false,
+        );
+
+        self::assertSame(ButtonType::Link, $button->getType());
+        self::assertNotNull($button->getUrl());
+        self::assertStringContainsString('tx_ximatypo3frontendedit', $button->getUrl());
+    }
+
+    #[Test]
+    public function createSimpleEditButtonSetsContextualUrl(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+
+        $button = $builder->createSimpleEditButton(
+            ['uid' => 1, 'CType' => 'text'],
+            0,
+            '/return',
+            false,
+            '/typo3/contextual',
+        );
+
+        self::assertSame('/typo3/contextual', $button->getContextualUrl());
+    }
+
+    #[Test]
+    public function createSimpleEditButtonWithoutContextualUrlSetsNull(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+
+        $button = $builder->createSimpleEditButton(
+            ['uid' => 1, 'CType' => 'text'],
+            0,
+            '/return',
+            false,
+        );
+
+        self::assertNull($button->getContextualUrl());
+    }
+
+    #[Test]
+    public function createFullMenuButtonReturnsMenuButton(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+
+        $button = $builder->createFullMenuButton();
+
+        self::assertSame(ButtonType::Menu, $button->getType());
+    }
+
+    #[Test]
+    public function addInfoSectionAddsChildrenToMenuButton(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $GLOBALS['LANG'] = new class {
+            public function sL(string $key): string
+            {
+                return 'Translated';
+            }
+        };
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'CType' => 'text', 'header' => 'Test'], ['label' => 'Text', 'icon' => 'content-text']);
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_info', $children);
+        self::assertArrayHasKey('info_header', $children);
+
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function addInfoSectionHandlesEmptyHeader(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $GLOBALS['LANG'] = new class {
+            public function sL(string $key): string
+            {
+                return 'Translated';
+            }
+        };
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'CType' => 'text', 'header' => ''], ['label' => 'Text']);
+
+        self::assertArrayHasKey('info_header', $menuButton->getChildren());
+
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function addInfoSectionHandlesMissingHeader(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $GLOBALS['LANG'] = new class {
+            public function sL(string $key): string
+            {
+                return 'Translated';
+            }
+        };
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'CType' => 'text'], ['label' => 'Text']);
+
+        self::assertArrayHasKey('info_header', $menuButton->getChildren());
+
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function addEditSectionAddsEditAndPageButtons(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, ['uid' => 1, 'CType' => 'text'], 0, 1, '/return');
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_edit', $children);
+        self::assertArrayHasKey('edit', $children);
+        self::assertArrayHasKey('edit_page', $children);
+    }
+
+    #[Test]
+    public function addEditSectionSetsContextualUrlOnEditButton(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, ['uid' => 1, 'CType' => 'text'], 0, 1, '/return', '/typo3/contextual');
+
+        self::assertSame('/typo3/contextual', $menuButton->getChildren()['edit']->getContextualUrl());
+    }
+
+    #[Test]
+    public function addActionSectionAddsAllActionButtons(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], '/return');
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_action', $children);
+        self::assertArrayHasKey('hide', $children);
+        self::assertArrayHasKey('info', $children);
+        self::assertArrayHasKey('move', $children);
+        self::assertArrayHasKey('history', $children);
+        self::assertArrayHasKey('new_content_after', $children);
+    }
+}

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Http\Uri;
-use TYPO3\CMS\Core\Imaging\{Icon, IconFactory, IconSize};
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementButtonBuilder;

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -20,7 +20,6 @@ use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Database\{Connection, ConnectionPool, Query\QueryBuilder, Query\Expression\ExpressionBuilder};
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -43,8 +43,6 @@ final class ContentElementMenuGeneratorTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $uriBuilderMock = $this->createMock(UriBuilder::class);
         $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
         GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
@@ -54,7 +52,6 @@ final class ContentElementMenuGeneratorTest extends TestCase
     {
         GeneralUtility::purgeInstances();
         unset($GLOBALS['BE_USER'], $GLOBALS['LANG']);
-        parent::tearDown();
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\{Connection, ConnectionPool, Query\QueryBuilder, Query\Expression\ExpressionBuilder};
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
+use Xima\XimaTypo3FrontendEdit\Service\Content\ContentElementFilter;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\{AdditionalDataHandler, ContentElementButtonBuilder, ContentElementMenuGenerator};
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+
+/**
+ * ContentElementMenuGeneratorTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ContentElementMenuGenerator::class)]
+final class ContentElementMenuGeneratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $uriBuilderMock = $this->createMock(UriBuilder::class);
+        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $generator = $this->createGenerator();
+
+        $request = $this->createRequestMock();
+        $result = $generator->getDropdown(1, '/return', 0, $request);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenBackendUserIsNull(): void
+    {
+        $GLOBALS['BE_USER'] = null;
+
+        $generator = $this->createGenerator();
+
+        $request = $this->createRequestMock();
+        $result = $generator->getDropdown(1, '/return', 0, $request);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenFrontendEditDisabled(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = [Configuration::UC_KEY_DISABLED => true];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $generator = $this->createGenerator();
+
+        $request = $this->createRequestMock();
+        $result = $generator->getDropdown(1, '/return', 0, $request);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenBackendUserHasNoUserData(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $generator = $this->createGenerator();
+
+        $request = $this->createRequestMock();
+        $result = $generator->getDropdown(1, '/return', 0, $request);
+
+        self::assertSame([], $result);
+    }
+
+    private function createRequestMock(): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturn(null);
+
+        return $request;
+    }
+
+    private function createGenerator(): ContentElementMenuGenerator
+    {
+        $iconFactoryMock = $this->createMock(IconFactory::class);
+        $iconFactoryMock->method('getIcon')->willReturn($this->createMock(Icon::class));
+        $iconService = new IconService($iconFactoryMock);
+        $urlBuilderService = new UrlBuilderService();
+        $backendUserService = new BackendUserService();
+        $contentElementButtonBuilder = new ContentElementButtonBuilder($iconService, $urlBuilderService);
+
+        $settingsService = (new ReflectionClass(SettingsService::class))->newInstanceWithoutConstructor();
+        $contentElementRepository = (new ReflectionClass(ContentElementRepository::class))->newInstanceWithoutConstructor();
+        $contentElementFilter = new ContentElementFilter($settingsService, $contentElementRepository);
+        $additionalDataHandler = (new ReflectionClass(AdditionalDataHandler::class))->newInstanceWithoutConstructor();
+
+        return new ContentElementMenuGenerator(
+            $this->createMock(EventDispatcher::class),
+            $backendUserService,
+            $contentElementFilter,
+            $contentElementButtonBuilder,
+            $contentElementRepository,
+            $additionalDataHandler,
+            $iconService,
+            $settingsService,
+            $urlBuilderService,
+            $this->createMock(ExtensionConfiguration::class),
+        );
+    }
+}

--- a/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\PageButtonBuilder;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+
+/**
+ * PageButtonBuilderTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(PageButtonBuilder::class)]
+final class PageButtonBuilderTest extends TestCase
+{
+    private IconService $iconService;
+    private UrlBuilderService $urlBuilderService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $iconMock = $this->createMock(Icon::class);
+        $iconFactoryMock = $this->createMock(IconFactory::class);
+        $iconFactoryMock->method('getIcon')->willReturn($iconMock);
+        $this->iconService = new IconService($iconFactoryMock);
+
+        $uriBuilderMock = $this->createMock(UriBuilder::class);
+        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+        $this->urlBuilderService = new UrlBuilderService();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['LANG'], $GLOBALS['TCA']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function addInfoSectionAddsChildrenToMenuButton(): void
+    {
+        $this->setUpGlobals();
+
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'title' => 'Test Page', 'doktype' => 1]);
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_info', $children);
+        self::assertArrayHasKey('info_header', $children);
+    }
+
+    #[Test]
+    public function addInfoSectionHandlesEmptyTitle(): void
+    {
+        $this->setUpGlobals();
+
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'title' => '', 'doktype' => 1]);
+
+        self::assertArrayHasKey('info_header', $menuButton->getChildren());
+    }
+
+    #[Test]
+    public function addInfoSectionHandlesMissingTitle(): void
+    {
+        $this->setUpGlobals();
+
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addInfoSection($menuButton, ['uid' => 1, 'doktype' => 1]);
+
+        self::assertArrayHasKey('info_header', $menuButton->getChildren());
+    }
+
+    #[Test]
+    public function addInfoSectionHandlesMissingDoktype(): void
+    {
+        $this->setUpGlobals();
+
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addInfoSection($menuButton, ['uid' => 1]);
+
+        self::assertArrayHasKey('info_header', $menuButton->getChildren());
+    }
+
+    #[Test]
+    public function addEditSectionAddsEditButtons(): void
+    {
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, 1, 0, '/return');
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_edit', $children);
+        self::assertArrayHasKey('edit_page_properties', $children);
+        self::assertArrayHasKey('edit_page', $children);
+    }
+
+    #[Test]
+    public function addEditSectionSetsContextualUrl(): void
+    {
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, 1, 0, '/return', '/typo3/contextual');
+
+        self::assertSame('/typo3/contextual', $menuButton->getChildren()['edit_page_properties']->getContextualUrl());
+    }
+
+    #[Test]
+    public function addActionSectionAddsInfoAndHistoryButtons(): void
+    {
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addActionSection($menuButton, 1, '/return');
+
+        $children = $menuButton->getChildren();
+        self::assertArrayHasKey('div_action', $children);
+        self::assertArrayHasKey('info', $children);
+        self::assertArrayHasKey('history', $children);
+    }
+
+    private function setUpGlobals(): void
+    {
+        $GLOBALS['LANG'] = new class {
+            public function sL(string $key): string
+            {
+                return 'Translated';
+            }
+        };
+        $GLOBALS['TCA']['pages']['columns']['doktype']['config']['items'] = [
+            ['label' => 'Standard', 'value' => 1],
+        ];
+        $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes'] = [
+            1 => 'apps-pagetree-page-default',
+        ];
+    }
+}

--- a/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
@@ -38,8 +38,6 @@ final class PageButtonBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $iconMock = $this->createMock(Icon::class);
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($iconMock);
@@ -55,7 +53,6 @@ final class PageButtonBuilderTest extends TestCase
     {
         GeneralUtility::purgeInstances();
         unset($GLOBALS['LANG'], $GLOBALS['TCA']);
-        parent::tearDown();
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\{PageButtonBuilder, PageMenuGenerator};
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+
+/**
+ * PageMenuGeneratorTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(PageMenuGenerator::class)]
+final class PageMenuGeneratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $uriBuilderMock = $this->createMock(UriBuilder::class);
+        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenRoutingIsNull(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnMap([
+            ['routing', null, null],
+            ['language', null, null],
+        ]);
+
+        $generator = $this->createGenerator();
+        $result = $generator->getDropdown($request);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenRoutingIsNotPageArguments(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnMap([
+            ['routing', null, new \stdClass()],
+            ['language', null, null],
+        ]);
+
+        $generator = $this->createGenerator();
+        $result = $generator->getDropdown($request);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenPageIdIsZero(): void
+    {
+        $routing = $this->createMock(PageArguments::class);
+        $routing->method('getPageId')->willReturn(0);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnMap([
+            ['routing', null, $routing],
+            ['language', null, null],
+        ]);
+
+        $generator = $this->createGenerator();
+        $result = $generator->getDropdown($request);
+
+        self::assertSame([], $result);
+    }
+
+    private function createGenerator(): PageMenuGenerator
+    {
+        $iconFactoryMock = $this->createMock(IconFactory::class);
+        $iconFactoryMock->method('getIcon')->willReturn($this->createMock(Icon::class));
+        $iconService = new IconService($iconFactoryMock);
+        $urlBuilderService = new UrlBuilderService();
+        $pageButtonBuilder = new PageButtonBuilder($iconService, $urlBuilderService);
+
+        return new PageMenuGenerator(
+            $pageButtonBuilder,
+            $this->createMock(EventDispatcher::class),
+            $this->createMock(ExtensionConfiguration::class),
+            $this->createMock(ConnectionPool::class),
+            $urlBuilderService,
+        );
+    }
+}

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -39,8 +39,6 @@ final class PageMenuGeneratorTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $uriBuilderMock = $this->createMock(UriBuilder::class);
         $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
         GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
@@ -49,7 +47,6 @@ final class PageMenuGeneratorTest extends TestCase
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        parent::tearDown();
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -71,7 +72,7 @@ final class PageMenuGeneratorTest extends TestCase
     {
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getAttribute')->willReturnMap([
-            ['routing', null, new \stdClass()],
+            ['routing', null, new stdClass()],
             ['language', null, null],
         ]);
 

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -47,7 +47,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildEditUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_edit', self::callback(static fn(array $params): bool => isset($params['edit']['tt_content'][1]) && 'edit' === $params['edit']['tt_content'][1]))
+            ->with('record_edit', self::callback(static fn (array $params): bool => isset($params['edit']['tt_content'][1]) && 'edit' === $params['edit']['tt_content'][1]))
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();
@@ -60,7 +60,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildPageLayoutUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn(array $params): bool => 1 === $params['id'] && 0 === $params['language']))
+            ->with('web_layout', self::callback(static fn (array $params): bool => 1 === $params['id'] && 0 === $params['language']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
@@ -73,7 +73,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildPageLayoutUrlIncludesScrollToElement(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn(array $params): bool => isset($params['scrollToElement']) && 42 === $params['scrollToElement']))
+            ->with('web_layout', self::callback(static fn (array $params): bool => isset($params['scrollToElement']) && 42 === $params['scrollToElement']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
@@ -99,7 +99,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildInfoUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('show_item', self::callback(static fn(array $params): bool => 1 === $params['uid'] && 'tt_content' === $params['table']))
+            ->with('show_item', self::callback(static fn (array $params): bool => 1 === $params['uid'] && 'tt_content' === $params['table']))
             ->willReturn(new Uri('/typo3/show_item'));
 
         $service = new UrlBuilderService();
@@ -125,7 +125,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildHistoryUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_history', self::callback(static fn(array $params): bool => 'tt_content:1' === $params['element']))
+            ->with('record_history', self::callback(static fn (array $params): bool => 'tt_content:1' === $params['element']))
             ->willReturn(new Uri('/typo3/record_history'));
 
         $service = new UrlBuilderService();
@@ -138,7 +138,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildNewContentAfterUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_edit', self::callback(static fn(array $params): bool => isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1]))
+            ->with('record_edit', self::callback(static fn (array $params): bool => isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1]))
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -34,8 +34,6 @@ final class UrlBuilderServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->uriBuilderMock = $this->createMock(UriBuilder::class);
         GeneralUtility::setSingletonInstance(UriBuilder::class, $this->uriBuilderMock);
     }
@@ -43,16 +41,13 @@ final class UrlBuilderServiceTest extends TestCase
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        parent::tearDown();
     }
 
     #[Test]
     public function buildEditUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_edit', self::callback(static function (array $params): bool {
-                return isset($params['edit']['tt_content'][1]) && 'edit' === $params['edit']['tt_content'][1];
-            }))
+            ->with('record_edit', self::callback(static fn(array $params): bool => isset($params['edit']['tt_content'][1]) && 'edit' === $params['edit']['tt_content'][1]))
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();
@@ -65,9 +60,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildPageLayoutUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static function (array $params): bool {
-                return 1 === $params['id'] && 0 === $params['language'];
-            }))
+            ->with('web_layout', self::callback(static fn(array $params): bool => 1 === $params['id'] && 0 === $params['language']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
@@ -80,9 +73,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildPageLayoutUrlIncludesScrollToElement(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static function (array $params): bool {
-                return isset($params['scrollToElement']) && 42 === $params['scrollToElement'];
-            }))
+            ->with('web_layout', self::callback(static fn(array $params): bool => isset($params['scrollToElement']) && 42 === $params['scrollToElement']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
@@ -108,9 +99,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildInfoUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('show_item', self::callback(static function (array $params): bool {
-                return 1 === $params['uid'] && 'tt_content' === $params['table'];
-            }))
+            ->with('show_item', self::callback(static fn(array $params): bool => 1 === $params['uid'] && 'tt_content' === $params['table']))
             ->willReturn(new Uri('/typo3/show_item'));
 
         $service = new UrlBuilderService();
@@ -136,9 +125,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildHistoryUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_history', self::callback(static function (array $params): bool {
-                return 'tt_content:1' === $params['element'];
-            }))
+            ->with('record_history', self::callback(static fn(array $params): bool => 'tt_content:1' === $params['element']))
             ->willReturn(new Uri('/typo3/record_history'));
 
         $service = new UrlBuilderService();
@@ -151,9 +138,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildNewContentAfterUrlReturnsCorrectUrl(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_edit', self::callback(static function (array $params): bool {
-                return isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1];
-            }))
+            ->with('record_edit', self::callback(static fn(array $params): bool => isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1]))
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+
+/**
+ * UrlBuilderServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(UrlBuilderService::class)]
+final class UrlBuilderServiceTest extends TestCase
+{
+    private UriBuilder $uriBuilderMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->uriBuilderMock = $this->createMock(UriBuilder::class);
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $this->uriBuilderMock);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function buildEditUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_edit', self::callback(static function (array $params): bool {
+                return isset($params['edit']['tt_content'][1]) && 'edit' === $params['edit']['tt_content'][1];
+            }))
+            ->willReturn(new Uri('/typo3/record/edit'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildEditUrl(1, 'tt_content', 0, '/return');
+
+        self::assertSame('/typo3/record/edit', $result);
+    }
+
+    #[Test]
+    public function buildPageLayoutUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('web_layout', self::callback(static function (array $params): bool {
+                return 1 === $params['id'] && 0 === $params['language'];
+            }))
+            ->willReturn(new Uri('/typo3/module/web/layout'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildPageLayoutUrl(1, 0, '/return');
+
+        self::assertSame('/typo3/module/web/layout', $result);
+    }
+
+    #[Test]
+    public function buildPageLayoutUrlIncludesScrollToElement(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('web_layout', self::callback(static function (array $params): bool {
+                return isset($params['scrollToElement']) && 42 === $params['scrollToElement'];
+            }))
+            ->willReturn(new Uri('/typo3/module/web/layout'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildPageLayoutUrl(1, 0, '/return', 42);
+
+        self::assertSame('/typo3/module/web/layout', $result);
+    }
+
+    #[Test]
+    public function buildHideUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('tce_db', self::anything())
+            ->willReturn(new Uri('/typo3/tce_db'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildHideUrl(1, '/return');
+
+        self::assertSame('/typo3/tce_db', $result);
+    }
+
+    #[Test]
+    public function buildInfoUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('show_item', self::callback(static function (array $params): bool {
+                return 1 === $params['uid'] && 'tt_content' === $params['table'];
+            }))
+            ->willReturn(new Uri('/typo3/show_item'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildInfoUrl(1, 'tt_content', '/return');
+
+        self::assertSame('/typo3/show_item', $result);
+    }
+
+    #[Test]
+    public function buildMoveUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('move_element', self::anything())
+            ->willReturn(new Uri('/typo3/move_element'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildMoveUrl(1, 'tt_content', 1, '/return');
+
+        self::assertSame('/typo3/move_element', $result);
+    }
+
+    #[Test]
+    public function buildHistoryUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_history', self::callback(static function (array $params): bool {
+                return 'tt_content:1' === $params['element'];
+            }))
+            ->willReturn(new Uri('/typo3/record_history'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildHistoryUrl(1, 'tt_content', '/return');
+
+        self::assertSame('/typo3/record_history', $result);
+    }
+
+    #[Test]
+    public function buildNewContentAfterUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_edit', self::callback(static function (array $params): bool {
+                return isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1];
+            }))
+            ->willReturn(new Uri('/typo3/record/edit'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildNewContentAfterUrl(1, '/return');
+
+        self::assertSame('/typo3/record/edit', $result);
+    }
+
+    #[Test]
+    public function isContextualEditRouteAvailableReturnsTrueWhenRouteExists(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_edit_contextual')
+            ->willReturn(new Uri('/typo3/record/edit/contextual'));
+
+        $service = new UrlBuilderService();
+
+        self::assertTrue($service->isContextualEditRouteAvailable());
+    }
+
+    #[Test]
+    public function isContextualEditRouteAvailableReturnsFalseWhenRouteNotFound(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_edit_contextual')
+            ->willThrowException(new RouteNotFoundException('Route not found'));
+
+        $service = new UrlBuilderService();
+
+        self::assertFalse($service->isContextualEditRouteAvailable());
+    }
+
+    #[Test]
+    public function buildContextualEditUrlReturnsUrlWhenRouteExists(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('record_edit_contextual', self::anything())
+            ->willReturn(new Uri('/typo3/record/edit/contextual'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildContextualEditUrl(1, 'tt_content', 0, '/return');
+
+        self::assertSame('/typo3/record/edit/contextual', $result);
+    }
+
+    #[Test]
+    public function buildContextualEditUrlReturnsNullWhenRouteNotFound(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->willThrowException(new RouteNotFoundException('Route not found'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildContextualEditUrl(1, 'tt_content', 0);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function buildToggleUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('ajax_frontendEdit_toggle', [])
+            ->willReturn(new Uri('/typo3/ajax/frontend-edit/toggle'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildToggleUrl();
+
+        self::assertSame('/typo3/ajax/frontend-edit/toggle', $result);
+    }
+
+    #[Test]
+    public function buildEditInformationUrlReturnsCorrectUrl(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('ajax_frontendEdit_editInformation', [])
+            ->willReturn(new Uri('/typo3/ajax/frontend-edit/edit-information'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildEditInformationUrl();
+
+        self::assertSame('/typo3/ajax/frontend-edit/edit-information', $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Add 6 new unit test files covering `ContentElementMenuGenerator`, `PageMenuGenerator`, `ContentElementButtonBuilder`, `PageButtonBuilder`, `UrlBuilderService`, and `BackendUserService` (140 tests, 263 assertions)
- Add defensive JavaScript error handling: graceful degradation on missing config, network error notifications, guard clauses for malformed backend responses
- Validate `pid` (positive int) and `language` (non-negative int) parameters in `AjaxController` via `filter_var` instead of silent `(int)` cast

## Test plan

- [ ] Run `vendor/bin/phpunit Tests/Unit/` — all 140 tests pass
- [ ] Run PHPStan level 8 — no errors
- [ ] Run PHP CS Fixer — no violations
- [ ] Verify frontend edit still works when `#frontend-edit-toolbar-config` is missing (should silently skip)
- [ ] Verify error notification appears when backend AJAX request fails
- [ ] Verify malformed content elements in response are skipped with warning log
- [ ] Verify invalid `pid`/`language` parameters return proper JSON error responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation with stricter parameter checking and specific error messages.
  * Improved error handling in frontend editing with better null checks and user-facing error notifications.

* **Tests**
  * Added comprehensive unit test coverage for authentication, menu generation, URL building, and UI services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->