### PR TITLE
feat: add delete button with confirmation dialog

### DIFF
--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -184,5 +184,9 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         // New content after button
         $newContentUrl = $this->urlBuilderService->buildNewContentAfterUrl($contentElement['uid'], $returnUrlAnchor);
         $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
+
+        // Delete button
+        $deleteUrl = $this->urlBuilderService->buildDeleteUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
+        $this->addButton($menuButton, 'delete', ButtonType::Link, url: $deleteUrl, icon: 'actions-delete');
     }
 }

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -106,7 +106,7 @@ final readonly class ResourceRendererService
             'message' => $this->translate('delete.confirm.message', "Are you sure you want to delete the record '%s'?"),
             'cancel' => $this->translate('delete.confirm.cancel', 'Cancel'),
             'delete' => $this->translate('delete.confirm.delete', 'Delete record (!)'),
-        ], \JSON_HEX_TAG | \JSON_HEX_AMP);
+        ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $resources['settings_config'] = sprintf(
             '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s;</script>',
             $nonceAttribute,

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -106,6 +106,8 @@ final readonly class ResourceRendererService
             'message' => $this->translate('delete.confirm.message', "Are you sure you want to delete the record '%s'?"),
             'cancel' => $this->translate('delete.confirm.cancel', 'Cancel'),
             'delete' => $this->translate('delete.confirm.delete', 'Delete record (!)'),
+            'success' => $this->translate('delete.success', 'Record deleted'),
+            'error' => $this->translate('delete.error', 'Could not delete the record'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $resources['settings_config'] = sprintf(
             '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s;</script>',

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -101,14 +101,21 @@ final readonly class ResourceRendererService
         $enableOutline = (null !== $request && $this->settingsService->isEnableOutline($request)) ? 'true' : 'false';
         $enableScrollToElement = (null !== $request && $this->settingsService->isEnableScrollToElement($request)) ? 'true' : 'false';
         $contextualEditing = (null !== $request && $this->settingsService->isContextualEditingEnabled($request)) ? 'true' : 'false';
+        $deleteLabels = json_encode([
+            'title' => $this->translate('delete.confirm.title', 'Delete this record?'),
+            'message' => $this->translate('delete.confirm.message', "Are you sure you want to delete the record '%s'?"),
+            'cancel' => $this->translate('delete.confirm.cancel', 'Cancel'),
+            'delete' => $this->translate('delete.confirm.delete', 'Delete record (!)'),
+        ], \JSON_HEX_TAG | \JSON_HEX_AMP);
         $resources['settings_config'] = sprintf(
-            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s;</script>',
+            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s;</script>',
             $nonceAttribute,
             $colorScheme,
             $showContextMenu,
             $enableOutline,
             $enableScrollToElement,
             $contextualEditing,
+            $deleteLabels,
         );
     }
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -194,6 +194,24 @@ final readonly class UrlBuilderService
     }
 
     /**
+     * @throws RouteNotFoundException
+     */
+    public function buildDeleteUrl(int $uid, string $table, string $returnUrl): string
+    {
+        return $this->uriBuilder->buildUriFromRoute(
+            'tce_db',
+            [
+                'cmd' => [
+                    $table => [
+                        $uid => ['delete' => 1],
+                    ],
+                ],
+                'redirect' => $returnUrl,
+            ],
+        )->__toString();
+    }
+
+    /**
      * @param array<string, mixed> $parameters
      *
      * @throws RouteNotFoundException

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -79,6 +79,34 @@
 				<source />
 				<target>Seitenoptionen</target>
 			</trans-unit>
+			<trans-unit id="delete">
+				<source />
+				<target>Löschen</target>
+			</trans-unit>
+			<trans-unit id="delete.confirm.title">
+				<source />
+				<target>Diesen Datensatz tatsächlich löschen?</target>
+			</trans-unit>
+			<trans-unit id="delete.confirm.message">
+				<source />
+				<target>Bist du sicher, dass du den Datensatz '%s' löschen möchtest?</target>
+			</trans-unit>
+			<trans-unit id="delete.confirm.cancel">
+				<source />
+				<target>Abbrechen</target>
+			</trans-unit>
+			<trans-unit id="delete.confirm.delete">
+				<source />
+				<target>Datensatz löschen(!)</target>
+			</trans-unit>
+			<trans-unit id="delete.success">
+				<source />
+				<target>Datensatz gelöscht</target>
+			</trans-unit>
+			<trans-unit id="delete.error">
+				<source />
+				<target>Der Datensatz konnte nicht gelöscht werden</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -60,6 +60,27 @@
 			<trans-unit id="tooltip.pageOptions">
 				<source>Page options</source>
 			</trans-unit>
+			<trans-unit id="delete">
+				<source>Delete</source>
+			</trans-unit>
+			<trans-unit id="delete.confirm.title">
+				<source>Delete this record?</source>
+			</trans-unit>
+			<trans-unit id="delete.confirm.message">
+				<source>Are you sure you want to delete the record '%s'?</source>
+			</trans-unit>
+			<trans-unit id="delete.confirm.cancel">
+				<source>Cancel</source>
+			</trans-unit>
+			<trans-unit id="delete.confirm.delete">
+				<source>Delete record (!)</source>
+			</trans-unit>
+			<trans-unit id="delete.success">
+				<source>Record deleted</source>
+			</trans-unit>
+			<trans-unit id="delete.error">
+				<source>Could not delete the record</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -767,6 +767,151 @@
 }
 
 /* ==========================================================================
+   Delete Confirmation Dialog
+   Uses TYPO3 backend modal class names (.modal-header, .modal-body, etc.)
+   so styles are inherited when backend/Bootstrap CSS is available.
+   These rules are scoped under .frontend-edit__dialog-overlay and serve as
+   fallback styles matching the TYPO3 backend dark theme.
+   ========================================================================== */
+.frontend-edit__dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 100001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.frontend-edit__dialog-overlay--show {
+    opacity: 1;
+}
+
+.frontend-edit__dialog-overlay .modal-dialog {
+    min-width: 500px;
+    max-width: 600px;
+    transform: scale(0.9);
+    transition: transform 0.2s ease;
+}
+
+.frontend-edit__dialog-overlay--show .modal-dialog {
+    transform: scale(1);
+}
+
+.frontend-edit__dialog-overlay .modal-content {
+    background: #2b2b2b;
+    border-radius: 2px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    border: none;
+}
+
+.frontend-edit__dialog-overlay .modal-header {
+    padding: 12px 16px;
+    background: #8b7a4a;
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: none;
+    border-radius: 2px 2px 0 0;
+}
+
+.frontend-edit__dialog-overlay .modal-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: #fff;
+    flex: 1;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.frontend-edit__dialog-overlay .close,
+.frontend-edit__dialog-overlay .btn-close {
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.8;
+    transition: opacity 0.2s ease;
+}
+
+.frontend-edit__dialog-overlay .close:hover,
+.frontend-edit__dialog-overlay .btn-close:hover {
+    opacity: 1;
+}
+
+.frontend-edit__dialog-overlay .close svg,
+.frontend-edit__dialog-overlay .btn-close svg {
+    width: 14px;
+    height: 14px;
+}
+
+.frontend-edit__dialog-overlay .modal-body {
+    padding: 20px;
+}
+
+.frontend-edit__dialog-overlay .modal-body p {
+    margin: 0;
+    color: #e0e0e0;
+    line-height: 1.5;
+    font-size: 14px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.frontend-edit__dialog-overlay .modal-footer {
+    padding: 12px 16px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    border-top: none;
+}
+
+.frontend-edit__dialog-overlay .btn {
+    padding: 6px 16px;
+    border: 1px solid #555;
+    border-radius: 2px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.frontend-edit__dialog-overlay .btn-default {
+    background: #3a3a3a;
+    color: #e0e0e0;
+    border-color: #555;
+}
+
+.frontend-edit__dialog-overlay .btn-default:hover {
+    background: #4a4a4a;
+    border-color: #666;
+}
+
+.frontend-edit__dialog-overlay .btn-warning {
+    background: #8b7a4a;
+    border-color: #8b7a4a;
+    color: #fff;
+}
+
+.frontend-edit__dialog-overlay .btn-warning:hover {
+    background: #9d8a5a;
+    border-color: #9d8a5a;
+}
+
+/* ==========================================================================
    Contextual Edit Sidebar (Experimental)
    ========================================================================== */
 
@@ -890,7 +1035,9 @@
     .frontend-edit__overlay,
     .frontend-edit__overlay--active,
     .frontend-edit__tooltip,
-    .frontend-edit__tooltip--visible {
+    .frontend-edit__tooltip--visible,
+    .frontend-edit__dialog-overlay,
+    .frontend-edit__dialog-overlay .modal-dialog {
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
     }

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -10,6 +10,21 @@
     --xfe-border-color: #e0e0e0;
     --xfe-outline-color: #aaaaaa;
     --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.5);
+    --xfe-dialog-bg: #ffffff;
+    --xfe-dialog-text: #1a1a1a;
+    --xfe-dialog-header-bg: #7a6a3f;
+    --xfe-dialog-header-text: #ffffff;
+    --xfe-dialog-btn-bg: #e8e8e8;
+    --xfe-dialog-btn-text: #1a1a1a;
+    --xfe-dialog-btn-border: #cccccc;
+    --xfe-dialog-btn-hover-bg: #d8d8d8;
+    --xfe-dialog-btn-hover-border: #bbbbbb;
+    --xfe-dialog-warning-bg: #7a6a3f;
+    --xfe-dialog-warning-border: #7a6a3f;
+    --xfe-dialog-warning-text: #ffffff;
+    --xfe-dialog-warning-hover-bg: #8d7c4e;
+    --xfe-dialog-warning-hover-border: #8d7c4e;
 }
 
 /* Light theme (explicit) */
@@ -24,6 +39,21 @@
     --xfe-border-color: #e0e0e0;
     --xfe-outline-color: #aaaaaa;
     --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.5);
+    --xfe-dialog-bg: #ffffff;
+    --xfe-dialog-text: #1a1a1a;
+    --xfe-dialog-header-bg: #7a6a3f;
+    --xfe-dialog-header-text: #ffffff;
+    --xfe-dialog-btn-bg: #e8e8e8;
+    --xfe-dialog-btn-text: #1a1a1a;
+    --xfe-dialog-btn-border: #cccccc;
+    --xfe-dialog-btn-hover-bg: #d8d8d8;
+    --xfe-dialog-btn-hover-border: #bbbbbb;
+    --xfe-dialog-warning-bg: #7a6a3f;
+    --xfe-dialog-warning-border: #7a6a3f;
+    --xfe-dialog-warning-text: #ffffff;
+    --xfe-dialog-warning-hover-bg: #8d7c4e;
+    --xfe-dialog-warning-hover-border: #8d7c4e;
 }
 
 /* Dark theme (explicit) */
