### PR TITLE
fix: sticky toolbar dropdown positioned off-screen on right/center placement

### DIFF
--- a/Resources/Public/JavaScript/sticky_toolbar.js
+++ b/Resources/Public/JavaScript/sticky_toolbar.js
@@ -339,6 +339,10 @@
         const menuBtn = this.container.querySelector('.frontend-edit__sticky-btn--menu');
         const dropdown = this.container.querySelector('.frontend-edit__sticky-dropdown');
 
+        // Move dropdown to document.body so position:fixed works correctly
+        // (toolbar may have CSS transform which creates a new containing block)
+        document.body.appendChild(dropdown);
+
         menuBtn.addEventListener('click', async (e) => {
           e.stopPropagation();
           const isVisible = dropdown.classList.contains('frontend-edit__sticky-dropdown--visible');
@@ -351,7 +355,7 @@
         });
 
         document.addEventListener('click', (e) => {
-          if (!dropdownContainer.contains(e.target)) {
+          if (!dropdownContainer.contains(e.target) && !dropdown.contains(e.target)) {
             dropdown.classList.remove('frontend-edit__sticky-dropdown--visible');
           }
         });


### PR DESCRIPTION
## Summary

- Fix dropdown menu appearing off-screen when sticky toolbar is placed at `right-center` (or any position using CSS `transform` for centering)

## Problem

Toolbar positions like `right-center` use `transform: translateY(-50%)` for centering. CSS transforms create a new containing block for `position: fixed` descendants, causing the dropdown's fixed coordinates (computed by Floating UI relative to the viewport) to be applied relative to the toolbar instead — pushing the dropdown off-screen.

## Changes

- `Resources/Public/JavaScript/sticky_toolbar.js` — Move dropdown element to `document.body` during setup so it escapes the transformed toolbar parent. Update click-outside handler to also check the detached dropdown element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sticky toolbar dropdown positioning to work correctly when ancestor elements have CSS transforms applied
  * Improved click detection for dropdown interactions to properly handle inside and outside click events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->