### PR TITLE
feat(idea): add ViewHelpers for empty column "Create new content" buttons

### DIFF
--- a/Classes/Service/Content/BackendLayoutService.php
+++ b/Classes/Service/Content/BackendLayoutService.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Service\Content;
+
+use Doctrine\DBAL\ParameterType;
+use TYPO3\CMS\Backend\View\BackendLayoutView;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service to retrieve backend layout column information for a page.
+ *
+ * Used by SingleColumnButtonViewHelper to determine whether a column
+ * is empty and should display a "Create new content" button.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class BackendLayoutService
+{
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * Get the backend layout columns for a page with their content count.
+     *
+     * @return array<int, array{colPos: int, name: string, contentCount: int}>
+     */
+    public function getColumnsForPage(int $pageId, int $languageUid = 0): array
+    {
+        $columns = [];
+
+        try {
+            $backendLayoutView = GeneralUtility::makeInstance(BackendLayoutView::class);
+            $backendLayout = $backendLayoutView->getBackendLayoutForPage($pageId);
+
+            if (null === $backendLayout) {
+                return [
+                    [
+                        'colPos' => 0,
+                        'name' => 'Content',
+                        'contentCount' => $this->getContentCountForColumn($pageId, 0, $languageUid),
+                    ],
+                ];
+            }
+
+            $structure = $backendLayout->getStructure();
+
+            if (isset($structure['__config']['backend_layout.']['rows.'])) {
+                foreach ($structure['__config']['backend_layout.']['rows.'] as $row) {
+                    if (!isset($row['columns.'])) {
+                        continue;
+                    }
+                    foreach ($row['columns.'] as $column) {
+                        if (!isset($column['colPos'])) {
+                            continue;
+                        }
+                        $colPos = (int) $column['colPos'];
+                        $columns[] = [
+                            'colPos' => $colPos,
+                            'name' => $this->translateLabel($column['name'] ?? 'Column '.$colPos),
+                            'contentCount' => $this->getContentCountForColumn($pageId, $colPos, $languageUid),
+                        ];
+                    }
+                }
+            }
+
+            if ([] === $columns && method_exists($backendLayout, 'getUsedColumns')) {
+                foreach ($backendLayout->getUsedColumns() as $colPos => $columnName) {
+                    $columns[] = [
+                        'colPos' => (int) $colPos,
+                        'name' => $this->translateLabel($columnName ?: 'Column '.$colPos),
+                        'contentCount' => $this->getContentCountForColumn($pageId, (int) $colPos, $languageUid),
+                    ];
+                }
+            }
+
+            if ([] === $columns) {
+                $columns = [
+                    [
+                        'colPos' => 0,
+                        'name' => 'Content',
+                        'contentCount' => $this->getContentCountForColumn($pageId, 0, $languageUid),
+                    ],
+                ];
+            }
+        } catch (\Throwable) {
+            $columns = [
+                [
+                    'colPos' => 0,
+                    'name' => 'Content',
+                    'contentCount' => $this->getContentCountForColumn($pageId, 0, $languageUid),
+                ],
+            ];
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Get the count of non-deleted content elements in a specific column.
+     */
+    public function getContentCountForColumn(int $pageId, int $colPos, int $languageUid = 0): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+
+        return (int) $queryBuilder
+            ->count('uid')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('colPos', $queryBuilder->createNamedParameter($colPos, ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($languageUid, ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('deleted', 0),
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function translateLabel(string $label): string
+    {
+        if (!str_starts_with($label, 'LLL:')) {
+            return $label;
+        }
+
+        try {
+            if (isset($GLOBALS['BE_USER']) && null !== $GLOBALS['BE_USER']) {
+                $languageServiceFactory = GeneralUtility::makeInstance(LanguageServiceFactory::class);
+                $languageService = $languageServiceFactory->createFromUserPreferences($GLOBALS['BE_USER']);
+
+                return $languageService->sL($label) ?: $label;
+            }
+        } catch (\Throwable) {
+            // Fallback to original label
+        }
+
+        return $label;
+    }
+}

--- a/Classes/ViewHelpers/ContainerColumnButtonViewHelper.php
+++ b/Classes/ViewHelpers/ContainerColumnButtonViewHelper.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\ViewHelpers;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+
+use function htmlspecialchars;
+use function sprintf;
+
+/**
+ * Renders a "Create new content" button for an empty container column.
+ *
+ * Use this inside container templates (e.g. 2-column, tabs, accordion)
+ * to show a "+" button when a container column has no child elements.
+ *
+ * Only visible when:
+ * - A backend user is logged in
+ * - Frontend editing is not disabled by the user
+ *
+ * Usage in Fluid templates (e.g. Container templates):
+ *
+ *     <!-- Register namespace (or use ext_localconf.php registration) -->
+ *     {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+ *
+ *     <!-- Inside a container template, show button when column is empty -->
+ *     <f:if condition="{column_content -> f:count()} == 0">
+ *         <xfe:containerColumnButton
+ *             pageId="{data.pid}"
+ *             containerUid="{data.uid}"
+ *             colPos="201"
+ *             columnName="Left Column"
+ *         />
+ *     </f:if>
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class ContainerColumnButtonViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('pageId', 'int', 'The page ID', true);
+        $this->registerArgument('containerUid', 'int', 'The UID of the container element', true);
+        $this->registerArgument('colPos', 'int', 'The column position within the container (e.g. 201, 202)', true);
+        $this->registerArgument('columnName', 'string', 'Display name shown on the button (uses locallang if omitted)', false, null);
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext,
+    ): string {
+        // Require authenticated backend user
+        $context = GeneralUtility::makeInstance(Context::class);
+        if (!$context->getPropertyFromAspect('backend.user', 'isLoggedIn', false)) {
+            return '';
+        }
+
+        // Respect user-level disable toggle
+        if ($GLOBALS['BE_USER']->uc[Configuration::UC_KEY_DISABLED] ?? false) {
+            return '';
+        }
+
+        $pageId = (int) $arguments['pageId'];
+        $containerUid = (int) $arguments['containerUid'];
+        $colPos = (int) $arguments['colPos'];
+        $columnName = $arguments['columnName'];
+
+        // Build the container new content URL
+        $urlBuilderService = GeneralUtility::makeInstance(UrlBuilderService::class);
+        $returnUrl = (string) $renderingContext->getRequest()->getUri();
+
+        try {
+            $newContentUrl = $urlBuilderService->buildContainerNewContentUrl($pageId, $containerUid, $colPos, $returnUrl);
+        } catch (\Exception) {
+            return '';
+        }
+
+        $buttonLabel = (null === $columnName || '' === $columnName)
+            ? self::translate('column.createContent', 'Create new content')
+            : $columnName;
+
+        return sprintf(
+            '<div class="frontend-edit__container-column-buttons" data-colpos="%d" data-container-parent="%d" hidden>'
+            .'<a href="%s" class="frontend-edit__new-content-link frontend-edit__open-modal">'
+            .'<div class="frontend-edit__new-content-button">'
+            .'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">'
+            .'<line x1="12" y1="5" x2="12" y2="19"/>'
+            .'<line x1="5" y1="12" x2="19" y2="12"/>'
+            .'</svg>'
+            .'<span>%s</span>'
+            .'</div>'
+            .'</a>'
+            .'</div>',
+            $colPos,
+            $containerUid,
+            htmlspecialchars($newContentUrl),
+            htmlspecialchars($buttonLabel),
+        );
+    }
+
+    private static function translate(string $key, string $fallback): string
+    {
+        try {
+            if (isset($GLOBALS['BE_USER']) && null !== $GLOBALS['BE_USER']) {
+                $languageService = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+                    ->createFromUserPreferences($GLOBALS['BE_USER']);
+
+                return $languageService->sL(
+                    'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:'.$key,
+                ) ?: $fallback;
+            }
+        } catch (\Throwable) {
+        }
+
+        return $fallback;
+    }
+}

--- a/Classes/ViewHelpers/SingleColumnButtonViewHelper.php
+++ b/Classes/ViewHelpers/SingleColumnButtonViewHelper.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\ViewHelpers;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Service\Content\BackendLayoutService;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+
+use function htmlspecialchars;
+use function sprintf;
+
+/**
+ * Renders a "Create new content" button for an empty page column.
+ *
+ * Only visible when:
+ * - A backend user is logged in
+ * - Frontend editing is not disabled by the user
+ * - The column exists in the backend layout and has no content
+ *
+ * Usage in Fluid templates (e.g. Page templates):
+ *
+ *     <!-- Register namespace (or use ext_localconf.php registration) -->
+ *     {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+ *
+ *     <!-- Show button for colPos 0 when empty -->
+ *     <xfe:singleColumnButton pageId="{data.uid}" colPos="0" columnName="Main Content" />
+ *
+ *     <!-- With language support -->
+ *     <xfe:singleColumnButton pageId="{data.uid}" colPos="1" columnName="Sidebar" languageUid="{data.sys_language_uid}" />
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class SingleColumnButtonViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('pageId', 'int', 'The page ID', true);
+        $this->registerArgument('colPos', 'int', 'The column position (colPos)', true);
+        $this->registerArgument('columnName', 'string', 'Column header label', false, null);
+        $this->registerArgument('languageUid', 'int', 'The language UID', false, 0);
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext,
+    ): string {
+        // Require authenticated backend user
+        $context = GeneralUtility::makeInstance(Context::class);
+        if (!$context->getPropertyFromAspect('backend.user', 'isLoggedIn', false)) {
+            return '';
+        }
+
+        // Respect user-level disable toggle
+        if ($GLOBALS['BE_USER']->uc[Configuration::UC_KEY_DISABLED] ?? false) {
+            return '';
+        }
+
+        // Only render in frontend context
+        $request = $renderingContext->getRequest();
+        $requestUri = (string) $request->getUri();
+        if (str_contains($requestUri, '/typo3/')) {
+            return '';
+        }
+
+        $pageId = (int) $arguments['pageId'];
+        $colPos = (int) $arguments['colPos'];
+        $columnName = $arguments['columnName'];
+        $languageUid = (int) $arguments['languageUid'];
+
+        // Auto-detect language from context if not explicitly set
+        if (0 === $languageUid) {
+            try {
+                $context = GeneralUtility::makeInstance(Context::class);
+                $languageUid = (int) $context->getPropertyFromAspect('language', 'id', 0);
+            } catch (\Exception) {
+                // Fallback to 0
+            }
+        }
+
+        // Check if column exists and is empty
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $backendLayoutService = GeneralUtility::makeInstance(BackendLayoutService::class, $connectionPool);
+        $columns = $backendLayoutService->getColumnsForPage($pageId, $languageUid);
+
+        $columnExists = false;
+        foreach ($columns as $column) {
+            if ((int) $column['colPos'] === $colPos) {
+                $columnExists = true;
+                if ($column['contentCount'] > 0) {
+                    return ''; // Column has content — no button needed
+                }
+                // Use backend layout column name if not provided via argument
+                if (null === $columnName || '' === $columnName) {
+                    $columnName = $column['name'] ?? 'Column '.$colPos;
+                }
+                break;
+            }
+        }
+
+        if (!$columnExists) {
+            return '';
+        }
+
+        // Build the new content wizard URL
+        $urlBuilderService = GeneralUtility::makeInstance(UrlBuilderService::class);
+        $returnUrl = (string) $request->getUri();
+
+        try {
+            $newContentUrl = $urlBuilderService->buildNewContentInColumnUrl($pageId, $colPos, $returnUrl);
+        } catch (\Exception) {
+            return '';
+        }
+
+        $createContentLabel = self::translate('column.createContent', 'Create new content');
+
+        return sprintf(
+            '<div class="frontend-edit__column-section" data-colpos="%d" hidden>'
+            .'<div class="frontend-edit__column-header">'
+            .'<span class="frontend-edit__column-name">%s</span>'
+            .'</div>'
+            .'<div class="frontend-edit__column-buttons">'
+            .'<a href="%s" class="frontend-edit__column-btn frontend-edit__open-modal">'
+            .'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">'
+            .'<line x1="12" y1="5" x2="12" y2="19"/>'
+            .'<line x1="5" y1="12" x2="19" y2="12"/>'
+            .'</svg>'
+            .'<span>%s</span>'
+            .'</a>'
+            .'</div>'
+            .'</div>',
+            $colPos,
+            htmlspecialchars($columnName),
+            htmlspecialchars($newContentUrl),
+            htmlspecialchars($createContentLabel),
+        );
+    }
+
+    private static function translate(string $key, string $fallback): string
+    {
+        try {
+            if (isset($GLOBALS['BE_USER']) && null !== $GLOBALS['BE_USER']) {
+                $languageService = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+                    ->createFromUserPreferences($GLOBALS['BE_USER']);
+
+                return $languageService->sL(
+                    'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:'.$key,
+                ) ?: $fallback;
+            }
+        } catch (\Throwable) {
+        }
+
+        return $fallback;
+    }
+}

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -79,6 +79,10 @@
 				<source />
 				<target>Seitenoptionen</target>
 			</trans-unit>
+			<trans-unit id="column.createContent">
+				<source />
+				<target>Neuen Inhalt erstellen</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -60,6 +60,9 @@
 			<trans-unit id="tooltip.pageOptions">
 				<source>Page options</source>
 			</trans-unit>
+			<trans-unit id="column.createContent">
+				<source>Create new content</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
- Add SingleColumnButtonViewHelper for empty page columns (auto-detects backend layout, checks content count)
- Add ContainerColumnButtonViewHelper for empty container columns (tabs, accordions, multi-column containers)
- Add BackendLayoutService for querying column info and content counts
- Add column.createContent translation (EN/DE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Create new content" buttons for empty frontend content columns, enabling editors to quickly add content to available page sections
  * Support for single-column and multi-column (container) layouts
  * Includes localization support with English and German UI labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->