### PR TITLE
chore: update PHP version constraint to >=8.2 in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
 	],
 	"ignorePaths": [
 		"package-lock.json"
-	]
+	],
+	"constraints": {
+		"php": ">=8.2"
+	}
 }


### PR DESCRIPTION
## Summary

- Add `constraints.php` setting (`>=8.2`) to `renovate.json` so Renovate respects the project's minimum PHP version when proposing dependency updates

## Changes

- `renovate.json` — Add `constraints` block with `php: ">=8.2"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system requirement constraints to require PHP 8.2 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->