### PR TITLE
feat: add empty column detection with "Create new content" buttons

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementMenuGenerator;
 
 use function is_array;
@@ -38,6 +39,7 @@ readonly class AjaxController
     public function __construct(
         private ContentElementMenuGenerator $contentElementMenuGenerator,
         private BackendUserService $backendUserService,
+        private EmptyColumnService $emptyColumnService,
     ) {}
 
     /**
@@ -122,7 +124,12 @@ readonly class AjaxController
 
         $dropdown = $this->contentElementMenuGenerator->getDropdown($pid, $returnUrl, $languageUid, $request, $data);
 
-        return new JsonResponse(mb_convert_encoding($dropdown, 'UTF-8'));
+        $emptyColumns = $this->emptyColumnService->getEmptyColumns($pid, $languageUid, $returnUrl, $data);
+
+        return new JsonResponse(mb_convert_encoding([
+            'contentElements' => $dropdown,
+            'emptyColumns' => $emptyColumns,
+        ], 'UTF-8'));
     }
 
     protected function getBackendUser(): ?BackendUserAuthentication

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Service\Content;
+
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\View\BackendLayoutView;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Detects empty backend layout columns and builds new-content URLs.
+ *
+ * Called by AjaxController to extend the editInformation response.
+ * The frontend JS matches the result against [data-xfe-colpos] DOM
+ * markers and injects "Create new content" buttons client-side.
+ *
+ * @license GPL-2.0-or-later
+ */
+final readonly class EmptyColumnService
+{
+    private bool $containerFieldExists;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private UriBuilder $uriBuilder,
+        private LanguageServiceFactory $languageServiceFactory,
+    ) {
+        $this->containerFieldExists = $this->detectContainerField();
+    }
+
+    /**
+     * @param int           $pid         Page UID
+     * @param int           $languageUid sys_language_uid
+     * @param string        $returnUrl   Frontend URL to return to after editing
+     * @param array<mixed>  $requestData Raw request data from the AJAX call
+     *
+     * @return list<array{colPos: int, newContentUrl: string, name?: string, containerUid?: int}>
+     */
+    public function getEmptyColumns(int $pid, int $languageUid, string $returnUrl, array $requestData = []): array
+    {
+        return [
+            ...$this->findEmptyPageColumns($pid, $languageUid, $returnUrl),
+            ...$this->findEmptyContainerColumns($pid, $languageUid, $returnUrl, $this->extractContainerMarkers($requestData)),
+        ];
+    }
+
+    /**
+     * @return list<array{colPos: int, name: string, newContentUrl: string}>
+     */
+    private function findEmptyPageColumns(int $pid, int $languageUid, string $returnUrl): array
+    {
+        $result = [];
+
+        foreach ($this->resolvePageColumns($pid) as $column) {
+            $colPos = (int) $column['colPos'];
+            if (!$this->isPageColumnEmpty($pid, $colPos, $languageUid)) {
+                continue;
+            }
+            try {
+                $result[] = [
+                    'colPos' => $colPos,
+                    'name' => $column['name'],
+                    'newContentUrl' => $this->buildNewContentUrl($pid, $colPos, $languageUid, $returnUrl),
+                ];
+            } catch (RouteNotFoundException) {
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int, int[]> $containerMarkers
+     *
+     * @return list<array{colPos: int, containerUid: int, newContentUrl: string}>
+     */
+    private function findEmptyContainerColumns(int $pid, int $languageUid, string $returnUrl, array $containerMarkers): array
+    {
+        if (!$this->containerFieldExists || [] === $containerMarkers) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($containerMarkers as $containerUid => $colPositions) {
+            $containerUid = (int) $containerUid;
+            if ($containerUid <= 0) {
+                continue;
+            }
+            foreach ($colPositions as $colPos) {
+                $colPos = (int) $colPos;
+                if (!$this->isContainerColumnEmpty($containerUid, $colPos, $languageUid)) {
+                    continue;
+                }
+                try {
+                    $result[] = [
+                        'colPos' => $colPos,
+                        'containerUid' => $containerUid,
+                        'newContentUrl' => $this->buildNewContentUrl($pid, $colPos, $languageUid, $returnUrl, $containerUid),
+                    ];
+                } catch (RouteNotFoundException) {
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<array{colPos: int, name: string}>
+     */
+    private function resolvePageColumns(int $pid): array
+    {
+        $default = [['colPos' => 0, 'name' => 'Content']];
+
+        try {
+            $backendLayoutView = GeneralUtility::makeInstance(BackendLayoutView::class);
+            $backendLayout = $backendLayoutView->getBackendLayoutForPage($pid);
+
+            if (null === $backendLayout) {
+                return $default;
+            }
+
+            $columns = $this->extractColumnsFromStructure($backendLayout->getStructure());
+
+            if ([] === $columns) {
+                foreach ($backendLayout->getUsedColumns() as $colPos => $name) {
+                    $columns[] = [
+                        'colPos' => (int) $colPos,
+                        'name' => $this->translateLabel($name ?: 'Column '.$colPos),
+                    ];
+                }
+            }
+
+            return [] !== $columns ? $columns : $default;
+        } catch (\Throwable) {
+            return $default;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $structure
+     *
+     * @return list<array{colPos: int, name: string}>
+     */
+    private function extractColumnsFromStructure(array $structure): array
+    {
+        $columns = [];
+
+        foreach ($structure['__config']['backend_layout.']['rows.'] ?? [] as $row) {
+            foreach ($row['columns.'] ?? [] as $column) {
+                if (!isset($column['colPos'])) {
+                    continue;
+                }
+                $columns[] = [
+                    'colPos' => (int) $column['colPos'],
+                    'name' => $this->translateLabel($column['name'] ?? 'Column '.$column['colPos']),
+                ];
+            }
+        }
+
+        return $columns;
+    }
+
+    private function isPageColumnEmpty(int $pid, int $colPos, int $languageUid): bool
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+
+        $conditions = [
+            $qb->expr()->eq('pid', $qb->createNamedParameter($pid, Connection::PARAM_INT)),
+            $qb->expr()->eq('colPos', $qb->createNamedParameter($colPos, Connection::PARAM_INT)),
+            $qb->expr()->in('sys_language_uid', [
+                $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
+                $qb->createNamedParameter(-1, Connection::PARAM_INT),
+            ]),
+            $qb->expr()->eq('deleted', 0),
+        ];
+
+        if ($this->containerFieldExists) {
+            $conditions[] = $qb->expr()->eq('tx_container_parent', 0);
+        }
+
+        return 0 === (int) $qb->count('uid')->from('tt_content')->where(...$conditions)->executeQuery()->fetchOne();
+    }
+
+    private function isContainerColumnEmpty(int $containerUid, int $colPos, int $languageUid): bool
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+
+        return 0 === (int) $qb
+            ->count('uid')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter($containerUid, Connection::PARAM_INT)),
+                $qb->expr()->eq('colPos', $qb->createNamedParameter($colPos, Connection::PARAM_INT)),
+                $qb->expr()->in('sys_language_uid', [
+                    $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
+                    $qb->createNamedParameter(-1, Connection::PARAM_INT),
+                ]),
+                $qb->expr()->eq('deleted', 0),
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    /**
+     * @throws RouteNotFoundException
+     */
+    private function buildNewContentUrl(int $pid, int $colPos, int $languageUid, string $returnUrl, ?int $containerUid = null): string
+    {
+        $defVals = [
+            'colPos' => $colPos,
+            'sys_language_uid' => $languageUid,
+        ];
+
+        if (null !== $containerUid) {
+            $defVals['tx_container_parent'] = $containerUid;
+        }
+
+        return $this->uriBuilder->buildUriFromRoute(
+            'record_edit',
+            [
+                'edit' => ['tt_content' => [$pid => 'new']],
+                'defVals' => ['tt_content' => $defVals],
+                'returnUrl' => $returnUrl,
+            ],
+        )->__toString();
+    }
+
+    /**
+     * @param array<mixed> $requestData
+     *
+     * @return array<int, int[]>
+     */
+    private function extractContainerMarkers(array $requestData): array
+    {
+        $markers = [];
+
+        foreach ((array) ($requestData['_containerMarkers'] ?? []) as $uid => $colPositions) {
+            $uid = (int) $uid;
+            if ($uid > 0 && is_array($colPositions)) {
+                $markers[$uid] = array_filter(array_map('intval', $colPositions));
+            }
+        }
+
+        return $markers;
+    }
+
+    private function detectContainerField(): bool
+    {
+        try {
+            $columns = $this->connectionPool
+                ->getConnectionForTable('tt_content')
+                ->createSchemaManager()
+                ->listTableColumns('tt_content');
+
+            return isset($columns['tx_container_parent']);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    private function translateLabel(string $label): string
+    {
+        if (!str_starts_with($label, 'LLL:')) {
+            return $label;
+        }
+
+        try {
+            if (isset($GLOBALS['BE_USER'])) {
+                return $this->languageServiceFactory
+                    ->createFromUserPreferences($GLOBALS['BE_USER'])
+                    ->sL($label) ?: $label;
+            }
+        } catch (\Throwable) {
+        }
+
+        return $label;
+    }
+}

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -13,22 +13,21 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Service\Content;
 
+use Throwable;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\View\BackendLayoutView;
-use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+use function is_array;
+
 /**
- * Detects empty backend layout columns and builds new-content URLs.
- *
- * Called by AjaxController to extend the editInformation response.
- * The frontend JS matches the result against [data-xfe-colpos] DOM
- * markers and injects "Create new content" buttons client-side.
+ * EmptyColumnService.
  *
  * @license GPL-2.0-or-later
+ * @author Konrad Michalik <hej@konradmichalik.dev>
  */
 final readonly class EmptyColumnService
 {
@@ -43,10 +42,10 @@ final readonly class EmptyColumnService
     }
 
     /**
-     * @param int           $pid         Page UID
-     * @param int           $languageUid sys_language_uid
-     * @param string        $returnUrl   Frontend URL to return to after editing
-     * @param array<mixed>  $requestData Raw request data from the AJAX call
+     * @param int          $pid         Page UID
+     * @param int          $languageUid sys_language_uid
+     * @param string       $returnUrl   Frontend URL to return to after editing
+     * @param array<mixed> $requestData Raw request data from the AJAX call
      *
      * @return list<array{colPos: int, newContentUrl: string, name?: string, containerUid?: int}>
      */
@@ -66,7 +65,7 @@ final readonly class EmptyColumnService
         $result = [];
 
         foreach ($this->resolvePageColumns($pid) as $column) {
-            $colPos = (int) $column['colPos'];
+            $colPos = $column['colPos'];
             if (!$this->isPageColumnEmpty($pid, $colPos, $languageUid)) {
                 continue;
             }
@@ -97,12 +96,10 @@ final readonly class EmptyColumnService
         $result = [];
 
         foreach ($containerMarkers as $containerUid => $colPositions) {
-            $containerUid = (int) $containerUid;
             if ($containerUid <= 0) {
                 continue;
             }
             foreach ($colPositions as $colPos) {
-                $colPos = (int) $colPos;
                 if (!$this->isContainerColumnEmpty($containerUid, $colPos, $languageUid)) {
                     continue;
                 }
@@ -130,11 +127,6 @@ final readonly class EmptyColumnService
         try {
             $backendLayoutView = GeneralUtility::makeInstance(BackendLayoutView::class);
             $backendLayout = $backendLayoutView->getBackendLayoutForPage($pid);
-
-            if (null === $backendLayout) {
-                return $default;
-            }
-
             $columns = $this->extractColumnsFromStructure($backendLayout->getStructure());
 
             if ([] === $columns) {
@@ -147,7 +139,7 @@ final readonly class EmptyColumnService
             }
 
             return [] !== $columns ? $columns : $default;
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return $default;
         }
     }
@@ -255,7 +247,7 @@ final readonly class EmptyColumnService
         foreach ((array) ($requestData['_containerMarkers'] ?? []) as $uid => $colPositions) {
             $uid = (int) $uid;
             if ($uid > 0 && is_array($colPositions)) {
-                $markers[$uid] = array_filter(array_map('intval', $colPositions));
+                $markers[$uid] = array_filter(array_map(intval(...), $colPositions), static fn (int $v): bool => $v > 0);
             }
         }
 
@@ -271,7 +263,7 @@ final readonly class EmptyColumnService
                 ->listTableColumns('tt_content');
 
             return isset($columns['tx_container_parent']);
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return false;
         }
     }
@@ -288,7 +280,7 @@ final readonly class EmptyColumnService
                     ->createFromUserPreferences($GLOBALS['BE_USER'])
                     ->sL($label) ?: $label;
             }
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
 
         return $label;

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -187,11 +187,12 @@ final readonly class EmptyColumnService
                 $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
                 $qb->createNamedParameter(-1, Connection::PARAM_INT),
             ]),
-            $qb->expr()->eq('deleted', 0),
+            $qb->expr()->eq('deleted', $qb->createNamedParameter(0, Connection::PARAM_INT)),
+            $qb->expr()->eq('hidden', $qb->createNamedParameter(0, Connection::PARAM_INT)),
         ];
 
         if ($this->containerFieldExists) {
-            $conditions[] = $qb->expr()->eq('tx_container_parent', 0);
+            $conditions[] = $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter(0, Connection::PARAM_INT));
         }
 
         return 0 === (int) $qb->count('uid')->from('tt_content')->where(...$conditions)->executeQuery()->fetchOne();
@@ -211,7 +212,8 @@ final readonly class EmptyColumnService
                     $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
                     $qb->createNamedParameter(-1, Connection::PARAM_INT),
                 ]),
-                $qb->expr()->eq('deleted', 0),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0, Connection::PARAM_INT)),
+                $qb->expr()->eq('hidden', $qb->createNamedParameter(0, Connection::PARAM_INT)),
             )
             ->executeQuery()
             ->fetchOne();

