### PR TITLE
docs: document v2.3 inline editing (iframe modal + sidebar)

### DIFF
--- a/Documentation/Configuration/SiteSettings.rst
+++ b/Documentation/Configuration/SiteSettings.rst
@@ -122,7 +122,9 @@ Appearance Settings
     ..  note::
 
         This feature is **experimental** and requires **TYPO3 v14.2+**.
-        It has no effect on TYPO3 v13 or earlier v14 versions.
+        It has no effect on TYPO3 v13 or earlier v14 versions, where the
+        extension uses an experimental slide-in iframe modal for inline
+        editing instead (enabled automatically, no configuration needed).
 
     Opens content element and page property edit forms in a sidebar panel directly in the
     frontend instead of navigating to the backend. Uses TYPO3's ``record_edit_contextual``

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -29,11 +29,11 @@ Features
 - Dark/Light Mode - Automatic or manual color scheme selection
 - Configurable Position - 12 toolbar positions available
 - :ref:`Save & Close <extconf-enableSaveAndCloseButton>` - Quick return to frontend after editing
-- :ref:`Contextual Editing Sidebar <contextual-editing>` *(experimental)* - Edit content directly in a sidebar panel without leaving the frontend (TYPO3 v14.2+)
+- :ref:`Inline Editing <contextual-editing>` *(experimental)* - Edit content directly in the frontend without navigating to the backend (TYPO3 v13: iframe modal, TYPO3 v14.2+: contextual sidebar)
 
 ..  versionadded:: 2.2.0
 
-    **Contextual Editing Sidebar** — A new experimental feature that allows editors
+    **Contextual Editing Sidebar** — An experimental feature that allows editors
     to edit content elements and page properties in a sidebar panel directly in the
     frontend. Leverages TYPO3 v14.2's ``record_edit_contextual`` route.
     See :ref:`contextual-editing` for details.
@@ -41,6 +41,13 @@ Features
     ..  figure:: /Images/sidebar.jpg
         :alt: Contextual editing sidebar
         :class: with-shadow
+
+..  versionadded:: 2.3.0
+
+    **Iframe Modal Editor** — An experimental slide-in iframe modal that brings
+    inline editing to TYPO3 v13. Opens the backend edit form in a panel directly
+    in the frontend — no configuration required.
+    See :ref:`contextual-editing` for details.
 
 ..  note::
     This is **not** a further development of the "original" extension `frontend_editing <https://extensions.typo3.org/extension/frontend_editing>`_. It is similar in some ways to the realisation of the `feedit <https://extensions.typo3.org/extension/feedit>`_ extension. This extension is an independent implementation with a different approach. See :ref:`Delineation <delineation>` for a detailed comparison with related extensions like `visual_editor <https://github.com/FriendsOfTYPO3/visual_editor>`_ and `content_preview <https://github.com/T3-UX/content_preview>`_.

--- a/Documentation/Usage/ContextualEditing.rst
+++ b/Documentation/Usage/ContextualEditing.rst
@@ -8,11 +8,17 @@ Contextual Editing (Sidebar)
 
 ..  versionadded:: 2.2.0
 
+..  versionchanged:: 2.3.0
+    On TYPO3 v13, an iframe modal editor is now used automatically — no
+    configuration required. The previous fallback (navigating to the backend)
+    no longer applies.
+
 ..  note::
 
-    This feature is **experimental** and requires **TYPO3 v14.2+**.
-    On TYPO3 v13 or earlier v14 versions, the extension falls back to its
-    standard behavior (navigating to the backend for editing).
+    All inline editing features (sidebar and iframe modal) are
+    **experimental**. The contextual editing sidebar requires
+    **TYPO3 v14.2+**. On TYPO3 v13, the extension provides a slide-in
+    iframe modal as an alternative inline editing experience.
 
 The contextual editing sidebar allows editors to edit content elements and page
 properties directly in the frontend without leaving the page. A sidebar panel
@@ -93,11 +99,12 @@ intended context, some advanced form features may have limited functionality:
 Fallback Behavior
 =================
 