@@ -38,6 +68,21 @@
     --xfe-border-color: #444444;
     --xfe-outline-color: #666666;
     --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.7);
+    --xfe-dialog-bg: #2b2b2b;
+    --xfe-dialog-text: #e0e0e0;
+    --xfe-dialog-header-bg: #7a6a3f;
+    --xfe-dialog-header-text: #ffffff;
+    --xfe-dialog-btn-bg: #3a3a3a;
+    --xfe-dialog-btn-text: #e0e0e0;
+    --xfe-dialog-btn-border: #555555;
+    --xfe-dialog-btn-hover-bg: #4a4a4a;
+    --xfe-dialog-btn-hover-border: #666666;
+    --xfe-dialog-warning-bg: #7a6a3f;
+    --xfe-dialog-warning-border: #7a6a3f;
+    --xfe-dialog-warning-text: #ffffff;
+    --xfe-dialog-warning-hover-bg: #8d7c4e;
+    --xfe-dialog-warning-hover-border: #8d7c4e;
 }
 
 /* Auto theme - follows system preference */
@@ -53,6 +98,21 @@
         --xfe-border-color: #444444;
         --xfe-outline-color: #666666;
         --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.7);
+        --xfe-dialog-bg: #2b2b2b;
+        --xfe-dialog-text: #e0e0e0;
+        --xfe-dialog-header-bg: #7a6a3f;
+        --xfe-dialog-header-text: #ffffff;
+        --xfe-dialog-btn-bg: #3a3a3a;
+        --xfe-dialog-btn-text: #e0e0e0;
+        --xfe-dialog-btn-border: #555555;
+        --xfe-dialog-btn-hover-bg: #4a4a4a;
+        --xfe-dialog-btn-hover-border: #666666;
+        --xfe-dialog-warning-bg: #7a6a3f;
+        --xfe-dialog-warning-border: #7a6a3f;
+        --xfe-dialog-warning-text: #ffffff;
+        --xfe-dialog-warning-hover-bg: #8d7c4e;
+        --xfe-dialog-warning-hover-border: #8d7c4e;
     }
 }
 