--- a/Classes/ViewHelpers/ColumnTargetViewHelper.php
+++ b/Classes/ViewHelpers/ColumnTargetViewHelper.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+
+use function sprintf;
+
+/**
+ * Renders a lightweight DOM marker for empty column detection.
+ *
+ * Outputs a hidden `<div>` with `data-xfe-colpos` (and optionally
+ * `data-xfe-container`) attributes. The actual "Create new content"
+ * button is injected client-side by frontend_edit.js after it receives
+ * empty-column data from the AJAX endpoint.
+ *
+ * Only rendered when a backend user is logged in and frontend editing
+ * is allowed and not disabled.
+ *
+ * Usage:
+ *
+ *     {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+ *
+ *     <!-- Page column marker -->
+ *     <xfe:columnTarget colPos="0" />
+ *
+ *     <!-- Container column marker -->
+ *     <xfe:columnTarget colPos="201" containerUid="{data.uid}" />
+ *
+ * @license GPL-2.0-or-later
+ */
+class ColumnTargetViewHelper extends AbstractViewHelper
+{
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function __construct(
+        private readonly BackendUserService $backendUserService,
+    ) {}
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('colPos', 'int', 'The column position (colPos) from the backend layout', true);
+        $this->registerArgument('containerUid', 'int', 'The UID of the parent container element (for container columns)', false);
+    }
+
+    public function render(): string
+    {
+        if (!$this->backendUserService->isFrontendEditAllowed()
+            || $this->backendUserService->isFrontendEditDisabled()
+        ) {
+            return '';
+        }
+
+        $colPos = (int) $this->arguments['colPos'];
+        $containerUid = $this->arguments['containerUid'] ?? null;
+
+        $containerAttr = null !== $containerUid
+            ? sprintf(' data-xfe-container="%d"', (int) $containerUid)
+            : '';
+
+        return sprintf(
+            '<div data-xfe-colpos="%d"%s hidden></div>',
+            $colPos,
+            $containerAttr,
+        );
+    }
+}

