### PR TITLE
fix: add explicit DI wiring for non-composer mode

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,3 +7,32 @@ services:
     Xima\XimaTypo3FrontendEdit\:
         resource: '../Classes/*'
         exclude: '../Classes/Domain/Model/*'
+
+    # Explicit wiring for non-composer mode compatibility
+    Xima\XimaTypo3FrontendEdit\Middleware\ToolRendererMiddleware:
+        arguments:
+            $resourceRendererService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\ResourceRendererService'
+            $settingsService: '@Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService'
+            $flashMessageService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\FlashMessageService'
+            $backendUserService: '@Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService'
+
+    Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator:
+        arguments:
+            $pageButtonBuilder: '@Xima\XimaTypo3FrontendEdit\Service\Menu\PageButtonBuilder'
+            $eventDispatcher: '@TYPO3\CMS\Core\EventDispatcher\EventDispatcher'
+            $extensionConfiguration: '@TYPO3\CMS\Core\Configuration\ExtensionConfiguration'
+            $connectionPool: '@TYPO3\CMS\Core\Database\ConnectionPool'
+            $urlBuilderService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService'
+
+    Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementMenuGenerator:
+        arguments:
+            $eventDispatcher: '@TYPO3\CMS\Core\EventDispatcher\EventDispatcher'
+            $backendUserService: '@Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService'
+            $contentElementFilter: '@Xima\XimaTypo3FrontendEdit\Service\Content\ContentElementFilter'
+            $contentElementButtonBuilder: '@Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementButtonBuilder'
+            $contentElementRepository: '@Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository'
+            $additionalDataHandler: '@Xima\XimaTypo3FrontendEdit\Service\Menu\AdditionalDataHandler'
+            $iconService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\IconService'
+            $settingsService: '@Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService'
+            $urlBuilderService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService'
+            $extensionConfiguration: '@TYPO3\CMS\Core\Configuration\ExtensionConfiguration'


### PR DESCRIPTION
## Summary
- Adds explicit constructor argument wiring in `Configuration/Services.yaml` for `ToolRendererMiddleware`, `PageMenuGenerator` and `ContentElementMenuGenerator`
- Fixes DI resolution failures in non-composer (classic) mode where autowiring does not fully resolve constructor dependencies
- No PHP code changes — strict type signatures remain intact

## Test plan
- [x] Tested in non-composer mode by issue reporter (@teamnewtvision)
- [x] Verify composer mode still works (autowiring + explicit wiring coexist)
- [x] Run `composer cgl lint`

Resolves #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated service configuration with explicit dependency bindings for core services to enhance configuration clarity and consistency in the service container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->