### PR TITLE
feat: align v13 iframe modal and v14 sidebar behavior

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -679,12 +679,10 @@
     gap: 10px;
     pointer-events: none;
     max-width: 400px;
-    transition: right 0.3s ease-out, left 0.3s ease-out;
+    transition: none;
 }
 
 .frontend-edit__sidebar-active .frontend-edit__notification-container {
-    right: auto;
-    left: 20px;
     z-index: 10006;
 }
 
@@ -1187,11 +1185,15 @@
     right: 0;
     bottom: 0;
     z-index: 99999;
-    display: none;
+    pointer-events: none;
+    visibility: hidden;
+    transition: visibility 0s 0.3s;
 }
 
 .frontend-edit__modal--open {
-    display: block;
+    pointer-events: auto;
+    visibility: visible;
+    transition: visibility 0s;
 }
 
 .frontend-edit__modal-overlay {
@@ -1200,7 +1202,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(0, 0, 0, 0.3);
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -1214,14 +1216,16 @@
     top: 0;
     right: 0;
     bottom: 0;
-    width: 90%;
-    max-width: 1200px;
-    background: white;
-    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+    width: 800px;
+    max-width: calc(100dvw - 1.5rem);
+    background: #f5f5f5;
+    border-radius: 0.75rem 0 0 0.75rem;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
     transform: translateX(100%);
-    transition: transform 0.3s ease;
+    transition: transform 0.3s ease-out;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 .frontend-edit__modal--open .frontend-edit__modal-panel {
@@ -1229,13 +1233,7 @@
 }
 
 .frontend-edit__modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 16px;
-    background: #1e1e1e;
-    border-bottom: 1px solid #3a3a3a;
-    flex-shrink: 0;
+    display: none;
 }
 
 .frontend-edit__modal-title {
@@ -1284,15 +1282,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #1e1e1e;
+    background: #f5f5f5;
     z-index: 1;
 }
 
 .frontend-edit__modal-spinner {
     width: 32px;
     height: 32px;
-    border: 3px solid rgba(255, 255, 255, 0.15);
-    border-top-color: #fff;
+    border: 3px solid rgba(0, 0, 0, 0.1);
+    border-top-color: #666;
     border-radius: 50%;
     animation: frontend-edit-spin 0.7s linear infinite;
 }
@@ -1302,6 +1300,6 @@
     height: 100%;
     border: none;
     display: block;
-    background: #1e1e1e;
+    background: #f5f5f5;
     pointer-events: auto;
 }

--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -135,30 +135,32 @@
       });
 
       // Monitor iframe loads
-      this.iframe.addEventListener('load', function () {
-        if (!self.sidebar.classList.contains('frontend-edit__sidebar--open')) return;
-        self.injectBackendStubs();
-        self.loader.classList.remove('frontend-edit__sidebar-loader--visible');
-        self.iframe.classList.add('frontend-edit__sidebar-iframe--loaded');
-        try {
-          var iframeUrl = self.iframe.contentWindow && self.iframe.contentWindow.location.href;
-          if (iframeUrl) {
-            var params = new URL(iframeUrl).searchParams;
-            if (params.get('justSaved') === '1') {
-              self.hasSaved = true;
-              self.captureSavedRecordTitle();
-            }
-            if (params.get('closed') === '1') {
-              log('Close detected via iframe URL');
-              self.close();
-              return;
-            }
+      this.iframe.addEventListener('load', this._onIframeLoad.bind(this));
+    },
+
+    _onIframeLoad: function () {
+      if (!this.sidebar.classList.contains('frontend-edit__sidebar--open')) return;
+      this.injectBackendStubs();
+      this.loader.classList.remove('frontend-edit__sidebar-loader--visible');
+      this.iframe.classList.add('frontend-edit__sidebar-iframe--loaded');
+      try {
+        var iframeUrl = this.iframe.contentWindow && this.iframe.contentWindow.location.href;
+        if (iframeUrl) {
+          var params = new URL(iframeUrl).searchParams;
+          if (params.get('justSaved') === '1') {
+            this.hasSaved = true;
+            this.captureSavedRecordTitle();
           }
-          self.enhanceIframeUI();
-        } catch (e) {
-          // Cross-origin, access error, or invalid URL
+          if (params.get('closed') === '1') {
+            log('Close detected via iframe URL');
+            this.close();
+            return;
+          }
         }
-      });
+        this.enhanceIframeUI();
+      } catch (e) {
+        // Cross-origin, access error, or invalid URL
+      }
     },
 
     open: function (contextualUrl, uid, targetBlank) {
@@ -182,21 +184,35 @@
       clearTimeout(this.closeTimeout);
       this.sidebar.classList.remove('frontend-edit__sidebar--open');
       this.backdrop.classList.remove('frontend-edit__sidebar-backdrop--visible');
-      var self = this;
-      this.resetTimeout = setTimeout(function () {
-        if (!self.sidebar.classList.contains('frontend-edit__sidebar--open')) {
-          self.iframe.src = 'about:blank';
+
+      // Capture UID before destroying iframe
+      var uid = this.hasSaved ? this.getEditedElementUid() : null;
+
+      // Destroy iframe immediately to prevent flash message consumption
+      if (this.iframe) {
+        this.iframe.src = 'about:blank';
+        if (this.iframe.parentNode) {
+          this.iframe.parentNode.removeChild(this.iframe);
         }
-      }, 300);
+      }
+
       if (this.hasSaved) {
-        this.showSaveNotification(this.savedRecordTitle);
-        setTimeout(function () { window.location.reload(); }, 2000);
+        this.queueNotification(this.savedRecordTitle);
+        if (uid) {
+          var url = new URL(window.location.href);
+          url.searchParams.set('scrollToContent', uid);
+          url.hash = '';
+          window.location.href = url.toString();
+        } else {
+          window.location.reload();
+        }
       } else {
         document.body.classList.remove('frontend-edit__sidebar-active');
-      }
-      if (this._triggerElement && this._triggerElement.focus) {
-        this._triggerElement.focus();
-        this._triggerElement = null;
+        this.recreateIframe();
+        if (this._triggerElement && this._triggerElement.focus) {
+          this._triggerElement.focus();
+          this._triggerElement = null;
+        }
       }
     },
 
@@ -354,16 +370,35 @@
       } catch (e) { /* ignore */ }
     },
 