-The contextual editing feature degrades gracefully:
+The inline editing features degrade gracefully:
 
 - **TYPO3 v13 / v14.0-v14.1**: The ``record_edit_contextual`` route does not
-  exist. The extension falls back to standard URL navigation.
-- **Setting disabled**: When ``enableContextualEditing`` is ``false`` (default),
-  all edit links behave as before.
+  exist. The extension uses a slide-in iframe modal that loads the standard
+  backend edit form. This works automatically without any configuration.
+- **TYPO3 v14.2+ with setting disabled**: When ``enableContextualEditing`` is
+  ``false`` (default), all edit links navigate to the backend as before.
 - **JavaScript disabled**: The ``href`` attribute on edit links still points to
   the standard backend URL, ensuring basic functionality.

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -31,10 +31,10 @@ in the frontend for logged-in backend users.
         ..  card-footer::   :ref:`Learn more <toolbar>`
             :button-style: btn btn-secondary stretched-link
 
-    ..  card::  Contextual Editing (Sidebar)
+    ..  card::  Inline Editing (experimental)
 
-        Edit content elements and page properties in a sidebar panel without
-        leaving the frontend. Experimental, requires TYPO3 v14.2+.
+        Edit content elements directly in the frontend. Uses a contextual
+        sidebar on TYPO3 v14.2+ or a slide-in iframe modal on TYPO3 v13.
 
         ..  card-footer::   :ref:`Learn more <contextual-editing>`
             :button-style: btn btn-secondary stretched-link

--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ The extension has been developed to provide a simple and lightweight solution to
 - **Configurable Position** - 12 toolbar positions available
 - **Save & Close** - Quick return to frontend after editing
 - **UserTSconfig** - Disable frontend editing per user or user group
+- **Inline Editing** *(experimental)* - Edit content directly in the frontend (v13: iframe modal, v14.2+: contextual sidebar)
 
 > [!NOTE]
-> **New in v2.2.0 — Contextual Editing Sidebar** *(experimental)*
+> **New in v2.3.0 — Inline Editing on TYPO3 v13** *(experimental)*
 >
-> Edit content elements and page properties directly in a sidebar panel without leaving the frontend. Uses TYPO3 v14.2's `record_edit_contextual` route for a streamlined editing experience.
+> Content elements can now be edited in a slide-in iframe modal directly in the frontend — no backend navigation required. This works automatically on TYPO3 v13 without any configuration.
+>
+> On TYPO3 v14.2+, the contextual editing sidebar (introduced in v2.2.0) remains the recommended editing experience. Enable via Site Settings: `frontendEdit.enableContextualEditing: true`
 >
 > ![Contextual Editing Sidebar](./Documentation/Images/sidebar.jpg)
 >
-> Enable via Site Settings: `frontendEdit.enableContextualEditing: true`
-> — [Documentation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)
+> [Documentation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)
 
 ## 🔥 Installation
 


### PR DESCRIPTION
## Summary

- Update README, Introduction, Usage, and Site Settings docs to reflect v2.3 inline editing
- Document iframe modal editor for TYPO3 v13 (automatic, no configuration needed)
- Clarify contextual sidebar remains the recommended experience on TYPO3 v14.2+
- Mark all inline editing features as experimental

## Changed files

- `README.md` — feature list + note block updated
- `Documentation/Introduction/Index.rst` — `versionadded:: 2.3.0` block
- `Documentation/Usage/Index.rst` — card text updated
- `Documentation/Usage/ContextualEditing.rst` — fallback behavior rewritten
- `Documentation/Configuration/SiteSettings.rst` — v13 iframe note added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed frontend editing feature to "Inline Editing" with clarified TYPO3 version support.
  * Added TYPO3 v13 support featuring an automatic slide-in iframe modal editor (no configuration required).
  * TYPO3 v14.2+ continues to use the contextual sidebar for inline editing.
  * Updated documentation and README to reflect version-specific editing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->