@@ -770,8 +830,8 @@
    Delete Confirmation Dialog
    Uses TYPO3 backend modal class names (.modal-header, .modal-body, etc.)
    so styles are inherited when backend/Bootstrap CSS is available.
-   These rules are scoped under .frontend-edit__dialog-overlay and serve as
-   fallback styles matching the TYPO3 backend dark theme.
+   These rules are scoped under .frontend-edit__dialog-overlay and use
+   --xfe-dialog-* custom properties to respect the active theme.
    ========================================================================== */
 .frontend-edit__dialog-overlay {
     position: fixed;
@@ -779,7 +839,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
+    background: var(--xfe-dialog-overlay-bg);
     z-index: 100001;
     display: flex;
     align-items: center;
@@ -793,8 +853,8 @@
 }
 
 .frontend-edit__dialog-overlay .modal-dialog {
-    min-width: 500px;
-    max-width: 600px;
+    width: 500px;
+    max-width: calc(100vw - 32px);
     transform: scale(0.9);
     transition: transform 0.2s ease;
 }
@@ -804,7 +864,7 @@
 }
 
 .frontend-edit__dialog-overlay .modal-content {
-    background: #2b2b2b;
+    background: var(--xfe-dialog-bg);
     border-radius: 2px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
     border: none;
@@ -812,8 +872,8 @@
 
 .frontend-edit__dialog-overlay .modal-header {
     padding: 12px 16px;
-    background: #8b7a4a;
-    color: #fff;
+    background: var(--xfe-dialog-header-bg);
+    color: var(--xfe-dialog-header-text);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -825,16 +885,15 @@
     margin: 0;
     font-size: 14px;
     font-weight: 500;
-    color: #fff;
+    color: var(--xfe-dialog-header-text);
     flex: 1;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
-.frontend-edit__dialog-overlay .close,
 .frontend-edit__dialog-overlay .btn-close {
     background: transparent;
     border: none;
-    color: #fff;
+    color: var(--xfe-dialog-header-text);
     font-size: 24px;
     line-height: 1;
     cursor: pointer;
@@ -848,12 +907,10 @@
     transition: opacity 0.2s ease;
 }
 
-.frontend-edit__dialog-overlay .close:hover,
 .frontend-edit__dialog-overlay .btn-close:hover {
     opacity: 1;
 }
 
-.frontend-edit__dialog-overlay .close svg,
 .frontend-edit__dialog-overlay .btn-close svg {
     width: 14px;
     height: 14px;
@@ -865,7 +922,7 @@
 
 .frontend-edit__dialog-overlay .modal-body p {
     margin: 0;
-    color: #e0e0e0;
+    color: var(--xfe-dialog-text);
     line-height: 1.5;
     font-size: 14px;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -881,7 +938,6 @@
 
 .frontend-edit__dialog-overlay .btn {
     padding: 6px 16px;
-    border: 1px solid #555;
     border-radius: 2px;
     font-size: 13px;
     cursor: pointer;
@@ -890,25 +946,25 @@
 }
 
 .frontend-edit__dialog-overlay .btn-default {
-    background: #3a3a3a;
-    color: #e0e0e0;
-    border-color: #555;
+    background: var(--xfe-dialog-btn-bg);
+    color: var(--xfe-dialog-btn-text);
+    border: 1px solid var(--xfe-dialog-btn-border);
 }
 
 .frontend-edit__dialog-overlay .btn-default:hover {
-    background: #4a4a4a;
-    border-color: #666;
+    background: var(--xfe-dialog-btn-hover-bg);
+    border-color: var(--xfe-dialog-btn-hover-border);
 }
 
 .frontend-edit__dialog-overlay .btn-warning {
-    background: #8b7a4a;
-    border-color: #8b7a4a;
-    color: #fff;
+    background: var(--xfe-dialog-warning-bg);
+    border: 1px solid var(--xfe-dialog-warning-border);
+    color: var(--xfe-dialog-warning-text);
 }
 
 .frontend-edit__dialog-overlay .btn-warning:hover {
-    background: #9d8a5a;
-    border-color: #9d8a5a;
+    background: var(--xfe-dialog-warning-hover-bg);
+    border-color: var(--xfe-dialog-warning-hover-border);
 }
 
 /* ==========================================================================

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -161,6 +161,127 @@
   };
 
   /**
+   * Delete Handler - Confirmation dialog + fetch-based deletion
+   * Labels are provided by ResourceRendererService via window.FRONTEND_EDIT_DELETE_LABELS
+   */
+  const DeleteHandler = {
+    labels() {
+      return window.FRONTEND_EDIT_DELETE_LABELS || {};
+    },
+
+    init() {
+      document.addEventListener('click', (e) => {
+        const link = e.target.closest('.frontend-edit__dropdown a.delete');
+        if (!link?.href) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+        Dropdown.closeAll();
+
+        // Read record info from data attributes (set in createDropdown)
+        const recordTitle = link.dataset.recordTitle || '';
+        const table = link.dataset.recordTable || 'tt_content';
+        const uid = link.dataset.recordUid || '';
+
+        this.confirm(uid, table, recordTitle).then((confirmed) => {
+          if (confirmed) this.execute(link.href);
+        });
+      });
+    },
+
+    confirm(uid, table, recordTitle) {
+      const l = this.labels();
+      return new Promise((resolve) => {
+        const overlay = document.createElement('div');
+        overlay.className = 'frontend-edit__dialog-overlay';
+
+        const modalDialog = document.createElement('div');
+        modalDialog.className = 'frontend-edit__dialog modal-dialog';
+        modalDialog.setAttribute('role', 'alertdialog');
+        modalDialog.setAttribute('aria-modal', 'true');
+        modalDialog.setAttribute('aria-labelledby', 'fe-dialog-title');
+
+        const modalContent = document.createElement('div');
+        modalContent.className = 'modal-content';
+
+        // Header — .modal-header
+        const modalHeader = document.createElement('div');
+        modalHeader.className = 'modal-header';
+        const title = document.createElement('h4');
+        title.id = 'fe-dialog-title';
+        title.className = 'modal-title';
+        title.textContent = l.title || 'Delete this record?';
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'close btn-close';
+        closeBtn.type = 'button';
+        closeBtn.innerHTML = ICONS.close;
+        closeBtn.setAttribute('aria-label', 'Close');
+        modalHeader.appendChild(title);
+        modalHeader.appendChild(closeBtn);
+
+        // Body — .modal-body, matches TYPO3 format: "Are you sure you want to delete the record 'Title [table:uid]'?"
+        const modalBody = document.createElement('div');
+        modalBody.className = 'modal-body';
+        const p = document.createElement('p');
+        const recordInfo = recordTitle
+          ? `${recordTitle} [${table}:${uid}]`
+          : `[${table}:${uid}]`;
+        const fallbackMessage = "Are you sure you want to delete the record '%s'?";
+        const baseMessage = l.message || fallbackMessage;
+        p.textContent = baseMessage.replace('%s', recordInfo);
+        modalBody.appendChild(p);
+
+        // Footer — .modal-footer with TYPO3 btn classes
+        const modalFooter = document.createElement('div');
+        modalFooter.className = 'modal-footer';
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn btn-default';
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = l.cancel || 'Cancel';
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'btn btn-warning';
+        deleteBtn.type = 'button';
+        deleteBtn.textContent = l.delete || 'Delete record (!)';
+        modalFooter.appendChild(cancelBtn);
+        modalFooter.appendChild(deleteBtn);
+
+        modalContent.appendChild(modalHeader);
+        modalContent.appendChild(modalBody);
+        modalContent.appendChild(modalFooter);
+        modalDialog.appendChild(modalContent);
+        overlay.appendChild(modalDialog);
+        document.body.appendChild(overlay);
+        requestAnimationFrame(() => overlay.classList.add('frontend-edit__dialog-overlay--show'));
+
+        const close = (result) => {
+          overlay.classList.remove('frontend-edit__dialog-overlay--show');
+          setTimeout(() => overlay.remove(), 200);
+          resolve(result);
+        };
+
+        closeBtn.addEventListener('click', () => close(false));
+        cancelBtn.addEventListener('click', () => close(false));
+        deleteBtn.addEventListener('click', () => close(true));
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) close(false); });
+        document.addEventListener('keydown', function onEsc(e) {
+          if (e.key === 'Escape') {
+            document.removeEventListener('keydown', onEsc);
+            close(false);
+          }
+        });
+
+        deleteBtn.focus();
+      });
+    },
+
+    execute(url) {
+      // Navigate to the tce_db URL same as hide, move, and other actions.
+      // TYPO3 processes the delete and redirects back to the returnUrl.
+      window.location.href = url;
+    }
+  };
+
+  /**
    * Notification Manager - Shows toast notifications for flash messages
    */
   const Notification = {
@@ -677,6 +798,14 @@
           el.classList.add(safeName);
         }
 
+        // Store record title on delete link for the confirmation dialog
+        if (name === 'delete' && action.type === 'link') {
+          const recordTitle = (contentElement.element?.header || '').replace(/<[^>]*>/g, '');
+          el.dataset.recordTitle = recordTitle;
+          el.dataset.recordTable = 'tt_content';
+          el.dataset.recordUid = contentElement.element?.uid || uid;
+        }
+
         if (action.icon) {
           const iconWrapper = document.createElement('span');
           iconWrapper.innerHTML = action.icon;
@@ -1071,6 +1200,7 @@
 
           Renderer.render(contentElements);
           Dropdown.setupGlobalHandler();
+          DeleteHandler.init();
         }
 
         Logger.log(`Frontend Edit initialization completed in ${Math.round(performance.now() - startTime)}ms`);

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -184,7 +184,7 @@
         const uid = link.dataset.recordUid || '';
 
         this.confirm(uid, table, recordTitle).then((confirmed) => {
-          if (confirmed) window.location.href = link.href;
+          if (confirmed) this.execute(link.href);
         });
       });
     },