--- a/Classes/ViewHelpers/ColumnTargetViewHelper.php
+++ b/Classes/ViewHelpers/ColumnTargetViewHelper.php
@@ -19,27 +19,10 @@ use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use function sprintf;
 
 /**
- * Renders a lightweight DOM marker for empty column detection.
- *
- * Outputs a hidden `<div>` with `data-xfe-colpos` (and optionally
- * `data-xfe-container`) attributes. The actual "Create new content"
- * button is injected client-side by frontend_edit.js after it receives
- * empty-column data from the AJAX endpoint.
- *
- * Only rendered when a backend user is logged in and frontend editing
- * is allowed and not disabled.
- *
- * Usage:
- *
- *     {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
- *
- *     <!-- Page column marker -->
- *     <xfe:columnTarget colPos="0" />
- *
- *     <!-- Container column marker -->
- *     <xfe:columnTarget colPos="201" containerUid="{data.uid}" />
+ * ColumnTargetViewHelper.
  *
  * @license GPL-2.0-or-later
+ * @author Konrad Michalik <hej@konradmichalik.dev>
  */
 class ColumnTargetViewHelper extends AbstractViewHelper
 {

--- a/Documentation/DeveloperCorner/EmptyColumns.rst
+++ b/Documentation/DeveloperCorner/EmptyColumns.rst
@@ -1,0 +1,126 @@
+..  include:: /Includes.rst.txt
+
+..  _empty-columns:
+
+=============
+Empty Columns
+=============
+
+The extension can display "Create new content" buttons for empty columns directly in the frontend. This allows editors to add content without switching to the TYPO3 backend.
+
+It works in two steps:
+
+1. The integrator places a lightweight marker in their Fluid templates
+2. The extension detects empty columns via AJAX and injects the buttons client-side
+
+ColumnTargetViewHelper
+======================
+
+The :php:`ColumnTargetViewHelper` renders a hidden :html:`<div>` element as a DOM marker. No content, no styling, no logic — just a marker that the JavaScript picks up after the page loads.
+
+Register the namespace in your Fluid template:
+
+..  code-block:: html
+
+    {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+
+Or use the XML namespace syntax:
+
+..  code-block:: html
+
+    <html xmlns:xfe="http://typo3.org/ns/Xima/XimaTypo3FrontendEdit/ViewHelpers"
+          data-namespace-typo3-fluid="true">
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - ``colPos``
+     - int
+     - yes
+     - The column position from the backend layout
+   * - ``containerUid``
+     - int
+     - no
+     - The UID of the parent container element (for b13/container columns)
+
+
+Page columns
+------------
+
+Place the marker after the content rendering for each column:
+
+..  code-block:: html
+    :caption: Page template (e.g. Default.html)
+
+    {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+
+    <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}" />
+    <xfe:columnTarget colPos="0" />
+
+    <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1'}" />
+    <xfe:columnTarget colPos="1" />
+
+When colPos 0 or 1 is empty, a "+" button appears at the marker position. Clicking it opens the TYPO3 record editor to create a new content element in that column.
+
+When the column has content, the marker stays hidden and has no effect on the page.
+
+Container columns
+-----------------
+
+For container elements (e.g. two-column layouts, tabs, accordions using `b13/container <https://github.com/b13/container>`__), add the ``containerUid`` argument:
+
+..  code-block:: html
+    :caption: Container template (e.g. TwoColumn.html)
+
+    {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+
+    <div class="column-left">
+        <f:for each="{children_201}" as="record">
+            <f:format.raw>{record.renderedContent}</f:format.raw>
+        </f:for>
+        <xfe:columnTarget colPos="201" containerUid="{data.uid}" />
+    </div>
+
+    <div class="column-right">
+        <f:for each="{children_202}" as="record">
+            <f:format.raw>{record.renderedContent}</f:format.raw>
+        </f:for>
+        <xfe:columnTarget colPos="202" containerUid="{data.uid}" />
+    </div>
+
+..  important::
+
+    Make sure the marker is always rendered, even when the container column is empty. If your template wraps the column content in a condition like ``<f:if condition="{children_201}">``, the marker will not be in the DOM when the column is empty and the button cannot appear.
+
+
+How it works
+============
+
+1. The ViewHelper renders :html:`<div data-xfe-colpos="0" hidden></div>` (invisible, no layout impact)
+2. The extension's JavaScript scans the page for these markers after loading
+3. An AJAX request to the backend checks which columns are empty
+4. For each empty column that has a matching marker, a "+" button is injected
+5. The button opens the TYPO3 record editor with the correct colPos pre-filled
+
+Container support requires the `b13/container <https://github.com/b13/container>`__ extension. The service automatically detects whether it is installed. Without it, only page columns are supported and container markers are silently ignored.
+
+
+..  note::
+
+    The marker is only rendered when a backend user is logged in and frontend editing is enabled. For regular frontend visitors, nothing is output.
+
+
+..  seealso::
+
+    View the sources on GitHub:
+
+    -   `ColumnTargetViewHelper <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/ViewHelpers/ColumnTargetViewHelper.php>`__
+    -   `EmptyColumnService <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/Service/Content/EmptyColumnService.php>`__

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -6,10 +6,11 @@
 Developer corner
 ================
 
-Two opportunities exist to extend the Edit Menu with custom entries:
+Three opportunities exist to extend the Edit Menu with custom entries:
 
 - Use an :ref:`event <events>` to modify the Edit Menu directly
 - Use a :ref:`viewhelper <data-attributes>` to extend the Edit Menu with data entries
+- Use :ref:`empty column markers <empty-columns>` to add "Create new content" buttons for empty columns
 
 Additionally, you can provide a :ref:`custom css <custom-styling>` file to adjust the styling.
 
@@ -18,4 +19,5 @@ Additionally, you can provide a :ref:`custom css <custom-styling>` file to adjus
 
     Events
     DataAttributes
+    EmptyColumns
     CustomStyling

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -107,6 +107,10 @@
 				<source />
 				<target>Der Datensatz konnte nicht gelöscht werden</target>
 			</trans-unit>
+			<trans-unit id="column.createContent">
+				<source />
+				<target>Neuen Inhalt erstellen</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -81,6 +81,9 @@
 			<trans-unit id="delete.error">
 				<source>Could not delete the record</source>
 			</trans-unit>
+			<trans-unit id="column.createContent">
+				<source>Create new content</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1010,6 +1010,14 @@
     color: var(--xfe-text-primary);
 }
 
+.frontend-edit__column-btn:focus-visible {
+    background: var(--xfe-bg-hover);
+    border-color: var(--xfe-outline-color);
+    color: var(--xfe-text-primary);
+    outline: 2px solid var(--xfe-outline-color);
+    outline-offset: 2px;
+}
+
 .frontend-edit__column-btn-icon {
     display: flex;
     align-items: center;

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -968,6 +968,64 @@
 }
 
 /* ==========================================================================
+   Empty Column Buttons
+   Injected by EmptyColumnRenderer into [data-xfe-colpos] markers.
+   Reveal hidden markers — CSS only loads for authenticated BE users.
+   ========================================================================== */
+
+[data-xfe-colpos][hidden] {
+    display: none !important;
+}
+
+[data-xfe-colpos]:not([hidden]) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 8px;
+    outline: 1px dashed var(--xfe-outline-color);
+}
+
+.frontend-edit__column-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 6px 8px;
+    color: var(--xfe-text-primary);
+    text-decoration: none;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1;
+    transition: all 0.2s ease;
+    border-radius: 4px;
+    border: 1px solid var(--xfe-border-color);
+    background: var(--xfe-bg-primary);
+}
+
+.frontend-edit__column-btn:hover {
+    background: var(--xfe-bg-hover);
+    border-color: var(--xfe-outline-color);
+    color: var(--xfe-text-primary);
+}
+
+.frontend-edit__column-btn-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.frontend-edit__column-btn-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.frontend-edit__column-btn-label {
+    font-weight: 400;
+}
+
+/* ==========================================================================
    Contextual Edit Sidebar (Experimental)
    ========================================================================== */
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -960,6 +960,33 @@
       // Add UIDs array for backend to fetch content elements
       dataItems._uids = Array.from(allUids).sort((a, b) => a - b);
 
