### PR TITLE
feat: add iframe modal editor for inline backend editing

### DIFF
--- a/Classes/Middleware/ToolRendererMiddleware.php
+++ b/Classes/Middleware/ToolRendererMiddleware.php
@@ -66,8 +66,13 @@ class ToolRendererMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        // Collect flash messages from backend session before rendering (if enabled)
-        $flashMessages = $this->settingsService->isEnableFlashMessages($request)
+        // Collect flash messages from backend session before rendering (if enabled).
+        //
+        // The iframe modal editor appends ?tx_ximatypo3frontendedit_iframe=1 to the
+        // save returnUrl so this follow-up request doesn't consume the flash queue —
+        // messages are left in the session for the parent page reload to pick up.
+        $isIframeRequest = isset($request->getQueryParams()['tx_ximatypo3frontendedit_iframe']);
+        $flashMessages = !$isIframeRequest && $this->settingsService->isEnableFlashMessages($request)
             ? $this->flashMessageService->collectFromSession()
             : [];
 

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -181,7 +181,10 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         $historyUrl = $this->urlBuilderService->buildHistoryUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
         $this->addButton($menuButton, 'history', ButtonType::Link, url: $historyUrl, icon: 'actions-history');
 
-        // New content after button - opens page layout with wizard via iframe_edit.js
+        // New content after button.
+        // URL builder returns a version-aware URL:
+        //  - v13.4: web_layout URL with hash for iframe_edit.js to auto-click the wizard
+        //  - v14.2+: record_edit URL with negative UID (standard backend new-after-element flow)
         $newContentUrl = $this->urlBuilderService->buildNewContentAfterUrl(
             (int) $contentElement['uid'],
             (int) ($contentElement['pid'] ?? 0),

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -156,6 +156,7 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
     public function addActionSection(
         Button $menuButton,
         array $contentElement,
+        int $languageUid,
         string $returnUrlAnchor,
     ): void {
         $this->addButton($menuButton, 'div_action', ButtonType::Divider);
@@ -189,6 +190,7 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
             (int) $contentElement['uid'],
             (int) ($contentElement['pid'] ?? 0),
             (int) ($contentElement['colPos'] ?? 0),
+            $languageUid,
             $returnUrlAnchor,
         );
         $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -181,8 +181,13 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         $historyUrl = $this->urlBuilderService->buildHistoryUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
         $this->addButton($menuButton, 'history', ButtonType::Link, url: $historyUrl, icon: 'actions-history');
 
-        // New content after button
-        $newContentUrl = $this->urlBuilderService->buildNewContentAfterUrl($contentElement['uid'], $returnUrlAnchor);
+        // New content after button - opens page layout with wizard via iframe_edit.js
+        $newContentUrl = $this->urlBuilderService->buildNewContentAfterUrl(
+            (int) $contentElement['uid'],
+            (int) ($contentElement['pid'] ?? 0),
+            (int) ($contentElement['colPos'] ?? 0),
+            $returnUrlAnchor,
+        );
         $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
 
         // Delete button

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -164,7 +164,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
 
         $this->contentElementButtonBuilder->addInfoSection($menuButton, $contentElement, $contentElementConfig);
         $this->contentElementButtonBuilder->addEditSection($menuButton, $contentElement, $languageUid, $pid, $returnUrlAnchor, $contextualUrl);
-        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $returnUrlAnchor);
+        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $languageUid, $returnUrlAnchor);
 
         return $menuButton;
     }

--- a/Classes/Service/Ui/BackendSettingsService.php
+++ b/Classes/Service/Ui/BackendSettingsService.php
@@ -13,18 +13,16 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Service\Ui;
 