@@ -264,6 +264,22 @@
 
         deleteBtn.focus();
       });
+    },
+
+    execute(url) {
+      const l = this.labels();
+      fetch(url, { method: 'GET', credentials: 'include' })
+        .then((response) => {
+          if (response.ok) {
+            Notification.show({ title: l.success || 'Record deleted', message: '', severity: 'ok' });
+            setTimeout(() => window.location.reload(), 1500);
+          } else {
+            Notification.show({ title: l.error || 'Could not delete the record', message: '', severity: 'error' });
+          }
+        })
+        .catch(() => {
+          Notification.show({ title: l.error || 'Could not delete the record', message: '', severity: 'error' });
+        });
     }
   };
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -192,6 +192,7 @@
     confirm(uid, table, recordTitle) {
       const l = this.labels();
       return new Promise((resolve) => {
+        const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
         const overlay = document.createElement('div');
         overlay.className = 'frontend-edit__dialog-overlay';
 
@@ -253,6 +254,9 @@
           document.removeEventListener('keydown', onEsc);
           overlay.classList.remove('frontend-edit__dialog-overlay--show');
           setTimeout(() => overlay.remove(), 200);
+          if (previousFocus && document.contains(previousFocus)) {
+            previousFocus.focus();
+          }
           resolve(result);
         };
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -184,7 +184,7 @@
         const uid = link.dataset.recordUid || '';
 
         this.confirm(uid, table, recordTitle).then((confirmed) => {
-          if (confirmed) this.execute(link.href);
+          if (confirmed) window.location.href = link.href;
         });
       });
     },