+      // Scan for empty column markers (placed by integrator in Fluid templates)
+      // Collect per-container colPos info so the backend knows which columns to check
+      const containerMarkers = {};
+      const pageColPositions = [];
+      document.querySelectorAll('[data-xfe-colpos]').forEach(marker => {
+        const colPos = parseInt(marker.dataset.xfeColpos, 10);
+        const containerUid = marker.dataset.xfeContainer;
+        if (containerUid) {
+          const uid = parseInt(containerUid, 10);
+          if (uid > 0) {
+            if (!containerMarkers[uid]) containerMarkers[uid] = [];
+            containerMarkers[uid].push(colPos);
+          }
+        } else {
+          pageColPositions.push(colPos);
+        }
+      });
+
+      if (Object.keys(containerMarkers).length > 0) {
+        dataItems._containerMarkers = containerMarkers;
+        Logger.log(`Found container markers`, containerMarkers);
+      }
+      if (pageColPositions.length > 0) {
+        dataItems._pageColPositions = pageColPositions;
+        Logger.log(`Found page column markers`, pageColPositions);
+      }
+
       Logger.log(`Collected ${allUids.size} unique content element UIDs for backend request`, {
         uids: dataItems._uids
       });
@@ -999,9 +1026,16 @@
         }
 
         const data = await response.json();
