### PR TITLE
chore(ci): trigger workflows on pull_request instead of all pushes

### DIFF
--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -2,7 +2,8 @@ name: CGL
 on:
   push:
     branches:
-      - '**'
+      - main
+  pull_request: ~
 
 jobs:
   cgl:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,8 @@ name: Tests
 on:
   push:
     branches:
-      - '**'
+      - main
+  pull_request: ~
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary

- Replace `push` on all branches with `push` on `main` only + `pull_request` trigger
- Enables CI checks for external PRs (forks)
- Avoids duplicate workflow runs on internal PRs

## Changes

- `.github/workflows/cgl.yml` — Switch trigger to `push: main` + `pull_request`
- `.github/workflows/tests.yml` — Switch trigger to `push: main` + `pull_request`