### PR TITLE
fix: sidebar close button overlap with backend close button

### DIFF
--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -82,13 +82,13 @@
       this.sidebar.setAttribute('aria-label', 'Edit content');
 
       // Close button
-      var closeButton = document.createElement('button');
-      closeButton.type = 'button';
-      closeButton.className = 'frontend-edit__sidebar-close';
-      closeButton.setAttribute('aria-label', 'Close editor');
-      closeButton.innerHTML = CLOSE_ICON;
-      closeButton.addEventListener('click', this.requestClose.bind(this));
-      this.sidebar.appendChild(closeButton);
+      this.closeButton = document.createElement('button');
+      this.closeButton.type = 'button';
+      this.closeButton.className = 'frontend-edit__sidebar-close';
+      this.closeButton.setAttribute('aria-label', 'Close editor');
+      this.closeButton.innerHTML = CLOSE_ICON;
+      this.closeButton.addEventListener('click', this.requestClose.bind(this));
+      this.sidebar.appendChild(this.closeButton);
 
       // Loading spinner
       this.loader = document.createElement('div');
@@ -168,6 +168,7 @@
       this.hasSaved = false;
       this.savedRecordTitle = null;
       this.targetBlank = targetBlank || false;
+      this.closeButton.style.display = '';
       this.loader.classList.add('frontend-edit__sidebar-loader--visible');
       this.iframe.classList.remove('frontend-edit__sidebar-iframe--loaded');
       this.backdrop.classList.add('frontend-edit__sidebar-backdrop--visible');
@@ -268,6 +269,16 @@
 
         if (closeBtn) {
           actionsBar.insertBefore(saveCloseBtn, closeBtn);
+
+          // Wire backend close button to close the sidebar
+          closeBtn.addEventListener('click', function (e) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            self.requestClose();
+          });
+
+          // Hide extension's own close button to avoid overlap
+          self.closeButton.style.display = 'none';
         } else {
           actionsBar.appendChild(saveCloseBtn);
         }


### PR DESCRIPTION
## Summary

- Hide extension's own close button (X) when the TYPO3 backend iframe provides its own close button, preventing visual overlap
- Wire the backend's close button to properly close the sidebar via `requestClose()`
- Restore close button visibility on reopen so it remains usable during iframe loading

## Changes

- `Resources/Public/JavaScript/contextual_edit.js` - Store close button reference, hide it when backend close button is available, restore on sidebar reopen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar close button state management and reset behavior when reopening
  * Fixed potential overlapping close buttons in the contextual edit interface when backend-provided close elements are present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->