-        Logger.log(`Backend response received with ${Object.keys(data).length} content element(s)`);
 
-        return data;
+        // Handle wrapped response { contentElements, emptyColumns }
+        if (data.contentElements !== undefined) {
+          Logger.log(`Backend response received with ${Object.keys(data.contentElements).length} content element(s) and ${(data.emptyColumns || []).length} empty column(s)`);
+          return data;
+        }
+
+        // Fallback for legacy response (plain content elements object)
+        Logger.log(`Backend response received with ${Object.keys(data).length} content element(s)`);
+        return { contentElements: data, emptyColumns: [] };
       } catch (error) {
         Notification.show({ title: 'Frontend Edit', message: 'Failed to load edit information', severity: 'error' });
         Logger.log('Failed to fetch content elements', { error: error.message }, 'error');
@@ -1153,6 +1187,62 @@
   };
 
   /**
+   * Empty Column Renderer - Matches AJAX emptyColumns data against
+   * [data-xfe-colpos] markers placed by the integrator in Fluid templates
+   * and injects "+" buttons client-side.
+   */
+  const EmptyColumnRenderer = {
+    render(emptyColumns) {
+      if (!emptyColumns || emptyColumns.length === 0) return;
+
+      Logger.log(`Processing ${emptyColumns.length} empty column(s)`);
+      let rendered = 0;
+
+      emptyColumns.forEach(col => {
+        let selector = `[data-xfe-colpos="${col.colPos}"]`;
+        if (col.containerUid) {
+          selector += `[data-xfe-container="${col.containerUid}"]`;
+        }
+
+        const marker = document.querySelector(selector);
+        if (!marker) {
+          Logger.log(`No marker found for colPos ${col.colPos}` + (col.containerUid ? ` container ${col.containerUid}` : ''), null, 'warn');
+          return;
+        }
+
+        if (!col.newContentUrl || !UI.isValidUrl(col.newContentUrl)) {
+          Logger.log(`Invalid URL for colPos ${col.colPos}`, null, 'warn');
+          return;
+        }
+
+        const link = document.createElement('a');
+        link.href = col.newContentUrl;
+        link.className = 'frontend-edit__column-btn frontend-edit__open-modal';
+        link.setAttribute('aria-label', col.name || 'Create new content');
+
+        const icon = document.createElement('span');
+        icon.className = 'frontend-edit__column-btn-icon';
+        icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>';
+        link.appendChild(icon);
+
+        const label = document.createElement('span');
+        label.className = 'frontend-edit__column-btn-label';
+        label.textContent = col.name || 'Create new content';
+        link.appendChild(label);
+
+        marker.innerHTML = '';
+        marker.appendChild(link);
+        marker.hidden = false;
+
+        rendered++;
+        Logger.log(`Empty column button rendered for colPos ${col.colPos}`, { name: col.name, url: col.newContentUrl });
+      });
+
+      Logger.log(`Empty column rendering complete: ${rendered}/${emptyColumns.length} buttons placed`);
+    }
+  };
+
+  /**
    * Main Application
    */
   const FrontendEdit = {
@@ -1202,9 +1292,10 @@
           OverlayManager.init();
 
           const dataItems = DataService.collectDataItems();
-          const contentElements = await DataService.fetchContentElements(dataItems);
+          const response = await DataService.fetchContentElements(dataItems);
 
-          Renderer.render(contentElements);
+          Renderer.render(response.contentElements || {});
+          EmptyColumnRenderer.render(response.emptyColumns || []);
           Dropdown.setupGlobalHandler();
           DeleteHandler.init();
         }

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -966,6 +966,8 @@
       const pageColPositions = [];
       document.querySelectorAll('[data-xfe-colpos]').forEach(marker => {
         const colPos = parseInt(marker.dataset.xfeColpos, 10);
+        if (!Number.isFinite(colPos)) return;
+
         const containerUid = marker.dataset.xfeContainer;
         if (containerUid) {
           const uid = parseInt(containerUid, 10);
@@ -1217,7 +1219,7 @@
 
         const link = document.createElement('a');
         link.href = col.newContentUrl;
-        link.className = 'frontend-edit__column-btn frontend-edit__open-modal';
+        link.className = 'frontend-edit__column-btn';
         link.setAttribute('aria-label', col.name || 'Create new content');
 
         const icon = document.createElement('span');


### PR DESCRIPTION
- Add ColumnTargetViewHelper as lightweight DOM marker for Fluid templates
- Add EmptyColumnService to detect empty page and container columns
- Extend AjaxController response with emptyColumn alongside contentElements
- Add EmptyColumnRenderer in frontend_edit.js to inject "+" buttons client-side
- Add CSS styles using --xfe-* theme variables light/dark/auto support
- Add column.createContent translations for EN and DE
- Container support is optional via b13/container schema detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend displays hidden markers and “Create new content” (“+”) buttons for empty page and container columns; editors can add content inline.
  * Client now requests and renders both existing content and available empty-column actions.

* **Style**
  * New UI styles for column markers and create-button visuals, including hover and focus states.

* **Documentation**
  * Added developer docs explaining how to enable empty-column markers and behavior.
  * Added English and German labels for the create-content action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->