+use Exception;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\{GeneralUtility, PathUtility};
+use Xima\XimaTypo3FrontendEdit\Configuration;
+
+use function sprintf;
 
 /**
  * BackendSettingsService.
- *
- * Generates the inline TYPO3 backend settings and global-object stubs that
- * must be present before any backend JavaScript module runs inside the
- * frontend-editing iframe. Without these stubs, modules such as
- * shortcut-menu.js or top-level-module-import.js throw because they expect
- * top.TYPO3.Backend.Topbar.Toolbar and similar objects.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
@@ -90,168 +88,37 @@ final readonly class BackendSettingsService
     }
 
     /**
-     * Generate a <script> tag with backend stubs and settings for the editing iframe.
+     * Generate the JSON data block + stubs script tag.
+     *
+     * The JSON block carries ajaxUrls and lang labels.
+     * The script tag loads backend_stubs.js which consumes that data.
      */
     public function getSettingsScript(string $nonce = ''): string
     {
-        $settingsJson = json_encode($this->buildSettings(), \JSON_HEX_TAG | \JSON_HEX_AMP);
-        $langJson = json_encode($this->buildLangLabels(), \JSON_HEX_TAG | \JSON_HEX_AMP);
         $nonceAttr = '' !== $nonce ? ' nonce="'.htmlspecialchars($nonce, \ENT_QUOTES, 'UTF-8').'"' : '';
 
-        return sprintf(
-            '<script%s>
-(function() {
-    "use strict";
-    if (!window.TYPO3) window.TYPO3 = {};
-    if (!window.TYPO3.settings) window.TYPO3.settings = {};
-    if (!window.TYPO3.lang) window.TYPO3.lang = {};
-    if (!window.TYPO3.Backend) window.TYPO3.Backend = {};
-
-    if (!window.TYPO3.Backend.Topbar) {
-        window.TYPO3.Backend.Topbar = {
-            Toolbar: {
-                registerEvent: function(cb) { try { cb(); } catch(e) {} },
-                refresh: function() {}
-            }
-        };
-    }
-    if (!window.TYPO3.Backend.Topbar.Toolbar) {
-        window.TYPO3.Backend.Topbar.Toolbar = {
-            registerEvent: function(cb) { try { cb(); } catch(e) {} },
-            refresh: function() {}
-        };
-    }
-
-    if (!window.TYPO3.Backend.consumerScope) {
-        window.TYPO3.Backend.consumerScope = {
-            attach: function() {},
-            detach: function() {},
-            invoke: function() {}
-        };
-    }
-
-    if (!window.TYPO3.Backend.ContentContainer) {
-        window.TYPO3.Backend.ContentContainer = {
-            setUrl: function(url) {
-                if (url && url.indexOf("/typo3/wizard/") !== -1) {
-                    if (window.TYPO3.Modal && window.TYPO3.Modal.advanced) {
-                        window.TYPO3.Modal.advanced({ content: url });
-                    }
-                    return Promise.resolve();
-                }
-                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
-                if (iframe) {
-                    try {
-                        var u = new URL(url, window.location.origin);
-                        var ret = u.searchParams.get("returnUrl") || "";
-                        if (!ret || ret.indexOf("/typo3/") !== -1) {
-                            u.searchParams.set("returnUrl", window.location.href);
-                        }
-                        if (!u.searchParams.has("tx_ximatypo3frontendedit")) {
-                            u.searchParams.set("tx_ximatypo3frontendedit", "");
-                        }
-                        iframe.src = u.toString();
-                    } catch(e) { iframe.src = url; }
-                }
-                return Promise.resolve();
-            },
-            refresh: function() {
-                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
-                if (iframe && iframe.contentWindow) iframe.contentWindow.location.reload();
-                return Promise.resolve();
-            },
-            get: function() {
-                return document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
-            }
-        };
-    }
-
-    if (!window.TYPO3.InfoWindow) {
-        window.TYPO3.InfoWindow = { showItem: function() {} };
-    }
-
-    if (!window.TYPO3.HotkeyStorage) {
-        window.TYPO3.HotkeyStorage = {
-            register: function() {},
-            unregister: function() {},
-            getScopedHotkeyMap: function() { return new Map(); }
-        };
-    }
-
-    if (!window.TYPO3.Modal) {
-        window.TYPO3.Modal = {
-            advanced: function(config) {
-                var url = config && (config.content || config.url || "");
-                if (url && url.indexOf("/typo3/wizard/") !== -1) {
-                    var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
-                    if (iframe && iframe.contentWindow && iframe.contentWindow.document) {
-                        var doc = iframe.contentWindow.document;
-                        var existing = doc.getElementById("fe-wizard-overlay");
-                        if (existing) existing.remove();
-                        var overlay = doc.createElement("div");
-                        overlay.id = "fe-wizard-overlay";
-                        overlay.style.cssText = "position:fixed;top:0;left:0;width:100%%;height:100%%;z-index:99999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;";
-                        var panel = doc.createElement("div");
-                        panel.style.cssText = "width:80%%;max-width:900px;height:80%%;background:#fff;border-radius:4px;overflow:hidden;position:relative;display:flex;flex-direction:column;box-shadow:0 4px 24px rgba(0,0,0,0.3);";
-                        var header = doc.createElement("div");
-                        header.style.cssText = "display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;";
-                        var closeBtn = doc.createElement("button");
-                        closeBtn.innerHTML = "&times;";
-                        closeBtn.style.cssText = "font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;";
-                        closeBtn.onclick = function() { overlay.remove(); };
-                        var wizIframe = doc.createElement("iframe");
-                        wizIframe.src = url;
-                        wizIframe.style.cssText = "flex:1;border:none;width:100%%;";
-                        header.appendChild(closeBtn);
-                        panel.appendChild(header);
-                        panel.appendChild(wizIframe);
-                        overlay.appendChild(panel);
-                        overlay.addEventListener("click", function(ev) { if (ev.target === overlay) overlay.remove(); });
-                        doc.body.appendChild(overlay);
-                    }
-                }
-                return { addEventListener: function() {}, on: function() {} };
-            },
-            confirm: function(title, content) { return Promise.resolve(confirm(content)); },
-            dismiss: function() {
-                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
-                if (iframe && iframe.contentWindow) {
-                    var overlay = iframe.contentWindow.document.getElementById("fe-wizard-overlay");
-                    if (overlay) overlay.remove();
-                }
-            },
-            currentModal: null
-        };
-    }
-
-    Object.assign(window.TYPO3.settings, %s);
-    Object.assign(window.TYPO3.lang, %s);
-    window.TYPO3.Backend._frontendEditContext = true;
-
-    document.addEventListener("typo3:import-javascript-module", function(e) {
-        if (e.detail && e.detail.specifier) {
-            e.detail.importPromise = import(e.detail.specifier).catch(function() { return {}; });
-        }
-    });
-})();
-</script>',
-            $nonceAttr,
-            $settingsJson,
-            $langJson,
-        );
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function buildSettings(): array
-    {
-        return [
-            'ajaxUrls' => $this->buildAjaxUrls(),
-            'DateTimePicker' => [
-                'DateFormat' => ['d.m.Y', 'Y-m-d'],
+        $dataJson = json_encode([
+            'settings' => [
+                'ajaxUrls' => $this->buildAjaxUrls(),
+                'DateTimePicker' => [
+                    'DateFormat' => ['d.m.Y', 'Y-m-d'],
+                ],
             ],
-        ];
+            'lang' => $this->buildLangLabels(),
+        ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
+
+        $stubsPath = PathUtility::getAbsoluteWebPath(
+            GeneralUtility::getFileAbsFileName('EXT:'.Configuration::EXT_KEY.'/Resources/Public/JavaScript/backend_stubs.js'),
+        );
+
+        return sprintf(
+            '<script%s type="application/json" id="frontend-edit-backend-stubs-data">%s</script>'
+            .'<script%s src="%s"></script>',
+            $nonceAttr,
+            $dataJson,
+            $nonceAttr,
+            $stubsPath,
+        );
     }
 
     /**
@@ -263,7 +130,7 @@ final readonly class BackendSettingsService
         foreach (self::REQUIRED_AJAX_ROUTES as $key => $routeIdentifier) {
             try {
                 $urls[$key] = (string) $this->uriBuilder->buildUriFromRoute($routeIdentifier);
-            } catch (\Exception) {
+            } catch (Exception) {
                 // Route may not exist in all TYPO3 versions
             }
         }

--- a/Classes/Service/Ui/BackendSettingsService.php
+++ b/Classes/Service/Ui/BackendSettingsService.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Service\Ui;
+
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * BackendSettingsService.
+ *
+ * Generates the inline TYPO3 backend settings and global-object stubs that
+ * must be present before any backend JavaScript module runs inside the
+ * frontend-editing iframe. Without these stubs, modules such as
+ * shortcut-menu.js or top-level-module-import.js throw because they expect
+ * top.TYPO3.Backend.Topbar.Toolbar and similar objects.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class BackendSettingsService
+{
+    /**
+     * AJAX routes required by tree components, link browser, and file handling.
+     *
+     * @var array<string, string>
+     */
+    private const REQUIRED_AJAX_ROUTES = [
+        'filestorage_tree_data' => 'ajax_filestorage_tree_data',
+        'filestorage_tree_filter' => 'ajax_filestorage_tree_filter',
+        'file_exists' => 'ajax_file_exists',
+        'file_process' => 'ajax_file_process',
+        'record_process' => 'ajax_record_process',
+        'contextmenu' => 'ajax_contextmenu',
+        'contextmenu_clipboard' => 'ajax_contextmenu_clipboard',
+        'link_browser_encodetypolink' => 'ajax_link_browser_encodetypolink',
+        'link_browser_page' => 'ajax_link_browser_page',
+        'link_browser_file' => 'ajax_link_browser_file',
+        'link_browser_folder' => 'ajax_link_browser_folder',
+        'link_browser_url' => 'ajax_link_browser_url',
+        'link_browser_mail' => 'ajax_link_browser_mail',
+        'link_browser_telephone' => 'ajax_link_browser_telephone',
+        'record_tree_data' => 'ajax_record_tree_data',
+        'record_tree_filter' => 'ajax_record_tree_filter',
+        'page_tree_data' => 'ajax_page_tree_data',
+        'page_tree_rootline' => 'ajax_page_tree_rootline',
+        'page_tree_filter' => 'ajax_page_tree_filter',
+        'page_tree_configuration' => 'ajax_page_tree_configuration',
+        'page_tree_browser_configuration' => 'ajax_page_tree_browser_configuration',
+        'page_tree_set_temporary_mount_point' => 'ajax_page_tree_set_temporary_mount_point',
+    ];
+
+    /**
+     * Language labels consumed by backend JavaScript modules.
+     *
+     * @var array<string, string>
+     */
+    private const REQUIRED_LANG_LABELS = [
+        'tree.networkError' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:tree.networkError',
+        'tree.noResults' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:tree.noResults',
+        'tree.loading' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:tree.loading',
+        'labels.datepicker.today' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.datepicker.today',
+        'labels.datepicker.clear' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.datepicker.clear',
+        'labels.datepicker.close' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.datepicker.close',
+        'button.ok' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:button.ok',
+        'button.cancel' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:button.cancel',
+        'button.close' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:button.close',
+        'labels.refresh' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.refresh',
+        'labels.search' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.search',
+        'file_upload.uploadedSuccessfully' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:file_upload.uploadedSuccessfully',
+        'file_upload.error' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:file_upload.error',
+    ];
+
+    private UriBuilder $uriBuilder;
+
+    public function __construct()
+    {
+        $this->uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+    }
+
+    /**
+     * Generate a <script> tag with backend stubs and settings for the editing iframe.
+     */
+    public function getSettingsScript(string $nonce = ''): string
+    {
+        $settingsJson = json_encode($this->buildSettings(), \JSON_HEX_TAG | \JSON_HEX_AMP);
+        $langJson = json_encode($this->buildLangLabels(), \JSON_HEX_TAG | \JSON_HEX_AMP);
+        $nonceAttr = '' !== $nonce ? ' nonce="'.htmlspecialchars($nonce, \ENT_QUOTES, 'UTF-8').'"' : '';
+
+        return sprintf(
+            '<script%s>
+(function() {
+    "use strict";
+    if (!window.TYPO3) window.TYPO3 = {};
+    if (!window.TYPO3.settings) window.TYPO3.settings = {};
+    if (!window.TYPO3.lang) window.TYPO3.lang = {};
+    if (!window.TYPO3.Backend) window.TYPO3.Backend = {};
+
+    if (!window.TYPO3.Backend.Topbar) {
+        window.TYPO3.Backend.Topbar = {
+            Toolbar: {
+                registerEvent: function(cb) { try { cb(); } catch(e) {} },
+                refresh: function() {}
+            }
+        };
+    }
+    if (!window.TYPO3.Backend.Topbar.Toolbar) {
+        window.TYPO3.Backend.Topbar.Toolbar = {
+            registerEvent: function(cb) { try { cb(); } catch(e) {} },
+            refresh: function() {}
+        };
+    }
+
+    if (!window.TYPO3.Backend.consumerScope) {
+        window.TYPO3.Backend.consumerScope = {
+            attach: function() {},
+            detach: function() {},
+            invoke: function() {}
+        };
+    }
+
+    if (!window.TYPO3.Backend.ContentContainer) {
+        window.TYPO3.Backend.ContentContainer = {
+            setUrl: function(url) {
+                if (url && url.indexOf("/typo3/wizard/") !== -1) {
+                    if (window.TYPO3.Modal && window.TYPO3.Modal.advanced) {
+                        window.TYPO3.Modal.advanced({ content: url });
+                    }
+                    return Promise.resolve();
+                }
+                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
+                if (iframe) {
+                    try {
+                        var u = new URL(url, window.location.origin);
+                        var ret = u.searchParams.get("returnUrl") || "";
+                        if (!ret || ret.indexOf("/typo3/") !== -1) {
+                            u.searchParams.set("returnUrl", window.location.href);
+                        }
+                        if (!u.searchParams.has("tx_ximatypo3frontendedit")) {
+                            u.searchParams.set("tx_ximatypo3frontendedit", "");
+                        }
+                        iframe.src = u.toString();
+                    } catch(e) { iframe.src = url; }
+                }
+                return Promise.resolve();
+            },
+            refresh: function() {
+                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
+                if (iframe && iframe.contentWindow) iframe.contentWindow.location.reload();
+                return Promise.resolve();
+            },
+            get: function() {
+                return document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
+            }
+        };
+    }
+
+    if (!window.TYPO3.InfoWindow) {
+        window.TYPO3.InfoWindow = { showItem: function() {} };
+    }
+
+    if (!window.TYPO3.HotkeyStorage) {
+        window.TYPO3.HotkeyStorage = {
+            register: function() {},
+            unregister: function() {},
+            getScopedHotkeyMap: function() { return new Map(); }
+        };
+    }
+
+    if (!window.TYPO3.Modal) {
+        window.TYPO3.Modal = {
+            advanced: function(config) {
+                var url = config && (config.content || config.url || "");
+                if (url && url.indexOf("/typo3/wizard/") !== -1) {
+                    var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
+                    if (iframe && iframe.contentWindow && iframe.contentWindow.document) {
+                        var doc = iframe.contentWindow.document;
+                        var existing = doc.getElementById("fe-wizard-overlay");
+                        if (existing) existing.remove();
+                        var overlay = doc.createElement("div");
+                        overlay.id = "fe-wizard-overlay";
+                        overlay.style.cssText = "position:fixed;top:0;left:0;width:100%%;height:100%%;z-index:99999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;";
+                        var panel = doc.createElement("div");
+                        panel.style.cssText = "width:80%%;max-width:900px;height:80%%;background:#fff;border-radius:4px;overflow:hidden;position:relative;display:flex;flex-direction:column;box-shadow:0 4px 24px rgba(0,0,0,0.3);";
+                        var header = doc.createElement("div");
+                        header.style.cssText = "display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;";
+                        var closeBtn = doc.createElement("button");
+                        closeBtn.innerHTML = "&times;";
+                        closeBtn.style.cssText = "font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;";
+                        closeBtn.onclick = function() { overlay.remove(); };
+                        var wizIframe = doc.createElement("iframe");
+                        wizIframe.src = url;
+                        wizIframe.style.cssText = "flex:1;border:none;width:100%%;";
+                        header.appendChild(closeBtn);
+                        panel.appendChild(header);
+                        panel.appendChild(wizIframe);
+                        overlay.appendChild(panel);
+                        overlay.addEventListener("click", function(ev) { if (ev.target === overlay) overlay.remove(); });
+                        doc.body.appendChild(overlay);
+                    }
+                }
+                return { addEventListener: function() {}, on: function() {} };
+            },
+            confirm: function(title, content) { return Promise.resolve(confirm(content)); },
+            dismiss: function() {
+                var iframe = document.querySelector("#xima-typo3-frontend-edit-modal-iframe");
+                if (iframe && iframe.contentWindow) {
+                    var overlay = iframe.contentWindow.document.getElementById("fe-wizard-overlay");
+                    if (overlay) overlay.remove();
+                }
+            },
+            currentModal: null
+        };
+    }
+
+    Object.assign(window.TYPO3.settings, %s);
+    Object.assign(window.TYPO3.lang, %s);
+    window.TYPO3.Backend._frontendEditContext = true;
+
+    document.addEventListener("typo3:import-javascript-module", function(e) {
+        if (e.detail && e.detail.specifier) {
+            e.detail.importPromise = import(e.detail.specifier).catch(function() { return {}; });
+        }
+    });
+})();
+</script>',
+            $nonceAttr,
+            $settingsJson,
+            $langJson,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSettings(): array
+    {
+        return [
+            'ajaxUrls' => $this->buildAjaxUrls(),
+            'DateTimePicker' => [
+                'DateFormat' => ['d.m.Y', 'Y-m-d'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildAjaxUrls(): array
+    {
+        $urls = [];
+        foreach (self::REQUIRED_AJAX_ROUTES as $key => $routeIdentifier) {
+            try {
+                $urls[$key] = (string) $this->uriBuilder->buildUriFromRoute($routeIdentifier);
+            } catch (\Exception) {
+                // Route may not exist in all TYPO3 versions
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildLangLabels(): array
+    {
+        $languageService = $this->getLanguageService();
+        if (null === $languageService) {
+            return [];
+        }
+
+        $labels = [];
+        foreach (self::REQUIRED_LANG_LABELS as $key => $llReference) {
+            $labels[$key] = $languageService->sL($llReference) ?: $key;
+        }
+
+        return $labels;
+    }
+
+    private function getLanguageService(): ?LanguageService
+    {
+        return $GLOBALS['LANG'] ?? null;
+    }
+}

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -45,6 +45,7 @@ final readonly class ResourceRendererService
         private BackendUserService $backendUserService,
         private UrlBuilderService $urlBuilderService,
         private PageMenuGenerator $pageMenuGenerator,
+        private BackendSettingsService $backendSettingsService,
     ) {}
 
     /**
@@ -61,9 +62,11 @@ final readonly class ResourceRendererService
             $nonceAttribute = '' !== $nonceValue ? ' nonce="'.$nonceValue.'"' : '';
             $resources = ResourceUtility::getResources(['nonce' => $nonceValue]);
 
+            $this->addBackendStubs($resources, $nonceValue);
             $this->addFloatingUiResource($resources, $nonceAttribute);
             $this->addSettingsConfig($resources, $nonceAttribute, $request);
             $this->addDebugConfig($resources, $nonceAttribute);
+            $this->addIframeEditResource($resources, $nonceAttribute);
             $this->addContextualEditResourceIfEnabled($resources, $request, $nonceAttribute);
             $this->addToolbarConfig($resources, $request);
             $this->addStickyToolbarResourcesIfEnabled($resources, $request, $nonceAttribute);
@@ -151,6 +154,34 @@ final readonly class ResourceRendererService
             '<script%s src="%s"></script>',
             $nonceAttribute,
             $contextualEditPath,
+        );
+    }
+
+    /**
+     * Add TYPO3 backend stubs as the FIRST resource.
+     *
+     * Delegates to BackendSettingsService which generates all required global
+     * stubs, AJAX URLs, and language labels for the editing iframe.
+     *
+     * @param array<string, string> $resources
+     */
+    private function addBackendStubs(array &$resources, string $nonceValue): void
+    {
+        $resources = ['backend_stubs' => $this->backendSettingsService->getSettingsScript($nonceValue)] + $resources;
+    }
+
+    /**
+     * @param array<string, string> $resources
+     */
+    private function addIframeEditResource(array &$resources, string $nonceAttribute): void
+    {
+        $iframeEditPath = PathUtility::getAbsoluteWebPath(
+            GeneralUtility::getFileAbsFileName('EXT:'.Configuration::EXT_KEY.'/Resources/Public/JavaScript/iframe_edit.js'),
+        );
+        $resources['iframe_edit'] = sprintf(
+            '<script%s src="%s"></script>',
+            $nonceAttribute,
+            $iframeEditPath,
         );
     }
 

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -28,6 +28,7 @@ use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 use Xima\XimaTypo3FrontendEdit\Utility\ResourceUtility;
 
 use function sprintf;
@@ -62,11 +63,19 @@ final readonly class ResourceRendererService
             $nonceAttribute = '' !== $nonceValue ? ' nonce="'.$nonceValue.'"' : '';
             $resources = ResourceUtility::getResources(['nonce' => $nonceValue]);
 
-            $this->addBackendStubs($resources, $nonceValue);
+            // Iframe modal editor is a TYPO3 v13-only fallback.
+            // On v14.2+, the contextual sidebar handles inline editing natively.
+            $isIframeModalEnabled = !VersionUtility::is14OrHigher();
+
+            if ($isIframeModalEnabled) {
+                $this->addBackendStubs($resources, $nonceValue);
+            }
             $this->addFloatingUiResource($resources, $nonceAttribute);
             $this->addSettingsConfig($resources, $nonceAttribute, $request);
             $this->addDebugConfig($resources, $nonceAttribute);
-            $this->addIframeEditResource($resources, $nonceAttribute);
+            if ($isIframeModalEnabled) {
+                $this->addIframeEditResource($resources, $nonceAttribute);
+            }
             $this->addContextualEditResourceIfEnabled($resources, $request, $nonceAttribute);
             $this->addToolbarConfig($resources, $request);
             $this->addStickyToolbarResourcesIfEnabled($resources, $request, $nonceAttribute);

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Service\Ui;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 
 /**
  * UrlBuilderService.
@@ -135,11 +136,30 @@ final readonly class UrlBuilderService
     }
 
     /**
+     * Build URL to create a new content element after an existing one.
+     *
+     * - On TYPO3 v13.4: returns a web_layout URL with a hash fragment so
+     *   iframe_edit.js can auto-click the correct wizard button.
+     * - On TYPO3 v14.2+: returns the native record_edit URL since the
+     *   contextual sidebar handles the new-content flow directly.
+     *
      * @throws RouteNotFoundException
      */
     public function buildNewContentAfterUrl(int $uid, int $pid, int $colPos, string $returnUrl): string
     {
-        // Hash params instruct iframe_edit.js which wizard button to auto-click
+        if (VersionUtility::is14OrHigher()) {
+            return $this->uriBuilder->buildUriFromRoute(
+                'record_edit',
+                [
+                    'edit' => [
+                        'tt_content' => [-$uid => 'new'],
+                    ],
+                    'returnUrl' => $returnUrl,
+                ],
+            )->__toString();
+        }
+
+        // v13: hash params tell iframe_edit.js which wizard button to auto-click
         return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'colPos='.$colPos.'&afterUid='.$uid);
     }
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -137,17 +137,30 @@ final readonly class UrlBuilderService
     /**
      * @throws RouteNotFoundException
      */
-    public function buildNewContentAfterUrl(int $uid, string $returnUrl): string
+    public function buildNewContentAfterUrl(int $uid, int $pid, int $colPos, string $returnUrl): string
     {
-        return $this->uriBuilder->buildUriFromRoute(
-            'record_edit',
-            [
-                'edit' => [
-                    'tt_content' => [-$uid => 'new'],
-                ],
-                'returnUrl' => $returnUrl,
-            ],
-        )->__toString();
+        // Hash params instruct iframe_edit.js which wizard button to auto-click
+        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'colPos='.$colPos.'&afterUid='.$uid);
+    }
+
+    /**
+     * Build URL to open the page layout wizard for a specific column (colPos).
+     *
+     * @throws RouteNotFoundException
+     */
+    public function buildNewContentInColumnUrl(int $pid, int $colPos, string $returnUrl): string
+    {
+        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'colPos='.$colPos);
+    }
+
+    /**
+     * Build URL to open the page layout wizard for a container column.
+     *
+     * @throws RouteNotFoundException
+     */
+    public function buildContainerNewContentUrl(int $pid, int $containerUid, int $colPos, string $returnUrl): string
+    {
+        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'container='.$containerUid.'&colPos='.$colPos);
     }
 
     /**
@@ -235,5 +248,27 @@ final readonly class UrlBuilderService
     private function buildRoute(string $route, array $parameters = []): string
     {
         return $this->uriBuilder->buildUriFromRoute($route, $parameters)->__toString();
+    }
+
+    /**
+     * Build a web_layout URL with a hash fragment for iframe_edit.js wizard auto-click.
+     *
+     * TYPO3's UriBuilder doesn't support hash fragments (they're client-side only),
+     * so we append them manually. The hash is parsed by iframe_edit.js to determine
+     * which "new content" wizard button to auto-click inside the iframe.
+     *
+     * @throws RouteNotFoundException
+     */
+    private function buildPageLayoutUrlWithHash(int $pid, string $returnUrl, string $hash): string
+    {
+        $url = $this->uriBuilder->buildUriFromRoute(
+            'web_layout',
+            [
+                'id' => $pid,
+                'returnUrl' => $returnUrl,
+            ],
+        )->__toString();
+
+        return $url.'#'.$hash;
     }
 }

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -145,7 +145,7 @@ final readonly class UrlBuilderService
      *
      * @throws RouteNotFoundException
      */
-    public function buildNewContentAfterUrl(int $uid, int $pid, int $colPos, string $returnUrl): string
+    public function buildNewContentAfterUrl(int $uid, int $pid, int $colPos, int $languageUid, string $returnUrl): string
     {
         if (VersionUtility::is14OrHigher()) {
             return $this->uriBuilder->buildUriFromRoute(
@@ -153,6 +153,7 @@ final readonly class UrlBuilderService
                 [
                     'edit' => [
                         'tt_content' => [-$uid => 'new'],
+                        'language' => $languageUid,
                     ],
                     'returnUrl' => $returnUrl,
                 ],
@@ -160,27 +161,7 @@ final readonly class UrlBuilderService
         }
 
         // v13: hash params tell iframe_edit.js which wizard button to auto-click
-        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'colPos='.$colPos.'&afterUid='.$uid);
-    }
-
-    /**
-     * Build URL to open the page layout wizard for a specific column (colPos).
-     *
-     * @throws RouteNotFoundException
-     */
-    public function buildNewContentInColumnUrl(int $pid, int $colPos, string $returnUrl): string
-    {
-        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'colPos='.$colPos);
-    }
-
-    /**
-     * Build URL to open the page layout wizard for a container column.
-     *
-     * @throws RouteNotFoundException
-     */
-    public function buildContainerNewContentUrl(int $pid, int $containerUid, int $colPos, string $returnUrl): string
-    {
-        return $this->buildPageLayoutUrlWithHash($pid, $returnUrl, 'container='.$containerUid.'&colPos='.$colPos);
+        return $this->buildPageLayoutUrlWithHash($pid, $languageUid, $returnUrl, 'colPos='.$colPos.'&afterUid='.$uid);
     }
 
     /**
@@ -279,12 +260,13 @@ final readonly class UrlBuilderService
      *
      * @throws RouteNotFoundException
      */
-    private function buildPageLayoutUrlWithHash(int $pid, string $returnUrl, string $hash): string
+    private function buildPageLayoutUrlWithHash(int $pid, int $languageUid, string $returnUrl, string $hash): string
     {
         $url = $this->uriBuilder->buildUriFromRoute(
             'web_layout',
             [
                 'id' => $pid,
+                'language' => $languageUid,
                 'returnUrl' => $returnUrl,
             ],
         )->__toString();

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1164,7 +1164,132 @@
         animation-duration: 0.01ms !important;
     }
 
-    .frontend-edit__sidebar-spinner {
+    .frontend-edit__sidebar-spinner,
+    .frontend-edit__modal-spinner {
         animation: none !important;
     }
+}
+
+/* ==========================================
+   MODAL (Iframe Edit Panel)
+   ========================================== */
+
+.frontend-edit__modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 99999;
+    display: none;
+}
+
+.frontend-edit__modal--open {
+    display: block;
+}
+
+.frontend-edit__modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.frontend-edit__modal--open .frontend-edit__modal-overlay {
+    opacity: 1;
+}
+
+.frontend-edit__modal-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 90%;
+    max-width: 1200px;
+    background: white;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.frontend-edit__modal--open .frontend-edit__modal-panel {
+    transform: translateX(0);
+}
+
+.frontend-edit__modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 16px;
+    background: #1e1e1e;
+    border-bottom: 1px solid #3a3a3a;
+    flex-shrink: 0;
+}
+
+.frontend-edit__modal-title {
+    color: #fff;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.frontend-edit__modal-close {
+    width: 28px;
+    height: 28px;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+
+.frontend-edit__modal-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.frontend-edit__modal-content {
+    position: relative;
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.frontend-edit__modal-loader {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #1e1e1e;
+    z-index: 1;
+}
+
+.frontend-edit__modal-spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid rgba(255, 255, 255, 0.15);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: frontend-edit-spin 0.7s linear infinite;
+}
+
+.frontend-edit__modal-content iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block;
+    background: #1e1e1e;
+    pointer-events: auto;
 }

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1159,7 +1159,13 @@
     .frontend-edit__tooltip,
     .frontend-edit__tooltip--visible,
     .frontend-edit__dialog-overlay,
-    .frontend-edit__dialog-overlay .modal-dialog {
+    .frontend-edit__dialog-overlay .modal-dialog,
+    .frontend-edit__modal,
+    .frontend-edit__modal--open,
+    .frontend-edit__modal-overlay,
+    .frontend-edit__modal-panel,
+    .frontend-edit__modal-loader,
+    .frontend-edit__modal-iframe {
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
     }
@@ -1255,6 +1261,12 @@
 }
 
 .frontend-edit__modal-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.frontend-edit__modal-close:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
     background: rgba(255, 255, 255, 0.1);
 }
 

--- a/Resources/Public/JavaScript/backend_stubs.js
+++ b/Resources/Public/JavaScript/backend_stubs.js
@@ -1,0 +1,259 @@
+/**
+ * TYPO3 Backend Stubs for frontend editing iframe (TYPO3 v13 only).
+ *
+ * Provides the minimum set of global TYPO3.* objects and AJAX endpoints
+ * required to boot TYPO3 backend JavaScript modules inside our editing
+ * iframe without throwing.
+ *
+ * ─────────────────────────────────────────────────────────────────────
+ * STUB POLICY — read this before adding or removing anything
+ * ─────────────────────────────────────────────────────────────────────
+ *
+ * This file follows a strict "minimum viable stub" policy:
+ *
+ *   1. Every stub below has a DOCUMENTED TRIGGER — a specific console
+ *      error observed in a real v13.4 edit flow without that stub.
+ *   2. NEVER add a stub "just in case". Defensive stubbing creates the
+ *      illusion of API support, while backend JS silently calls the
+ *      no-op method and fails downstream (e.g. regular-event.js
+ *      "Delegating event failed" warnings).
+ *   3. To add a new stub:
+ *        a. Reproduce the console error in a real edit flow (v13.4).
+ *        b. Add the minimum implementation that silences the error.
+ *        c. Document the trigger (module name + error message) in a
+ *           comment directly above the stub block.
+ *   4. To remove a stub:
+ *        a. Comment it out.
+ *        b. Walk through every editing flow: open modal, edit text,
+ *           open RTE, link browser, file picker, Save, Save & Close,
+ *           info / move / history, new content after.
+ *        c. If no error appears, delete the stub.
+ *
+ * Dynamic data (ajaxUrls, lang labels) is supplied from PHP via a
+ * <script type="application/json" id="frontend-edit-backend-stubs-data">
+ * block rendered by BackendSettingsService.
+ *
+ * Helpers (ensureReturnUrl, openWizardOverlay) are exposed on
+ * window.XimaFrontendEdit so iframe_edit.js can reuse them without
+ * duplication.
+ */
+(function () {
+    'use strict';
+
+    const IFRAME_ID = 'xima-typo3-frontend-edit-modal-iframe';
+    const WIZARD_OVERLAY_ID = 'fe-wizard-overlay';
+
+    function readStubData() {
+        const dataEl = document.getElementById('frontend-edit-backend-stubs-data');
+        if (!dataEl) return { settings: {}, lang: {} };
+        try {
+            return JSON.parse(dataEl.textContent || '{}');
+        } catch (e) {
+            return { settings: {}, lang: {} };
+        }
+    }
+
+    function getIframe() {
+        return document.querySelector('#' + IFRAME_ID);
+    }
+
+    /**
+     * Build the returnUrl that TYPO3 redirects to after Save.
+     *
+     * Appends `tx_ximatypo3frontendedit_iframe=1` so the ToolRendererMiddleware
+     * on that follow-up frontend request knows NOT to consume the flash message
+     * queue — the parent page will consume them after it reloads.
+     */
+    function buildIframeReturnUrl() {
+        const returnUrl = new URL(window.location.href);
+        returnUrl.searchParams.set('tx_ximatypo3frontendedit_iframe', '1');
+        return returnUrl.toString();
+    }
+
+    /**
+     * Ensure a backend URL carries a frontend returnUrl and the extension marker
+     * so the Save & Close button is wired into the iframe flow.
+     */
+    function ensureReturnUrl(url) {
+        try {
+            const u = new URL(url, window.location.origin);
+            const existing = u.searchParams.get('returnUrl') || '';
+
+            // Rebuild returnUrl: use existing if it's a frontend URL, otherwise
+            // default to current page. Always add the iframe marker.
+            let returnUrl;
+            if (existing && existing.indexOf('/typo3/') === -1) {
+                returnUrl = new URL(existing, window.location.origin);
+            } else {
+                returnUrl = new URL(window.location.href);
+            }
+            returnUrl.searchParams.set('tx_ximatypo3frontendedit_iframe', '1');
+            u.searchParams.set('returnUrl', returnUrl.toString());
+
+            if (!u.searchParams.has('tx_ximatypo3frontendedit')) {
+                u.searchParams.set('tx_ximatypo3frontendedit', '');
+            }
+            return u.toString();
+        } catch (e) {
+            return url;
+        }
+    }
+
+    /**
+     * Open a wizard URL inside a nested overlay within the edit iframe.
+     * Used for link browser, file picker, and other wizards that TYPO3 normally
+     * opens via Modal.advanced().
+     */
+    function openWizardOverlay(url) {
+        const iframe = getIframe();
+        if (!iframe || !iframe.contentWindow || !iframe.contentWindow.document) return;
+
+        const doc = iframe.contentWindow.document;
+        const existing = doc.getElementById(WIZARD_OVERLAY_ID);
+        if (existing) existing.remove();
+
+        const overlay = doc.createElement('div');
+        overlay.id = WIZARD_OVERLAY_ID;
+        overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;';
+
+        const panel = doc.createElement('div');
+        panel.style.cssText = 'width:80%;max-width:900px;height:80%;background:#fff;border-radius:4px;overflow:hidden;position:relative;display:flex;flex-direction:column;box-shadow:0 4px 24px rgba(0,0,0,0.3);';
+
+        const header = doc.createElement('div');
+        header.style.cssText = 'display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;';
+
+        const closeBtn = doc.createElement('button');
+        closeBtn.innerHTML = '&times;';
+        closeBtn.style.cssText = 'font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;';
+        closeBtn.onclick = function () { overlay.remove(); };
+
+        const wizIframe = doc.createElement('iframe');
+        wizIframe.src = url;
+        wizIframe.style.cssText = 'flex:1;border:none;width:100%;';
+
+        header.appendChild(closeBtn);
+        panel.appendChild(header);
+        panel.appendChild(wizIframe);
+        overlay.appendChild(panel);
+        overlay.addEventListener('click', function (ev) { if (ev.target === overlay) overlay.remove(); });
+        doc.body.appendChild(overlay);
+    }
+
+    // Expose helpers used by iframe_edit.js
+    window.XimaFrontendEdit = window.XimaFrontendEdit || {};
+    window.XimaFrontendEdit.ensureReturnUrl = ensureReturnUrl;
+    window.XimaFrontendEdit.openWizardOverlay = openWizardOverlay;
+
+    // ── Global TYPO3 stubs ─────────────────────────────────────────
+    //
+    // Minimum viable stub set. Each stub below has a documented trigger —
+    // ── Global TYPO3 stubs ─────────────────────────────────────────
+    // See STUB POLICY comment at the top of this file.
+
+    // Base namespaces. Required because every stub below attaches to them.
+    if (!window.TYPO3) window.TYPO3 = {};
+    if (!window.TYPO3.settings) window.TYPO3.settings = {};
+    if (!window.TYPO3.lang) window.TYPO3.lang = {};
+    if (!window.TYPO3.Backend) window.TYPO3.Backend = {};
+
+    // Trigger: shortcut-menu.js reads top.TYPO3.Backend.Topbar.Toolbar
+    //   unconditionally at load time.
+    // Error without it:
+    //   "TypeError: can't access property 'Toolbar', Topbar is undefined"
+    //   (shortcut-menu.js line 13)
+    if (!window.TYPO3.Backend.Topbar) {
+        window.TYPO3.Backend.Topbar = {
+            Toolbar: {
+                registerEvent: function (cb) { try { cb(); } catch (e) {} },
+                refresh: function () {}
+            }
+        };
+    }
+
+    // Trigger: TYPO3 backend modules call ContentContainer.setUrl() /
+    //   refresh() / get() to navigate "the main content frame" after
+    //   certain actions (save redirects, inline edits, field updates).
+    //   We override setUrl to keep navigation INSIDE our iframe, and
+    //   divert wizard URLs into our nested overlay instead of the
+    //   native backend layout.
+    if (!window.TYPO3.Backend.ContentContainer) {
+        window.TYPO3.Backend.ContentContainer = {
+            setUrl: function (url) {
+                if (url && url.indexOf('/typo3/wizard/') !== -1) {
+                    if (window.TYPO3.Modal && window.TYPO3.Modal.advanced) {
+                        window.TYPO3.Modal.advanced({ content: url });
+                    }
+                    return Promise.resolve();
+                }
+                const iframe = getIframe();
+                if (iframe) iframe.src = ensureReturnUrl(url);
+                return Promise.resolve();
+            },
+            refresh: function () {
+                const iframe = getIframe();
+                if (iframe && iframe.contentWindow) iframe.contentWindow.location.reload();
+                return Promise.resolve();
+            },
+            get: function () {
+                return getIframe();
+            }
+        };
+    }
+
+    // Trigger: link browser, element browser, and file picker wizards
+    //   inside the edit form call TYPO3.Modal.advanced({ content: wizardUrl })
+    //   to open themselves. Without a stub they crash; without routing
+    //   through our overlay they escape the iframe sandbox.
+    // Also used: Modal.dismiss() when the wizard closes.
+    // confirm() is kept because TCA delete/inline confirmations call it.
+    if (!window.TYPO3.Modal) {
+        window.TYPO3.Modal = {
+            advanced: function (config) {
+                const url = config && (config.content || config.url || '');
+                if (url && url.indexOf('/typo3/wizard/') !== -1) {
+                    openWizardOverlay(url);
+                }
+                return { addEventListener: function () {}, on: function () {} };
+            },
+            confirm: function (title, content) { return Promise.resolve(confirm(content)); },
+            dismiss: function () {
+                const iframe = getIframe();
+                if (iframe && iframe.contentWindow) {
+                    const overlay = iframe.contentWindow.document.getElementById(WIZARD_OVERLAY_ID);
+                    if (overlay) overlay.remove();
+                }
+            },
+            currentModal: null
+        };
+    }
+
+    // Hydrate TYPO3.settings and TYPO3.lang from the JSON data block
+    // rendered by BackendSettingsService.
+    //
+    // Triggers (all resolved by this hydration):
+    //   - tree.js (v13.4 line 13): "can't access property 'tree_networkError',
+    //     top.TYPO3.lang is undefined"
+    //   - date-time-picker.js (line 13): "can't access property 'DateFormat',
+    //     TYPO3.settings.DateTimePicker is undefined"
+    //   - file-storage-browser.js (line 13): "can't access property
+    //     'filestorage_tree_data', top.TYPO3.settings.ajaxUrls is undefined"
+    //
+    // The _frontendEditContext flag is a marker our own code can check to
+    // detect it's running inside the iframe.
+    const stubData = readStubData();
+    Object.assign(window.TYPO3.settings, stubData.settings || {});
+    Object.assign(window.TYPO3.lang, stubData.lang || {});
+    window.TYPO3.Backend._frontendEditContext = true;
+
+    // Trigger: TYPO3 backend uses a CustomEvent "typo3:import-javascript-module"
+    //   as a dynamic-import indirection layer. Any module that does
+    //   `top.document.dispatchEvent(new CustomEvent("typo3:import-javascript-module", ...))`
+    //   waits for us to resolve `e.detail.importPromise`.
+    // Without this listener: the module silently never loads (no error, but
+    //   broken UI — e.g. CKEditor plugins, date pickers, tree components).
+    document.addEventListener('typo3:import-javascript-module', function (e) {
+        if (e.detail && e.detail.specifier) {
+            e.detail.importPromise = import(e.detail.specifier).catch(function () { return {}; });
+        }
+    });
+})();

--- a/Resources/Public/JavaScript/backend_stubs.js
+++ b/Resources/Public/JavaScript/backend_stubs.js
@@ -100,6 +100,43 @@
     }
 
     /**
+     * Patch TYPO3.Modal.dismiss on parent, main iframe, and wizard iframe
+     * windows so the link browser can close the overlay after selecting.
+     */
+    function patchDismissForOverlay(iframe, overlay, wizIframe) {
+        const patchDismiss = function (modalObj) {
+            if (!modalObj) return;
+            const orig = modalObj.dismiss;
+            modalObj.dismiss = function () {
+                if (overlay.parentNode) overlay.remove();
+                modalObj.dismiss = orig || function () {};
+                if (typeof orig === 'function') orig.call(this);
+            };
+        };
+
+        // Parent window (for top.TYPO3.Modal.dismiss calls)
+        patchDismiss(window.TYPO3 && window.TYPO3.Modal);
+
+        // Main iframe (for parent.TYPO3.Modal.dismiss calls from wizard)
+        try { patchDismiss(iframe.contentWindow && iframe.contentWindow.TYPO3 && iframe.contentWindow.TYPO3.Modal); } catch (_) { /* cross-origin */ }
+
+        // Wizard iframe after it loads: poll briefly for its TYPO3.Modal to appear
+        wizIframe.addEventListener('load', function () {
+            try {
+                const wizWin = wizIframe.contentWindow;
+                const deadline = Date.now() + 4000;
+                (function tick() {
+                    if (wizWin.TYPO3 && wizWin.TYPO3.Modal) {
+                        patchDismiss(wizWin.TYPO3.Modal);
+                        return;
+                    }
+                    if (Date.now() < deadline) setTimeout(tick, 100);
+                })();
+            } catch (_) { /* cross-origin */ }
+        });
+    }
+
+    /**
      * Open a wizard URL inside a nested overlay within the edit iframe.
      * Used for link browser, file picker, and other wizards that TYPO3 normally
      * opens via Modal.advanced().
@@ -108,35 +145,43 @@
         const iframe = getIframe();
         if (!iframe || !iframe.contentWindow || !iframe.contentWindow.document) return;
 
-        const doc = iframe.contentWindow.document;
-        const existing = doc.getElementById(WIZARD_OVERLAY_ID);
-        if (existing) existing.remove();
+        try {
+            const doc = iframe.contentWindow.document;
+            const existing = doc.getElementById(WIZARD_OVERLAY_ID);
+            if (existing) existing.remove();
 
-        const overlay = doc.createElement('div');
-        overlay.id = WIZARD_OVERLAY_ID;
-        overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;';
+            const overlay = doc.createElement('div');
+            overlay.id = WIZARD_OVERLAY_ID;
+            overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;';
 
-        const panel = doc.createElement('div');
-        panel.style.cssText = 'width:80%;max-width:900px;height:80%;background:#fff;border-radius:4px;overflow:hidden;position:relative;display:flex;flex-direction:column;box-shadow:0 4px 24px rgba(0,0,0,0.3);';
+            const panel = doc.createElement('div');
+            panel.style.cssText = 'width:80%;max-width:900px;height:80%;background:#fff;border-radius:4px;overflow:hidden;position:relative;display:flex;flex-direction:column;box-shadow:0 4px 24px rgba(0,0,0,0.3);';
 
-        const header = doc.createElement('div');
-        header.style.cssText = 'display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;';
+            const header = doc.createElement('div');
+            header.style.cssText = 'display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;';
 
-        const closeBtn = doc.createElement('button');
-        closeBtn.innerHTML = '&times;';
-        closeBtn.style.cssText = 'font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;';
-        closeBtn.onclick = function () { overlay.remove(); };
+            const closeBtn = doc.createElement('button');
+            closeBtn.innerHTML = '&times;';
+            closeBtn.style.cssText = 'font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;';
+            closeBtn.onclick = function () { overlay.remove(); };
 
-        const wizIframe = doc.createElement('iframe');
-        wizIframe.src = url;
-        wizIframe.style.cssText = 'flex:1;border:none;width:100%;';
+            const wizIframe = doc.createElement('iframe');
+            wizIframe.src = url;
+            wizIframe.style.cssText = 'flex:1;border:none;width:100%;';
 
-        header.appendChild(closeBtn);
-        panel.appendChild(header);
-        panel.appendChild(wizIframe);
-        overlay.appendChild(panel);
-        overlay.addEventListener('click', function (ev) { if (ev.target === overlay) overlay.remove(); });
-        doc.body.appendChild(overlay);
+            header.appendChild(closeBtn);
+            panel.appendChild(header);
+            panel.appendChild(wizIframe);
+            overlay.appendChild(panel);
+            overlay.addEventListener('click', function (ev) { if (ev.target === overlay) overlay.remove(); });
+            doc.body.appendChild(overlay);
+
+            // Patch Modal.dismiss so link browser / file picker close the overlay
+            patchDismissForOverlay(iframe, overlay, wizIframe);
+        } catch (err) {
+            // Cross-origin access to iframe failed, fall back to popup
+            try { iframe.contentWindow.open(url, '_blank', 'width=1000,height=700'); } catch (_) { /* ignore */ }
+        }
     }
 
     // Expose helpers used by iframe_edit.js

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -108,35 +108,17 @@
    *    redirect does not consume the flash queue inside the iframe
    * 2. The tx_ximatypo3frontendedit marker so the Save & Close button is added
    *