@@ -204,7 +204,6 @@
         const modalContent = document.createElement('div');
         modalContent.className = 'modal-content';
 
-        // Header — .modal-header
         const modalHeader = document.createElement('div');
         modalHeader.className = 'modal-header';
         const title = document.createElement('h4');
@@ -212,26 +211,22 @@
         title.className = 'modal-title';
         title.textContent = l.title || 'Delete this record?';
         const closeBtn = document.createElement('button');
-        closeBtn.className = 'close btn-close';
+        closeBtn.className = 'btn-close';
         closeBtn.type = 'button';
         closeBtn.innerHTML = ICONS.close;
         closeBtn.setAttribute('aria-label', 'Close');
         modalHeader.appendChild(title);
         modalHeader.appendChild(closeBtn);
 
-        // Body — .modal-body, matches TYPO3 format: "Are you sure you want to delete the record 'Title [table:uid]'?"
         const modalBody = document.createElement('div');
         modalBody.className = 'modal-body';
         const p = document.createElement('p');
         const recordInfo = recordTitle
           ? `${recordTitle} [${table}:${uid}]`
           : `[${table}:${uid}]`;
-        const fallbackMessage = "Are you sure you want to delete the record '%s'?";
-        const baseMessage = l.message || fallbackMessage;
-        p.textContent = baseMessage.replace('%s', recordInfo);
+        p.textContent = (l.message || "Are you sure you want to delete the record '%s'?").replace('%s', recordInfo);
         modalBody.appendChild(p);
 
