### PR TITLE
build: remove PHP version constraint from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,5 @@
 	],
 	"ignorePaths": [
 		"package-lock.json"
-	],
-	"constraints": {
-		"php": ">=8.2"
-	}
+	]
 }


### PR DESCRIPTION
## Summary

- Remove redundant PHP version constraint (`>=8.2`) from `renovate.json` so Renovate relies on the constraint already declared in `composer.json`

## Changes

- `renovate.json` — drop `constraints.php` block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration by removing PHP version constraints from dependency management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->