-   * Delegates to the shared implementation in backend_stubs.js.
-   * Kept as a local fallback in case backend_stubs.js didn't load.
+   * Single source of truth in backend_stubs.js. Both files are v13-only
+   * and backend_stubs.js loads first, so window.XimaFrontendEdit is always
+   * available. If it isn't, that's a real loading bug we want to surface
+   * loudly rather than silently branch into a drift-prone copy.
    */
   function ensureReturnUrl(url) {
     if (window.XimaFrontendEdit?.ensureReturnUrl) {
       return window.XimaFrontendEdit.ensureReturnUrl(url);
     }
-    try {
-      const u = new URL(url, window.location.origin);
-      const existing = u.searchParams.get('returnUrl') || '';
-
-      // Rebuild returnUrl: use existing if it's a frontend URL, otherwise
-      // default to current page. Always add the iframe marker.
-      let returnUrl;
-      if (existing && !existing.includes('/typo3/')) {
-        returnUrl = new URL(existing, window.location.origin);
-      } else {
-        returnUrl = new URL(window.location.href);
-      }
-      returnUrl.searchParams.set('tx_ximatypo3frontendedit_iframe', '1');
-      u.searchParams.set('returnUrl', returnUrl.toString());
-
-      if (!u.searchParams.has('tx_ximatypo3frontendedit')) {
-        u.searchParams.set('tx_ximatypo3frontendedit', '');
-      }
-      return u.toString();
-    } catch (_) {
-      return url;
-    }
+    Logger.log('window.XimaFrontendEdit.ensureReturnUrl missing — backend_stubs.js did not load', null, 'error');
+    return url;
   }
 
   // ── Modal ──────────────────────────────────────────────────────────