-        // Footer — .modal-footer with TYPO3 btn classes
         const modalFooter = document.createElement('div');
         modalFooter.className = 'modal-footer';
         const cancelBtn = document.createElement('button');
@@ -253,7 +248,9 @@
         document.body.appendChild(overlay);
         requestAnimationFrame(() => overlay.classList.add('frontend-edit__dialog-overlay--show'));
 
+        const onEsc = (e) => { if (e.key === 'Escape') close(false); };
         const close = (result) => {
+          document.removeEventListener('keydown', onEsc);
           overlay.classList.remove('frontend-edit__dialog-overlay--show');
           setTimeout(() => overlay.remove(), 200);
           resolve(result);
@@ -263,21 +260,10 @@
         cancelBtn.addEventListener('click', () => close(false));
         deleteBtn.addEventListener('click', () => close(true));
         overlay.addEventListener('click', (e) => { if (e.target === overlay) close(false); });
-        document.addEventListener('keydown', function onEsc(e) {
-          if (e.key === 'Escape') {
-            document.removeEventListener('keydown', onEsc);
-            close(false);
-          }
-        });
+        document.addEventListener('keydown', onEsc);
 
         deleteBtn.focus();
       });
-    },
-
-    execute(url) {
-      // Navigate to the tce_db URL same as hide, move, and other actions.
-      // TYPO3 processes the delete and redirects back to the returnUrl.
-      window.location.href = url;
     }
   };
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -268,9 +268,9 @@
 
     execute(url) {
       const l = this.labels();
-      fetch(url, { method: 'GET', credentials: 'include' })
+      fetch(url, { method: 'GET', credentials: 'include', redirect: 'manual' })
         .then((response) => {
-          if (response.ok) {
+          if (response.type === 'opaqueredirect' || response.ok) {
             Notification.show({ title: l.success || 'Record deleted', message: '', severity: 'ok' });
             setTimeout(() => window.location.reload(), 1500);
           } else {


### PR DESCRIPTION
- Adds a delete action to the content element context menu. Clicking it shows a confirmation dialog (matching a bit the typo3 design) before executing the deletion via fetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete action added to content element actions with an in-page confirmation modal, keyboard/overlay dismissal, success/error toasts, and automatic page refresh on successful deletion.

* **Translations**
  * German and English strings added for delete label, confirmation dialog (title, message, cancel/confirm) and success/error outcomes.

* **Style**
  * New theme-aware dialog styling, animations, and reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->