### PR TITLE
fix: improve content element UID badge contrast in dark mode

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -157,8 +157,10 @@
     font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
     font-size: 11px;
     background: rgba(255, 255, 255, 0.15);
+    color: inherit;
     padding: 1px 4px;
     border-radius: 3px;
+    opacity: 0.75;
 }
 
 .frontend-edit__toolbar-label svg {


### PR DESCRIPTION
## Summary

- Fix poor readability of content element UID badge (red on dark gray) in dark mode
- Add `color: inherit` to prevent external `<code>` styles from bleeding through
- Add subtle `opacity: 0.75` to de-emphasize the UID number, matching TYPO3 backend conventions

## Changes

- `Resources/Public/Css/FrontendEdit.css` - Fix `.frontend-edit__toolbar-label code` styling for dark mode contrast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of code text in the frontend edit toolbar with adjusted transparency and color styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->