@@ -196,12 +178,14 @@
       IframeHandler.overrideContentContainer(iframe);
       iframe.src = url;
 
-      // Show header only for views without a native close button
-      // (info, move, history). Edit forms have their own Save/Close UI.
-      const needsHeader = /record\/(info|history)|move_element/.test(url);
-      const header = this.element.querySelector('.frontend-edit__modal-header');
-      if (header) {
-        header.style.display = needsHeader ? 'flex' : 'none';
+      // Keep the close button always reachable as an escape route (ESC and
+      // backdrop click aren't discoverable if the TYPO3-native close fails
+      // to render). Only hide the title text for edit forms, where the
+      // record title lives inside the iframe's own header.
+      const showTitle = /record\/(info|history)|move_element/.test(url);
+      const title = this.element.querySelector('.frontend-edit__modal-title');
+      if (title) {
+        title.style.display = showTitle ? '' : 'none';
       }
 
       setTimeout(() => this.element.classList.add('frontend-edit__modal--open'), ANIMATION_DELAY_MS);
@@ -573,102 +557,18 @@
     // ── Wizard overlay ────────────────────────────────────────────
 
     /**
-     * Open a wizard URL (e.g. link browser) in an overlay inside the
-     * iframe's document. This keeps `parent` pointing at the edit form
-     * so TYPO3's callbacks (field value updates) work correctly.
+     * Open a wizard URL (e.g. link browser) in a nested overlay inside
+     * the iframe. Delegates to the single shared implementation in
+     * backend_stubs.js (window.XimaFrontendEdit.openWizardOverlay) so
+     * there's no divergent duplicate.
      */
     openWizardOverlay(iframe, wizardUrl) {
-      try {
-        const doc = iframe.contentWindow.document;
-
-        // Remove existing overlay
-        const existing = doc.getElementById('fe-wizard-overlay');
-        if (existing) existing.remove();
-
-        const overlay = doc.createElement('div');
-        overlay.id = 'fe-wizard-overlay';
-        overlay.style.cssText =
-          'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;' +
-          'background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;';
-
-        const panel = doc.createElement('div');
-        panel.style.cssText =
-          'width:80%;max-width:900px;height:80%;background:#fff;border-radius:4px;' +
-          'overflow:hidden;position:relative;display:flex;flex-direction:column;' +
-          'box-shadow:0 4px 24px rgba(0,0,0,0.3);';
-
-        const header = doc.createElement('div');
-        header.style.cssText =
-          'display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;';
-
-        const closeBtn = doc.createElement('button');
-        closeBtn.innerHTML = '&times;';
-        closeBtn.style.cssText =
-          'font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;';
-        closeBtn.onclick = () => overlay.remove();
-
-        const wizIframe = doc.createElement('iframe');
-        wizIframe.src = wizardUrl;
-        wizIframe.style.cssText = 'flex:1;border:none;width:100%;';
-
-        header.appendChild(closeBtn);
-        panel.appendChild(header);
-        panel.appendChild(wizIframe);
-        overlay.appendChild(panel);
-
-        // Close on backdrop click
-        overlay.addEventListener('click', (e) => {
-          if (e.target === overlay) overlay.remove();
-        });
-
-        doc.body.appendChild(overlay);
+      if (window.XimaFrontendEdit?.openWizardOverlay) {
+        window.XimaFrontendEdit.openWizardOverlay(wizardUrl);
         Logger.log('Wizard overlay opened', { url: wizardUrl });
-
-        // Patch Modal.dismiss so the link browser can close the overlay
-        this._patchDismissForOverlay(iframe, overlay, wizIframe);
-
-      } catch (err) {
-        Logger.log('Failed to create wizard overlay — falling back to popup', err, 'error');
-        try {
-          iframe.contentWindow.open(wizardUrl, '_blank', 'width=1000,height=700');
-        } catch (_) { /* ignore */ }
+        return;
       }
-    },
-
-    /**
-     * Patch TYPO3.Modal.dismiss on parent and iframe windows so the
-     * link browser can close the wizard overlay after selecting a link.
-     */
-    _patchDismissForOverlay(iframe, overlay, wizIframe) {
-      const patchDismiss = (modalObj) => {
-        if (!modalObj) return;
-        const orig = modalObj.dismiss;
-        modalObj.dismiss = function () {
-          if (overlay.parentNode) overlay.remove();
-          modalObj.dismiss = orig || function () {};
-          if (typeof orig === 'function') orig.call(this);
-        };
-      };
-
-      // Parent window (for top.TYPO3.Modal.dismiss calls)
-      patchDismiss(window.TYPO3?.Modal);
-
-      // Main iframe (for parent.TYPO3.Modal.dismiss calls from wizard)
-      try { patchDismiss(iframe.contentWindow?.TYPO3?.Modal); } catch (_) {}
-
-      // Wizard iframe after it loads (for local Modal.dismiss calls)
-      wizIframe.addEventListener('load', () => {
-        try {
-          const wizWin = wizIframe.contentWindow;
-          // Patch wizWin.TYPO3.Modal.dismiss as soon as it's available
-          // (wait up to 4s for the wizard's TYPO3 namespace to boot).
-          waitFor(() => {
-            if (!wizWin.TYPO3?.Modal) return false;
-            patchDismiss(wizWin.TYPO3.Modal);
-            return true;
-          }, 100, 4000);
-        } catch (_) { /* cross-origin */ }
-      });
+      Logger.log('window.XimaFrontendEdit.openWizardOverlay missing — backend_stubs.js did not load', null, 'error');
     },
 
     // ── Navigation detection ───────────────────────────────────────
@@ -781,12 +681,18 @@
   window.addEventListener('message', (event) => {
     if (typeof event.data !== 'object' || !event.data) return;
 
-    // Only accept same-origin messages while a modal is active.
-    // Prevents third-party iframes from triggering a reload, while still
-    // allowing the TYPO3 backend iframe to dispatch messages even during
-    // navigation (when event.source / contentWindow may be transient).
+    // Only accept messages from the active modal iframe's origin.
+    // Compare against the iframe's src origin (not window.location.origin)
+    // so setups where backend and frontend live on different domains still
+    // work correctly (e.g. backend.example.com vs www.example.com).
     if (!Modal.iframe) return;
-    if (event.origin !== window.location.origin) return;
+    let iframeOrigin;
+    try {
+      iframeOrigin = new URL(Modal.iframe.src, window.location.href).origin;
+    } catch (_) {
+      return;
+    }
+    if (event.origin !== iframeOrigin) return;
 
     const action = event.data.actionName;
     if (action === 'typo3:formengine:save-close') {

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -126,6 +126,7 @@
   const Modal = {
     element: null,
     iframe: null,
+    closeTimer: null,
 
     getOrCreate() {
       if (this.element) return this.element;
@@ -166,6 +167,13 @@
       // flash message queue inside the iframe — the parent reload picks
       // them up instead.
       url = ensureReturnUrl(url);
+
+      // Cancel any pending close-timeout from a prior close() so it can't
+      // clobber the fresh iframe we're about to open.
+      if (this.closeTimer) {
+        clearTimeout(this.closeTimer);
+        this.closeTimer = null;
+      }
 
       this.getOrCreate();
       IframeHandler._wizardAutoClicked = false;
@@ -221,7 +229,17 @@
       if (!this.element) return;
       Logger.log('Closing modal');
       this.element.classList.remove('frontend-edit__modal--open');
-      setTimeout(() => {
+
+      // Replace any previous pending cleanup with a fresh one so we never
+      // have two racing timeouts. The callback also double-checks that the
+      // modal is still closed before wiping the iframe, so a re-open()
+      // between schedule and fire is safe.
+      if (this.closeTimer) {
+        clearTimeout(this.closeTimer);
+      }
+      this.closeTimer = setTimeout(() => {
+        this.closeTimer = null;
+        if (!this.element || this.element.classList.contains('frontend-edit__modal--open')) return;
         if (this.iframe) {
           this.iframe.src = 'about:blank';
           this.iframe.style.opacity = '0.5';

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -1,0 +1,690 @@
+/**
+ * TYPO3 Frontend Edit - Modal Iframe Editor
+ *
+ * Opens TYPO3 backend editing forms inside a slide-in panel (iframe).
+ * Backend stubs are initialized by BackendSettingsService (inline script)
+ * which loads BEFORE this file.
+ */
+(function () {
+  'use strict';
+
+  // ── Constants ──────────────────────────────────────────────────────
+
+  const MODAL_ID = 'xima-typo3-frontend-edit-modal';
+  const IFRAME_ID = 'xima-typo3-frontend-edit-modal-iframe';
+  const ANIMATION_DELAY_MS = 10;
+  const ANIMATION_DURATION_MS = 300;
+  const WIZARD_CLICK_DELAY_MS = 1000;
+  const CONTENT_CONTAINER_POLL_MS = 5;
+  const CONTENT_CONTAINER_MAX_POLLS = 1000;
+  const WIZARD_PATCH_POLL_MS = 50;
+  const WIZARD_PATCH_MAX_POLLS = 200;
+  const WIZARD_SELECTORS = 'typo3-backend-new-record-wizard, typo3-backend-new-content-element-wizard';
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  const Logger = {
+    log(message, data = null, level = 'log') {
+      if (!window.FRONTEND_EDIT_DEBUG) return;
+      const prefix = '%c[frontend-edit-modal]%c';
+      const styles = ['font-weight: bold;', 'font-weight: normal;'];
+      data !== null
+        ? console[level](prefix, ...styles, message, data)
+        : console[level](prefix, ...styles, message);
+    }
+  };
+
+  function isBackendUrl(url) {
+    return url && url.includes('/typo3/');
+  }
+
+  function isFrontendUrl(url) {
+    return url && !url.includes('/typo3/') && url.includes(window.location.hostname);
+  }
+
+  function isPageLayoutPath(href, origin) {
+    try {
+      const { pathname } = new URL(href, origin);
+      return pathname.includes('web/layout') || pathname.includes('web_layout');
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isWizardUrl(url) {
+    return url && url.includes('/typo3/wizard/');
+  }
+
+  /**
+   * Ensure a backend URL has:
+   * 1. A returnUrl pointing to our frontend page (not a backend route)
+   * 2. The tx_ximatypo3frontendedit marker so the Save & Close button is added
+   */
+  function ensureReturnUrl(url) {
+    try {
+      const u = new URL(url, window.location.origin);
+      const existing = u.searchParams.get('returnUrl') || '';
+      if (!existing || existing.includes('/typo3/')) {
+        u.searchParams.set('returnUrl', window.location.href);
+      }
+      if (!u.searchParams.has('tx_ximatypo3frontendedit')) {
+        u.searchParams.set('tx_ximatypo3frontendedit', '');
+      }
+      return u.toString();
+    } catch (_) {
+      return url;
+    }
+  }
+
+  // ── Modal ──────────────────────────────────────────────────────────
+
+  const Modal = {
+    element: null,
+    iframe: null,
+
+    getOrCreate() {
+      if (this.element) return this.element;
+
+      const modal = document.createElement('div');
+      modal.id = MODAL_ID;
+      modal.className = 'frontend-edit__modal';
+      modal.innerHTML =
+        '<div class="frontend-edit__modal-overlay"></div>' +
+        '<div class="frontend-edit__modal-panel">' +
+          '<div class="frontend-edit__modal-header">' +
+            '<span class="frontend-edit__modal-title"></span>' +
+            '<button class="frontend-edit__modal-close" title="Close">&times;</button>' +
+          '</div>' +
+          '<div class="frontend-edit__modal-content">' +
+            '<div class="frontend-edit__modal-loader">' +
+              '<div class="frontend-edit__modal-spinner"></div>' +
+            '</div>' +
+            '<iframe id="' + IFRAME_ID + '" class="t3js-scaffold-content-module-iframe" allow="fullscreen"></iframe>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(modal);
+
+      const close = () => this.close();
+      modal.querySelector('.frontend-edit__modal-overlay').addEventListener('click', close);
+      modal.querySelector('.frontend-edit__modal-close').addEventListener('click', close);
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+
+      this.element = modal;
+      this.iframe = modal.querySelector('#' + IFRAME_ID);
+      Logger.log('Modal created');
+      return modal;
+    },
+
+    open(url) {
+      this.getOrCreate();
+      IframeHandler._wizardAutoClicked = false;
+      const { iframe } = this;
+      const loader = this.element.querySelector('.frontend-edit__modal-loader');
+
+      iframe.style.opacity = '0';
+      if (loader) loader.style.display = 'flex';
+
+      IframeHandler.overrideContentContainer(iframe);
+      iframe.src = url;
+
+      // Only show header for info modals
+      const header = this.element.querySelector('.frontend-edit__modal-header');
+      if (header) {
+        header.style.display = url.includes('record/info') ? 'flex' : 'none';
+      }
+
+      setTimeout(() => this.element.classList.add('frontend-edit__modal--open'), ANIMATION_DELAY_MS);
+
+      iframe.onload = () => {
+        // Detect frontend URL early — stop scripts before they break
+        try {
+          const href = iframe.contentWindow?.location.href;
+          if (href && isFrontendUrl(href)) {
+            Logger.log('Frontend URL detected on load — aborting iframe');
+            iframe.src = 'about:blank';
+            IframeHandler.closeAndReload();
+            return;
+          }
+        } catch (_) { /* cross-origin */ }
+
+        if (loader) loader.style.display = 'none';
+        iframe.style.display = '';
+        iframe.style.opacity = '1';
+        Logger.log('Iframe loaded');
+        IframeHandler.onLoad(iframe);
+      };
+
+      iframe.onerror = () => {
+        Logger.log('Iframe failed to load', null, 'error');
+        setTimeout(() => this.close(), 2000);
+      };
+
+      Logger.log('Modal opened', { url });
+    },
+
+    close() {
+      if (!this.element) return;
+      Logger.log('Closing modal');
+      this.element.classList.remove('frontend-edit__modal--open');
+      setTimeout(() => {
+        if (this.iframe) {
+          this.iframe.src = 'about:blank';
+          this.iframe.style.opacity = '0.5';
+        }
+      }, ANIMATION_DURATION_MS);
+    }
+  };
+
+  // ── IframeHandler ──────────────────────────────────────────────────
+
+  const IframeHandler = {
+
+    // ── Lifecycle ───────────────────────────────────────────────────
+
+    onLoad(iframe) {
+      this.overrideContentContainer(iframe);
+      this.autoClickWizardButton(iframe);
+      this.patchWizardComponents(iframe);
+      this.interceptIframeClicks(iframe);
+      this.detectFrontendNavigation(iframe);
+      this.hideUnnecessaryButtons(iframe);
+    },
+
+    /**
+     * Hide buttons that are not useful inside the frontend-edit modal
+     * (e.g. the "View" button which links back to the frontend page).
+     */
+    hideUnnecessaryButtons(iframe) {
+      try {
+        const doc = iframe.contentWindow?.document;
+        if (!doc) return;
+        doc.querySelectorAll('.t3js-editform-view').forEach(el => el.remove());
+      } catch (_) { /* cross-origin */ }
+    },
+
+    /**
+     * Override ContentContainer.setUrl inside the iframe so backend navigation
+     * stays within our modal iframe instead of targeting the parent window.
+     */
+    overrideContentContainer(iframe) {
+      let attempts = 0;
+      const interval = setInterval(() => {
+        attempts++;
+        try {
+          const cc = iframe.contentWindow?.TYPO3?.Backend?.ContentContainer;
+          if (!cc || cc._overridden) { if (cc?._overridden) clearInterval(interval); return; }
+          cc._overridden = true;
+          const setUrl = (url) => {
+            if (isFrontendUrl(url)) {
+              IframeHandler.closeAndReload();
+              return Promise.resolve();
+            }
+            if (isWizardUrl(url)) {
+              Logger.log('Wizard URL in ContentContainer.setUrl — opening overlay', { url });
+              IframeHandler.openWizardOverlay(iframe, url);
+              return Promise.resolve();
+            }
+            iframe.src = ensureReturnUrl(url);
+            return Promise.resolve();
+          };
+          try {
+            Object.defineProperty(cc, 'setUrl', { value: setUrl, writable: true, configurable: true });
+          } catch (_) {
+            cc.setUrl = setUrl;
+          }
+          Logger.log('ContentContainer.setUrl overridden');
+          clearInterval(interval);
+        } catch (_) { /* cross-origin */ }
+        if (attempts >= CONTENT_CONTAINER_MAX_POLLS) clearInterval(interval);
+      }, CONTENT_CONTAINER_POLL_MS);
+    },
+
+    // ── Wizard auto-click ──────────────────────────────────────────
+
+    _wizardAutoClicked: false,
+
+    autoClickWizardButton(iframe) {
+      try {
+        if (this._wizardAutoClicked) return;
+
+        const currentUrl = (iframe.contentWindow?.location.href || iframe.src || '');
+        const hashPart = currentUrl.split('#')[1];
+        if (!hashPart) return;
+
+        const params = new URLSearchParams(hashPart);
+        const colPos = params.get('colPos');
+        const container = params.get('container');
+        const afterUid = params.get('afterUid');
+        if (!colPos) return;
+
+        Logger.log('Auto-click wizard detected', { colPos, container, afterUid });
+
+        setTimeout(() => {
+          try {
+            const buttons = iframe.contentWindow.document.querySelectorAll(
+              'typo3-backend-new-content-element-wizard-button'
+            );
+            for (const btn of buttons) {
+              if (this.matchesWizardButton(btn.getAttribute('url') || '', colPos, container, afterUid)) {
+                this._wizardAutoClicked = true;
+                btn.click();
+                return;
+              }
+            }
+          } catch (e) { Logger.log('Error clicking wizard button', e, 'error'); }
+        }, WIZARD_CLICK_DELAY_MS);
+      } catch (_) { /* ignore */ }
+    },
+
+    matchesWizardButton(btnUrl, colPos, container, afterUid) {
+      const colPosMatch = btnUrl.match(/colPos=(\d+)/);
+
+      if (afterUid) {
+        const m = btnUrl.match(/uid_pid=-(\d+)/);
+        return m && m[1] === afterUid && colPosMatch && colPosMatch[1] === colPos;
+      }
+      if (container) {
+        const m = btnUrl.match(/tx_container_parent=(\d+)/);
+        return colPosMatch && colPosMatch[1] === colPos && m && m[1] === container;
+      }
+      return colPosMatch && colPosMatch[1] === colPos && !btnUrl.includes('tx_container_parent');
+    },
+
+    // ── Wizard component patching ──────────────────────────────────
+
+    patchWizardComponents(iframe) {
+      try {
+        const win = iframe.contentWindow;
+        if (!win) return;
+
+        let attempts = 0;
+        const interval = setInterval(() => {
+          attempts++;
+          try {
+            for (const wizard of win.document.querySelectorAll(WIZARD_SELECTORS)) {
+              if (wizard._frontendEditPatched) continue;
+              wizard._frontendEditPatched = true;
+              const original = wizard.handleItemClick;
+              wizard.handleItemClick = function (item) {
+                if (item?.url) { win.location.href = ensureReturnUrl(item.url); return; }
+                if (original) return original.call(this, item);
+              };
+              Logger.log('Wizard component patched');
+            }
+          } catch (_) { /* ignore */ }
+          if (attempts >= WIZARD_PATCH_MAX_POLLS) clearInterval(interval);
+        }, WIZARD_PATCH_POLL_MS);
+
+        this.installWizardClickInterception(win);
+      } catch (_) { /* ignore */ }
+    },
+
+    installWizardClickInterception(win) {
+      try {
+        const doc = win.document;
+        if (!doc?.body || doc._wizardInterceptionInstalled) return;
+        doc._wizardInterceptionInstalled = true;
+
+        doc.addEventListener('click', (e) => {
+          const wizard = e.target.closest(WIZARD_SELECTORS);
+          if (!wizard?.items) return;
+          const button = e.target.closest('button');
+          if (!button) return;
+
+          const identifier = button.getAttribute('data-identifier');
+          const label = (button.querySelector('.item-label') || button).textContent.trim();
+
+          for (const key in wizard.items) {
+            const category = wizard.items[key];
+            if (!category?.items) continue;
+            for (const item of category.items) {
+              const matches = (identifier && item.identifier === identifier)
+                || (label && item.label?.includes(label));
+              if (matches && item.url) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                win.location.href = ensureReturnUrl(item.url);
+                return;
+              }
+            }
+          }
+        }, true);
+
+        if (doc.body) {
+          new MutationObserver(() => this.installWizardClickInterception(win))
+            .observe(doc.body, { childList: true, subtree: true });
+        }
+        Logger.log('Wizard click interception installed');
+      } catch (_) { /* ignore */ }
+    },
+
+    // ── Iframe click routing ───────────────────────────────────────
+
+    /**
+     * Route clicks inside the iframe:
+     *   1. File selector        → popup window
+     *   2. Edit form close      → close modal, reload frontend
+     *   3. Page layout nav      → close modal, reload frontend
+     *   4. Frontend link        → close modal, reload frontend
+     *   5. Any other backend <a>→ navigate iframe directly
+     *      (bypasses TYPO3's content-container.js which breaks in nested iframes)
+     */
+    interceptIframeClicks(iframe) {
+      try {
+        const doc = iframe.contentWindow?.document;
+        if (!doc) return;
+
+        doc.addEventListener('click', (e) => {
+          // 0. Save & close button → show loader (modal will close after save)
+          const saveCloseBtn = e.target.closest('[data-js="save-close"], [name="_saveandclosedok"]');
+          if (saveCloseBtn) {
+            Logger.log('Save & Close button clicked, showing modal loader');
+            this.showModalLoader();
+            return; // Let the click through — TYPO3 handles the form submit
+          }
+
+          // 0b. Regular Save button → let TYPO3 handle without hiding the iframe
+          const saveBtn = e.target.closest('[data-js="save"], [name="_savedok"]');
+          if (saveBtn) {
+            Logger.log('Save button clicked');
+            return; // Let the click through — TYPO3 handles the form submit
+          }
+
+          // 1. File selector → popup
+          const fileTarget = e.target.closest(
+            'button[data-file-irre-object], a[href*="wizard/element/browser"], button[title*="Select"]'
+          );
+          if (fileTarget) { this.handleFileSelector(e, fileTarget); return; }
+
+          // 1b. TYPO3 form engine controls (link popup, element browser, etc.) open
+          //     their own Modal — skip so TYPO3's JS handles the click natively
+          if (e.target.closest('.t3js-element-browser, a[href*="wizard/link"]')) return;
+
+          const link = e.target.closest('a[href]');
+          if (!link) return;
+          const href = link.getAttribute('href') || '';
+
+          // 2. Edit form close button
+          if (link.matches('.t3js-editform-close')) {
+            e.preventDefault();
+            e.stopPropagation();
+            Logger.log('Close button clicked');
+            this.closeAndReload();
+            return;
+          }
+
+          // 3. Direct navigation to page layout → return to frontend
+          if (isPageLayoutPath(href, iframe.contentWindow.location.origin)) {
+            e.preventDefault();
+            e.stopPropagation();
+            Logger.log('Page layout link clicked');
+            this.closeAndReload();
+            return;
+          }
+
+          // 4. Frontend link
+          if (isFrontendUrl(href) && !href.includes('about:blank')) {
+            e.preventDefault();
+            e.stopPropagation();
+            this.closeAndReload();
+            return;
+          }
+
+          // 5. Wizard links (link browser, etc.) → open in wizard overlay
+          if (isWizardUrl(href)) {
+            e.preventDefault();
+            e.stopPropagation();
+            IframeHandler.openWizardOverlay(iframe, link.href);
+            return;
+          }
+
+          // 6. Backend link → navigate iframe directly
+          if (isBackendUrl(href)) {
+            e.preventDefault();
+            e.stopPropagation();
+            Logger.log('Backend link → navigating iframe', { href });
+            iframe.contentWindow.location.href = ensureReturnUrl(link.href);
+          }
+        }, true);
+      } catch (_) { /* cross-origin */ }
+    },
+
+    handleFileSelector(e, target) {
+      const rawUrl = target.getAttribute('href')
+        || target.getAttribute('data-url')
+        || target.getAttribute('onclick');
+      if (!rawUrl) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      let fileUrl = rawUrl;
+      if (rawUrl.includes('window.open') || rawUrl.includes('location.href')) {
+        const match = rawUrl.match(/['"]([^'"]+)['"]/);
+        if (match) fileUrl = match[1];
+      }
+      Logger.log('Opening file selector in popup', fileUrl);
+      window.open(fileUrl, '_blank', 'width=1200,height=800');
+    },
+
+    // ── Wizard overlay ────────────────────────────────────────────
+
+    /**
+     * Open a wizard URL (e.g. link browser) in an overlay inside the
+     * iframe's document. This keeps `parent` pointing at the edit form
+     * so TYPO3's callbacks (field value updates) work correctly.
+     */
+    openWizardOverlay(iframe, wizardUrl) {
+      try {
+        const doc = iframe.contentWindow.document;
+
+        // Remove existing overlay
+        const existing = doc.getElementById('fe-wizard-overlay');
+        if (existing) existing.remove();
+
+        const overlay = doc.createElement('div');
+        overlay.id = 'fe-wizard-overlay';
+        overlay.style.cssText =
+          'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;' +
+          'background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;';
+
+        const panel = doc.createElement('div');
+        panel.style.cssText =
+          'width:80%;max-width:900px;height:80%;background:#fff;border-radius:4px;' +
+          'overflow:hidden;position:relative;display:flex;flex-direction:column;' +
+          'box-shadow:0 4px 24px rgba(0,0,0,0.3);';
+
+        const header = doc.createElement('div');
+        header.style.cssText =
+          'display:flex;justify-content:flex-end;padding:4px 8px;background:#eee;flex-shrink:0;';
+
+        const closeBtn = doc.createElement('button');
+        closeBtn.innerHTML = '&times;';
+        closeBtn.style.cssText =
+          'font-size:22px;background:none;border:none;cursor:pointer;padding:2px 8px;line-height:1;';
+        closeBtn.onclick = () => overlay.remove();
+
+        const wizIframe = doc.createElement('iframe');
+        wizIframe.src = wizardUrl;
+        wizIframe.style.cssText = 'flex:1;border:none;width:100%;';
+
+        header.appendChild(closeBtn);
+        panel.appendChild(header);
+        panel.appendChild(wizIframe);
+        overlay.appendChild(panel);
+
+        // Close on backdrop click
+        overlay.addEventListener('click', (e) => {
+          if (e.target === overlay) overlay.remove();
+        });
+
+        doc.body.appendChild(overlay);
+        Logger.log('Wizard overlay opened', { url: wizardUrl });
+
+        // Patch Modal.dismiss so the link browser can close the overlay
+        this._patchDismissForOverlay(iframe, overlay, wizIframe);
+
+      } catch (err) {
+        Logger.log('Failed to create wizard overlay — falling back to popup', err, 'error');
+        try {
+          iframe.contentWindow.open(wizardUrl, '_blank', 'width=1000,height=700');
+        } catch (_) { /* ignore */ }
+      }
+    },
+
+    /**
+     * Patch TYPO3.Modal.dismiss on parent and iframe windows so the
+     * link browser can close the wizard overlay after selecting a link.
+     */
+    _patchDismissForOverlay(iframe, overlay, wizIframe) {
+      const patchDismiss = (modalObj) => {
+        if (!modalObj) return;
+        const orig = modalObj.dismiss;
+        modalObj.dismiss = function () {
+          if (overlay.parentNode) overlay.remove();
+          modalObj.dismiss = orig || function () {};
+          if (typeof orig === 'function') orig.call(this);
+        };
+      };
+
+      // Parent window (for top.TYPO3.Modal.dismiss calls)
+      patchDismiss(window.TYPO3?.Modal);
+
+      // Main iframe (for parent.TYPO3.Modal.dismiss calls from wizard)
+      try { patchDismiss(iframe.contentWindow?.TYPO3?.Modal); } catch (_) {}
+
+      // Wizard iframe after it loads (for local Modal.dismiss calls)
+      wizIframe.addEventListener('load', () => {
+        try {
+          const wizWin = wizIframe.contentWindow;
+          // Try to patch immediately, then poll briefly
+          const tryPatch = () => {
+            if (wizWin.TYPO3?.Modal) { patchDismiss(wizWin.TYPO3.Modal); return true; }
+            return false;
+          };
+          if (!tryPatch()) {
+            let attempts = 0;
+            const interval = setInterval(() => {
+              if (tryPatch() || ++attempts > 40) clearInterval(interval);
+            }, 100);
+          }
+        } catch (_) { /* cross-origin */ }
+      });
+    },
+
+    // ── Navigation detection ───────────────────────────────────────
+
+    detectFrontendNavigation(iframe) {
+      try {
+        const currentHref = iframe.contentWindow.location.href;
+        if (isFrontendUrl(currentHref)) {
+          Logger.log('Detected frontend URL in iframe');
+          this.closeAndReload();
+          return;
+        }
+        // After a wizard auto-click + save cycle, navigating back to
+        // web_layout means the record was saved — close and reload.
+        if (this._wizardAutoClicked && isPageLayoutPath(currentHref, iframe.contentWindow.location.origin)) {
+          Logger.log('Detected page layout after wizard save — closing modal');
+          this.closeAndReload();
+        }
+      } catch (_) { /* cross-origin */ }
+    },
+
+    /**
+     * Extract the content element UID from the iframe's edit form URL.
+     * Pattern: edit[tt_content][{uid}]=edit (URL-encoded or plain).
+     */
+    getEditedElementUid() {
+      try {
+        const url = Modal.iframe?.contentWindow?.location.href;
+        if (!url) return null;
+        const match = url.match(/edit%5Btt_content%5D%5B(\d+)%5D=edit/i)
+          || url.match(/edit\[tt_content\]\[(\d+)\]=edit/i);
+        return match ? match[1] : null;
+      } catch (_) {
+        return null;
+      }
+    },
+
+    /**
+     * Show black overlay with spinner INSIDE the modal (covers the iframe).
+     * Called on save button click — modal stays open, user sees spinner.
+     */
+    showModalLoader() {
+      const loader = Modal.element?.querySelector('.frontend-edit__modal-loader');
+      if (loader) {
+        loader.style.display = 'flex';
+      }
+      if (Modal.iframe) {
+        Modal.iframe.style.display = 'none';
+      }
+    },
+
+    /**
+     * Reload the page. The modal loader is already visible at this point.
+     */
+    closeAndReload(scrollToEdited = false) {
+      let uid = null;
+      if (scrollToEdited) uid = this.getEditedElementUid();
+
+      // Show modal loader in case it wasn't shown yet (e.g. close without save)
+      this.showModalLoader();
+
+      // Stop the iframe immediately to prevent the frontend page from loading
+      // inside it (GSAP, CKEditor, etc. break when running in an iframe context)
+      if (Modal.iframe) {
+        Modal.iframe.src = 'about:blank';
+      }
+
+      if (uid) {
+        const url = new URL(window.location.href);
+        url.searchParams.set('scrollToContent', uid);
+        url.hash = '';
+        window.location.href = url.toString();
+      } else {
+        window.location.reload();
+      }
+    }
+  };
+
+  // ── LinkInterceptor (frontend page clicks → open modal) ─────────
+
+  const LinkInterceptor = {
+    init() {
+      document.addEventListener('click', (e) => {
+        const target =
+          e.target.closest('.frontend-edit__btn--edit') ||
+          e.target.closest('.frontend-edit__dropdown a:not(.hide):not(.delete)') ||
+          e.target.closest('.frontend-edit__sticky-dropdown a') ||
+          e.target.closest('.frontend-edit__open-modal');
+
+        if (target?.href && isBackendUrl(target.href)) {
+          e.preventDefault();
+          e.stopPropagation();
+          Modal.open(target.href);
+          Logger.log('Link intercepted → modal', { href: target.href });
+        }
+      }, true);
+    }
+  };
+
+  // ── Message Handler (save & close from iframe) ──────────────────
+
+  window.addEventListener('message', (event) => {
+    if (typeof event.data !== 'object' || !event.data) return;
+    const action = event.data.actionName;
+    if (action === 'typo3:formengine:save-close') {
+      Logger.log('Save & close triggered from iframe');
+      IframeHandler.closeAndReload(true);
+    } else if (action === 'typo3:formengine:close') {
+      Logger.log('Close triggered from iframe');
+      IframeHandler.closeAndReload(false);
+    }
+  });
+
+  // ── Init ───────────────────────────────────────────────────────────
+
+  LinkInterceptor.init();
+  Logger.log('Modal edit system initialized');
+})();

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -9,17 +9,63 @@
   'use strict';
 
   // ── Constants ──────────────────────────────────────────────────────
+  //
+  // POLLING / MONKEY-PATCH POLICY (TYPO3 v13 only)
+  // ──────────────────────────────────────────────
+  // TYPO3 v13 does not expose a stable hook for embedded backend forms,
+  // so we poll for internal objects (ContentContainer, wizard components)
+  // and monkey-patch their methods to keep navigation inside our iframe.
+  //
+  // This is fragile by nature: any TYPO3 v13 patch release that renames
+  // or refactors these internals silently breaks the feature. The
+  // tradeoff is intentional and bounded by TYPO3 v13's lifetime — the
+  // entire iframe modal is gated to v13 only (see ResourceRendererService).
+  // On v14.2+ the contextual sidebar handles this natively, no polling.
+  //
+  // All timeouts/intervals are tuned to be just generous enough for slow
+  // dev environments without burning CPU. We use waitFor() with a single
+  // setTimeout-recursion + cap, not setInterval, so failed waits stop
+  // cleanly instead of accumulating handles.
 
   const MODAL_ID = 'xima-typo3-frontend-edit-modal';
   const IFRAME_ID = 'xima-typo3-frontend-edit-modal-iframe';
   const ANIMATION_DELAY_MS = 10;
   const ANIMATION_DURATION_MS = 300;
-  const WIZARD_CLICK_DELAY_MS = 1000;
-  const CONTENT_CONTAINER_POLL_MS = 5;
-  const CONTENT_CONTAINER_MAX_POLLS = 1000;
-  const WIZARD_PATCH_POLL_MS = 50;
-  const WIZARD_PATCH_MAX_POLLS = 200;
+
+  // ContentContainer is created by TYPO3 backend modules during iframe
+  // boot. We need to override setUrl before any backend code calls it
+  // (typically within ~50-200ms on a normal machine).
+  const CONTENT_CONTAINER_POLL_MS = 25;       // every 25ms
+  const CONTENT_CONTAINER_TIMEOUT_MS = 3000;  // give up after 3s
+
+  // Wizard custom elements (<typo3-backend-new-content-element-wizard>)
+  // are upgraded asynchronously after the iframe page renders.
+  const WIZARD_PATCH_POLL_MS = 100;           // every 100ms
+  const WIZARD_PATCH_TIMEOUT_MS = 5000;       // give up after 5s
+
+  // Fixed wait before auto-clicking a wizard button (give the wizard
+  // time to render its items after the page loads).
+  const WIZARD_CLICK_DELAY_MS = 800;
+
   const WIZARD_SELECTORS = 'typo3-backend-new-record-wizard, typo3-backend-new-content-element-wizard';
+
+  /**
+   * Poll until predicate() returns truthy or timeout elapses.
+   * Cleaner than raw setInterval — single timeout chain, no leaked
+   * handles, automatic stop on success or timeout.
+   *
+   * @param {() => *} predicate Called repeatedly; truthy return = done.
+   * @param {number} intervalMs Delay between attempts.
+   * @param {number} timeoutMs  Total budget before giving up.
+   */
+  function waitFor(predicate, intervalMs, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    function tick() {
+      try { if (predicate()) return; } catch (_) { /* ignore */ }
+      if (Date.now() < deadline) setTimeout(tick, intervalMs);
+    }
+    tick();
+  }
 
   // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -58,15 +104,32 @@
   /**
    * Ensure a backend URL has:
    * 1. A returnUrl pointing to our frontend page (not a backend route)
+   *    with tx_ximatypo3frontendedit_iframe=1 marker so the post-save
+   *    redirect does not consume the flash queue inside the iframe
    * 2. The tx_ximatypo3frontendedit marker so the Save & Close button is added
+   *
+   * Delegates to the shared implementation in backend_stubs.js.
+   * Kept as a local fallback in case backend_stubs.js didn't load.
    */
   function ensureReturnUrl(url) {
+    if (window.XimaFrontendEdit?.ensureReturnUrl) {
+      return window.XimaFrontendEdit.ensureReturnUrl(url);
+    }
     try {
       const u = new URL(url, window.location.origin);
       const existing = u.searchParams.get('returnUrl') || '';
-      if (!existing || existing.includes('/typo3/')) {
-        u.searchParams.set('returnUrl', window.location.href);
+
+      // Rebuild returnUrl: use existing if it's a frontend URL, otherwise
+      // default to current page. Always add the iframe marker.
+      let returnUrl;
+      if (existing && !existing.includes('/typo3/')) {
+        returnUrl = new URL(existing, window.location.origin);
+      } else {
+        returnUrl = new URL(window.location.href);
       }
+      returnUrl.searchParams.set('tx_ximatypo3frontendedit_iframe', '1');
+      u.searchParams.set('returnUrl', returnUrl.toString());
+
       if (!u.searchParams.has('tx_ximatypo3frontendedit')) {
         u.searchParams.set('tx_ximatypo3frontendedit', '');
       }
@@ -116,6 +179,12 @@
     },
 
     open(url) {
+      // Ensure the returnUrl carries tx_ximatypo3frontendedit_iframe=1
+      // so the post-save redirect to the frontend URL does not consume the
+      // flash message queue inside the iframe — the parent reload picks
+      // them up instead.
+      url = ensureReturnUrl(url);
+
       this.getOrCreate();
       IframeHandler._wizardAutoClicked = false;
       const { iframe } = this;
@@ -127,10 +196,12 @@
       IframeHandler.overrideContentContainer(iframe);
       iframe.src = url;
 
-      // Only show header for info modals
+      // Show header only for views without a native close button
+      // (info, move, history). Edit forms have their own Save/Close UI.
+      const needsHeader = /record\/(info|history)|move_element/.test(url);
       const header = this.element.querySelector('.frontend-edit__modal-header');
       if (header) {
-        header.style.display = url.includes('record/info') ? 'flex' : 'none';
+        header.style.display = needsHeader ? 'flex' : 'none';
       }
 
       setTimeout(() => this.element.classList.add('frontend-edit__modal--open'), ANIMATION_DELAY_MS);
@@ -205,38 +276,36 @@
     /**
      * Override ContentContainer.setUrl inside the iframe so backend navigation
      * stays within our modal iframe instead of targeting the parent window.
+     *
+     * ContentContainer is created asynchronously by TYPO3 backend modules
+     * during iframe boot, so we have to wait for it before patching.
      */
     overrideContentContainer(iframe) {
-      let attempts = 0;
-      const interval = setInterval(() => {
-        attempts++;
-        try {
-          const cc = iframe.contentWindow?.TYPO3?.Backend?.ContentContainer;
-          if (!cc || cc._overridden) { if (cc?._overridden) clearInterval(interval); return; }
-          cc._overridden = true;
-          const setUrl = (url) => {
-            if (isFrontendUrl(url)) {
-              IframeHandler.closeAndReload();
-              return Promise.resolve();
-            }
-            if (isWizardUrl(url)) {
-              Logger.log('Wizard URL in ContentContainer.setUrl — opening overlay', { url });
-              IframeHandler.openWizardOverlay(iframe, url);
-              return Promise.resolve();
-            }
-            iframe.src = ensureReturnUrl(url);
+      waitFor(() => {
+        const cc = iframe.contentWindow?.TYPO3?.Backend?.ContentContainer;
+        if (!cc || cc._overridden) return cc?._overridden === true;
+        cc._overridden = true;
+        const setUrl = (url) => {
+          if (isFrontendUrl(url)) {
+            IframeHandler.closeAndReload();
             return Promise.resolve();
-          };
-          try {
-            Object.defineProperty(cc, 'setUrl', { value: setUrl, writable: true, configurable: true });
-          } catch (_) {
-            cc.setUrl = setUrl;
           }
-          Logger.log('ContentContainer.setUrl overridden');
-          clearInterval(interval);
-        } catch (_) { /* cross-origin */ }
-        if (attempts >= CONTENT_CONTAINER_MAX_POLLS) clearInterval(interval);
-      }, CONTENT_CONTAINER_POLL_MS);
+          if (isWizardUrl(url)) {
+            Logger.log('Wizard URL in ContentContainer.setUrl — opening overlay', { url });
+            IframeHandler.openWizardOverlay(iframe, url);
+            return Promise.resolve();
+          }
+          iframe.src = ensureReturnUrl(url);
+          return Promise.resolve();
+        };
+        try {
+          Object.defineProperty(cc, 'setUrl', { value: setUrl, writable: true, configurable: true });
+        } catch (_) {
+          cc.setUrl = setUrl;
+        }
+        Logger.log('ContentContainer.setUrl overridden');
+        return true;
+      }, CONTENT_CONTAINER_POLL_MS, CONTENT_CONTAINER_TIMEOUT_MS);
     },
 
     // ── Wizard auto-click ──────────────────────────────────────────
@@ -292,28 +361,31 @@
 
     // ── Wizard component patching ──────────────────────────────────
 
+    /**
+     * Patch wizard custom elements inside the iframe so they don't escape
+     * our iframe context. Wizards are upgraded asynchronously, so we poll.
+     */
     patchWizardComponents(iframe) {
       try {
         const win = iframe.contentWindow;
         if (!win) return;
 
-        let attempts = 0;
-        const interval = setInterval(() => {
-          attempts++;
-          try {
-            for (const wizard of win.document.querySelectorAll(WIZARD_SELECTORS)) {
-              if (wizard._frontendEditPatched) continue;
-              wizard._frontendEditPatched = true;
-              const original = wizard.handleItemClick;
-              wizard.handleItemClick = function (item) {
-                if (item?.url) { win.location.href = ensureReturnUrl(item.url); return; }
-                if (original) return original.call(this, item);
-              };
-              Logger.log('Wizard component patched');
-            }
-          } catch (_) { /* ignore */ }
-          if (attempts >= WIZARD_PATCH_MAX_POLLS) clearInterval(interval);
-        }, WIZARD_PATCH_POLL_MS);
+        // Poll for wizard components and patch any we haven't seen yet.
+        // Returns false (keep polling) until the timeout elapses — wizards
+        // can appear at different times as the form renders.
+        waitFor(() => {
+          for (const wizard of win.document.querySelectorAll(WIZARD_SELECTORS)) {
+            if (wizard._frontendEditPatched) continue;
+            wizard._frontendEditPatched = true;
+            const original = wizard.handleItemClick;
+            wizard.handleItemClick = function (item) {
+              if (item?.url) { win.location.href = ensureReturnUrl(item.url); return; }
+              if (original) return original.call(this, item);
+            };
+            Logger.log('Wizard component patched');
+          }
+          return false; // keep polling until timeout
+        }, WIZARD_PATCH_POLL_MS, WIZARD_PATCH_TIMEOUT_MS);
 
         this.installWizardClickInterception(win);
       } catch (_) { /* ignore */ }
@@ -350,10 +422,9 @@
           }
         }, true);
 
-        if (doc.body) {
-          new MutationObserver(() => this.installWizardClickInterception(win))
-            .observe(doc.body, { childList: true, subtree: true });
-        }
+        // Click handler is delegated at document level, so it catches wizards
+        // rendered later (no MutationObserver needed — the observer re-fired
+        // on every DOM mutation which was wasted work on big forms).
         Logger.log('Wizard click interception installed');
       } catch (_) { /* ignore */ }
     },
@@ -361,92 +432,124 @@
     // ── Iframe click routing ───────────────────────────────────────
 
     /**
-     * Route clicks inside the iframe:
-     *   1. File selector        → popup window
-     *   2. Edit form close      → close modal, reload frontend
-     *   3. Page layout nav      → close modal, reload frontend
-     *   4. Frontend link        → close modal, reload frontend
-     *   5. Any other backend <a>→ navigate iframe directly
-     *      (bypasses TYPO3's content-container.js which breaks in nested iframes)
+     * Route clicks inside the iframe through an ordered list of handlers.
+     * Each handler returns `true` if it fully handled the event (stop),
+     * or `false` to let the next handler try.
      */
     interceptIframeClicks(iframe) {
       try {
         const doc = iframe.contentWindow?.document;
         if (!doc) return;
 
+        const handlers = [
+          this._handleSaveCloseClick.bind(this),
+          this._handleSaveClick.bind(this),
+          this._handleFileSelectorClick.bind(this),
+          this._handleNativeBrowserModalClick.bind(this),
+          this._handleEditFormCloseClick.bind(this),
+          this._handlePageLayoutNavClick.bind(this),
+          this._handleFrontendLinkClick.bind(this),
+          this._handleWizardLinkClick.bind(this),
+          this._handleBackendLinkClick.bind(this),
+        ];
+
         doc.addEventListener('click', (e) => {
-          // 0. Save & close button → show loader (modal will close after save)
-          const saveCloseBtn = e.target.closest('[data-js="save-close"], [name="_saveandclosedok"]');
-          if (saveCloseBtn) {
-            Logger.log('Save & Close button clicked, showing modal loader');
-            this.showModalLoader();
-            return; // Let the click through — TYPO3 handles the form submit
-          }
-
-          // 0b. Regular Save button → let TYPO3 handle without hiding the iframe
-          const saveBtn = e.target.closest('[data-js="save"], [name="_savedok"]');
-          if (saveBtn) {
-            Logger.log('Save button clicked');
-            return; // Let the click through — TYPO3 handles the form submit
-          }
-
-          // 1. File selector → popup
-          const fileTarget = e.target.closest(
-            'button[data-file-irre-object], a[href*="wizard/element/browser"], button[title*="Select"]'
-          );
-          if (fileTarget) { this.handleFileSelector(e, fileTarget); return; }
-
-          // 1b. TYPO3 form engine controls (link popup, element browser, etc.) open
-          //     their own Modal — skip so TYPO3's JS handles the click natively
-          if (e.target.closest('.t3js-element-browser, a[href*="wizard/link"]')) return;
-
-          const link = e.target.closest('a[href]');
-          if (!link) return;
-          const href = link.getAttribute('href') || '';
-
-          // 2. Edit form close button
-          if (link.matches('.t3js-editform-close')) {
-            e.preventDefault();
-            e.stopPropagation();
-            Logger.log('Close button clicked');
-            this.closeAndReload();
-            return;
-          }
-
-          // 3. Direct navigation to page layout → return to frontend
-          if (isPageLayoutPath(href, iframe.contentWindow.location.origin)) {
-            e.preventDefault();
-            e.stopPropagation();
-            Logger.log('Page layout link clicked');
-            this.closeAndReload();
-            return;
-          }
-
-          // 4. Frontend link
-          if (isFrontendUrl(href) && !href.includes('about:blank')) {
-            e.preventDefault();
-            e.stopPropagation();
-            this.closeAndReload();
-            return;
-          }
-
-          // 5. Wizard links (link browser, etc.) → open in wizard overlay
-          if (isWizardUrl(href)) {
-            e.preventDefault();
-            e.stopPropagation();
-            IframeHandler.openWizardOverlay(iframe, link.href);
-            return;
-          }
-
-          // 6. Backend link → navigate iframe directly
-          if (isBackendUrl(href)) {
-            e.preventDefault();
-            e.stopPropagation();
-            Logger.log('Backend link → navigating iframe', { href });
-            iframe.contentWindow.location.href = ensureReturnUrl(link.href);
+          for (const handler of handlers) {
+            if (handler(e, iframe)) return;
           }
         }, true);
       } catch (_) { /* cross-origin */ }
+    },
+
+    // ── Click handlers (return true if handled) ─────────────────────
+
+    _handleSaveCloseClick(e) {
+      if (!e.target.closest('[data-js="save-close"], [name="_saveandclosedok"]')) return false;
+      Logger.log('Save & Close button clicked, showing modal loader');
+      this.showModalLoader();
+      return true; // click passes through — TYPO3 handles the form submit
+    },
+
+    _handleSaveClick(e) {
+      if (!e.target.closest('[data-js="save"], [name="_savedok"]')) return false;
+      Logger.log('Save button clicked');
+      // Don't show the loader here — it covers the iframe while TYPO3
+      // re-initializes CKEditor on the new form, and CKEditor's
+      // _removeDomSelection crashes when the iframe isn't visible/focused
+      // (window.getSelection() returns null).
+      return true; // click passes through — TYPO3 handles the form submit
+    },
+
+    _handleFileSelectorClick(e) {
+      // Structural selectors only — no i18n-fragile title matching
+      const fileTarget = e.target.closest(
+        'button[data-file-irre-object], a[href*="wizard/element/browser"], [data-mode="file"], [data-toggle="formengine-inline"]'
+      );
+      if (!fileTarget) return false;
+      this.handleFileSelector(e, fileTarget);
+      return true;
+    },
+
+    _handleNativeBrowserModalClick(e) {
+      // TYPO3 form engine controls (link popup, element browser, etc.) open
+      // their own Modal natively — don't interfere.
+      return !!e.target.closest('.t3js-element-browser, a[href*="wizard/link"]');
+    },
+
+    _handleEditFormCloseClick(e) {
+      const link = e.target.closest('a[href]');
+      if (!link || !link.matches('.t3js-editform-close')) return false;
+      e.preventDefault();
+      e.stopPropagation();
+      Logger.log('Close button clicked');
+      this.closeAndReload();
+      return true;
+    },
+
+    _handlePageLayoutNavClick(e, iframe) {
+      const link = e.target.closest('a[href]');
+      if (!link) return false;
+      const href = link.getAttribute('href') || '';
+      if (!isPageLayoutPath(href, iframe.contentWindow.location.origin)) return false;
+      e.preventDefault();
+      e.stopPropagation();
+      Logger.log('Page layout link clicked');
+      this.closeAndReload();
+      return true;
+    },
+
+    _handleFrontendLinkClick(e) {
+      const link = e.target.closest('a[href]');
+      if (!link) return false;
+      const href = link.getAttribute('href') || '';
+      if (!isFrontendUrl(href) || href.includes('about:blank')) return false;
+      e.preventDefault();
+      e.stopPropagation();
+      this.closeAndReload();
+      return true;
+    },
+
+    _handleWizardLinkClick(e, iframe) {
+      const link = e.target.closest('a[href]');
+      if (!link) return false;
+      const href = link.getAttribute('href') || '';
+      if (!isWizardUrl(href)) return false;
+      e.preventDefault();
+      e.stopPropagation();
+      IframeHandler.openWizardOverlay(iframe, link.href);
+      return true;
+    },
+
+    _handleBackendLinkClick(e, iframe) {
+      const link = e.target.closest('a[href]');
+      if (!link) return false;
+      const href = link.getAttribute('href') || '';
+      if (!isBackendUrl(href)) return false;
+      e.preventDefault();
+      e.stopPropagation();
+      Logger.log('Backend link → navigating iframe', { href });
+      iframe.contentWindow.location.href = ensureReturnUrl(link.href);
+      return true;
     },
 
     handleFileSelector(e, target) {
@@ -557,17 +660,13 @@
       wizIframe.addEventListener('load', () => {
         try {
           const wizWin = wizIframe.contentWindow;
-          // Try to patch immediately, then poll briefly
-          const tryPatch = () => {
-            if (wizWin.TYPO3?.Modal) { patchDismiss(wizWin.TYPO3.Modal); return true; }
-            return false;
-          };
-          if (!tryPatch()) {
-            let attempts = 0;
-            const interval = setInterval(() => {
-              if (tryPatch() || ++attempts > 40) clearInterval(interval);
-            }, 100);
-          }
+          // Patch wizWin.TYPO3.Modal.dismiss as soon as it's available
+          // (wait up to 4s for the wizard's TYPO3 namespace to boot).
+          waitFor(() => {
+            if (!wizWin.TYPO3?.Modal) return false;
+            patchDismiss(wizWin.TYPO3.Modal);
+            return true;
+          }, 100, 4000);
         } catch (_) { /* cross-origin */ }
       });
     },
@@ -623,6 +722,10 @@
 
     /**
      * Reload the page. The modal loader is already visible at this point.
+     *
+     * Fully destroys the iframe before reloading — otherwise the live iframe
+     * can consume session-based flash messages (or trigger other side effects)
+     * in the brief window between reload trigger and parent navigation.
      */
     closeAndReload(scrollToEdited = false) {
       let uid = null;
@@ -631,10 +734,14 @@
       // Show modal loader in case it wasn't shown yet (e.g. close without save)
       this.showModalLoader();
 
-      // Stop the iframe immediately to prevent the frontend page from loading
-      // inside it (GSAP, CKEditor, etc. break when running in an iframe context)
+      // Fully remove the iframe from the DOM so it can no longer execute or
+      // consume shared session state (flash messages, csrf tokens, etc.).
       if (Modal.iframe) {
         Modal.iframe.src = 'about:blank';
+        if (Modal.iframe.parentNode) {
+          Modal.iframe.parentNode.removeChild(Modal.iframe);
+        }
+        Modal.iframe = null;
       }
 
       if (uid) {
@@ -673,6 +780,14 @@
 
   window.addEventListener('message', (event) => {
     if (typeof event.data !== 'object' || !event.data) return;
+
+    // Only accept same-origin messages while a modal is active.
+    // Prevents third-party iframes from triggering a reload, while still
+    // allowing the TYPO3 backend iframe to dispatch messages even during
+    // navigation (when event.source / contentWindow may be transient).
+    if (!Modal.iframe) return;
+    if (event.origin !== window.location.origin) return;
+
     const action = event.data.actionName;
     if (action === 'typo3:formengine:save-close') {
       Logger.log('Save & close triggered from iframe');

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -198,7 +198,7 @@ final class ContentElementButtonBuilderTest extends TestCase
         $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
         $menuButton = new Button('Menu', ButtonType::Menu);
 
-        $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], '/return');
+        $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], 0, '/return');
 
         $children = $menuButton->getChildren();
         self::assertArrayHasKey('div_action', $children);

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 
 /**
  * UrlBuilderServiceTest.
@@ -135,16 +136,38 @@ final class UrlBuilderServiceTest extends TestCase
     }
 
     #[Test]
-    public function buildNewContentAfterUrlReturnsCorrectUrl(): void
+    public function buildNewContentAfterUrlReturnsRecordEditUrlOnV14(): void
     {
+        if (!VersionUtility::is14OrHigher()) {
+            self::markTestSkipped('TYPO3 v14+ only');
+        }
+
         $this->uriBuilderMock->method('buildUriFromRoute')
             ->with('record_edit', self::callback(static fn (array $params): bool => isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1]))
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();
-        $result = $service->buildNewContentAfterUrl(1, '/return');
+        $result = $service->buildNewContentAfterUrl(1, 5, 0, '/return');
 
         self::assertSame('/typo3/record/edit', $result);
+    }
+
+    #[Test]
+    public function buildNewContentAfterUrlReturnsHashedWebLayoutUrlOnV13(): void
+    {
+        if (VersionUtility::is14OrHigher()) {
+            self::markTestSkipped('TYPO3 v13 only');
+        }
+
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('web_layout', self::callback(static fn (array $params): bool => 5 === ($params['id'] ?? null) && '/return' === ($params['returnUrl'] ?? null)))
+            ->willReturn(new Uri('/typo3/module/web/layout'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildNewContentAfterUrl(1, 5, 0, '/return');
+
+        // Hash fragment carries colPos + afterUid for the iframe wizard auto-click
+        self::assertSame('/typo3/module/web/layout#colPos=0&afterUid=1', $result);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -147,7 +147,7 @@ final class UrlBuilderServiceTest extends TestCase
             ->willReturn(new Uri('/typo3/record/edit'));
 
         $service = new UrlBuilderService();
-        $result = $service->buildNewContentAfterUrl(1, 5, 0, '/return');
+        $result = $service->buildNewContentAfterUrl(1, 5, 0, 2, '/return');
 
         self::assertSame('/typo3/record/edit', $result);
     }
@@ -160,11 +160,11 @@ final class UrlBuilderServiceTest extends TestCase
         }
 
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn (array $params): bool => 5 === ($params['id'] ?? null) && '/return' === ($params['returnUrl'] ?? null)))
+            ->with('web_layout', self::callback(static fn (array $params): bool => 5 === ($params['id'] ?? null) && 2 === ($params['language'] ?? null) && '/return' === ($params['returnUrl'] ?? null)))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
-        $result = $service->buildNewContentAfterUrl(1, 5, 0, '/return');
+        $result = $service->buildNewContentAfterUrl(1, 5, 0, 2, '/return');
 
         // Hash fragment carries colPos + afterUid for the iframe wizard auto-click
         self::assertSame('/typo3/module/web/layout#colPos=0&afterUid=1', $result);


### PR DESCRIPTION
- Add iframe_edit.js (slide-in panel that opens backend forms without navigating away from the frontend)
- Add BackendSettingsService providing TYPO3 global stubs for the iframe
- Update new-content-after URLs to use hash-based web_layout wizard pattern
- Add modal CSS styles for the slide-in panel
- On TYPO3 13.4: all actions open in iframe modal
- On TYPO3 14.2+: edit uses contextual sidebar, other actions use iframe modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slide-in modal iframe for frontend editing with loader, wizard overlay and in-iframe navigation handling
  * Injected backend settings/stubs script to bootstrap the iframe environment and normalize return URLs
  * New handling to target specific page, column and language when creating new content

* **Bug Fixes**
  * Iframe requests no longer consume backend flash messages, preserving them for the parent page reload

* **Styles**
  * Added modal UI styles and reduced-motion support for modal spinner

* **Tests**
  * Updated unit tests for version-specific new-content URL behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->