-    showSaveNotification: function (recordTitle) {
-      // Use the Notification module exposed by frontend_edit.js
-      if (window.FrontendEditNotification) {
+    queueNotification: function (recordTitle) {
+      try {
         var name = recordTitle || 'Record';
-        window.FrontendEditNotification.show({
+        sessionStorage.setItem('xfe-pending-notification', JSON.stringify({
           title: 'Record updated',
-          message: 'Record "' + name + '" has been updated.\nThe view is being refreshed.',
+          message: '"' + name + '" has been saved.',
           severity: 'ok'
-        });
+        }));
+      } catch (e) { /* sessionStorage unavailable */ }
+    },
+
+    getEditedElementUid: function () {
+      try {
+        var iframeUrl = this.iframe && this.iframe.src;
+        if (!iframeUrl) return null;
+        var match = iframeUrl.match(/edit%5Btt_content%5D%5B(\d+)%5D|edit\[tt_content\]\[(\d+)\]/);
+        return match ? (match[1] || match[2]) : null;
+      } catch (e) {
+        return null;
       }
+    },
+
+    recreateIframe: function () {
+      var newIframe = document.createElement('iframe');
+      newIframe.className = 'frontend-edit__sidebar-iframe';
+      newIframe.setAttribute('title', 'Edit content');
+      this.sidebar.appendChild(newIframe);
+      this.iframe = newIframe;
+      this.iframe.addEventListener('load', this._onIframeLoad.bind(this));
     }
   };
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1284,6 +1284,15 @@
         // Expose for contextual_edit.js (separate script, outside this IIFE)
         window.FrontendEditNotification = Notification;
 
+        // Show queued notification from previous page (e.g. contextual sidebar save)
+        try {
+          const pending = sessionStorage.getItem('xfe-pending-notification');
+          if (pending) {
+            sessionStorage.removeItem('xfe-pending-notification');
+            Notification.show(JSON.parse(pending));
+          }
+        } catch (_) { /* ignore */ }
+
         // Initialize contextual editing sidebar if loaded
         if (window.ContextualEdit) {
           window.ContextualEdit.init();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,3 +10,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'scrollToContent';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'tx_ximatypo3frontendedit_iframe';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'tx_ximatypo3frontendedit';


### PR DESCRIPTION
## Summary

- Align iframe modal (v13) visual styling with contextual sidebar (v14): same width, border-radius, backdrop opacity, slide-in animation, and light background
- Unify reload behavior: both versions now reload immediately after save, with scroll-to-element support
- Replace v14 pre-reload notification (2s delay) with sessionStorage-based notification that survives the reload
- Keep toast notifications on the right side for both v13 and v14 (previously moved to left when sidebar was open)
- Exclude extension query parameters from cHash calculation to prevent 404 errors

## Changes

- `ext_localconf.php` — Exclude `scrollToContent`, `tx_ximatypo3frontendedit_iframe`, `tx_ximatypo3frontendedit` from cHash
- `Resources/Public/Css/FrontendEdit.css` — Modal panel matches sidebar (800px, border-radius, `#f5f5f5` background, `ease-out` transition, header hidden, light loader/spinner), notification stays right
- `Resources/Public/JavaScript/contextual_edit.js` — Immediate iframe destruction + reload, `sessionStorage` notification queue, `scrollToContent` support, `_onIframeLoad` extracted (DRY), `recreateIframe()` for close-without-save
- `Resources/Public/JavaScript/frontend_edit.js` — Read and display queued sessionStorage notification after reload