### PR TITLE
fix: open empty-column "+" button in iframe modal on v13

### DIFF
--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -717,6 +717,7 @@
           e.target.closest('.frontend-edit__btn--edit') ||
           e.target.closest('.frontend-edit__dropdown a:not(.hide):not(.delete)') ||
           e.target.closest('.frontend-edit__sticky-dropdown a') ||
+          e.target.closest('.frontend-edit__column-btn') ||
           e.target.closest('.frontend-edit__open-modal');
 
         if (target?.href && isBackendUrl(target.href)) {


### PR DESCRIPTION
- The LinkInterceptor in iframe_edit.js routes clicks on edit/menu links into the iframe modal, but the selector list omitted the .frontend-edit__column-btn class used by the empty-column "+" buttons. With enableContextualEditing enabled on TYPO3 v13, clicking the button fell through to a full-page navigation instead of opening the modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Extended the set of clickable interface elements that can now open the backend edit modal when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->