### PR TITLE
chore(ci): update TYPO3 test matrix to 14.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,5 +10,5 @@ jobs:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests.yml@main
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
-      typo3-versions: '["13.4", "14.2"]'
+      typo3-versions: '["13.4", "14.3"]'
       dependencies: '["highest", "lowest"]'


### PR DESCRIPTION
## Summary

- Update TYPO3 version in CI test matrix from 14.2 to 14.3

## Changes

- `.github/workflows/tests.yml` - Bump TYPO3 test version to 14.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration to support the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->