### PR TITLE
refactor: simplify TYPO3 v13/v14 compatibility for static analysis

### DIFF
--- a/Classes/Utility/Compatibility/BackendUserUtility.php
+++ b/Classes/Utility/Compatibility/BackendUserUtility.php
@@ -35,10 +35,11 @@ class BackendUserUtility
      */
     public static function hasRecordEditAccess(BackendUserAuthentication $backendUser, string $table, array $record): bool
     {
-        if (method_exists($backendUser, 'checkRecordEditAccess')) { // @phpstan-ignore function.alreadyNarrowedType (v13 compat)
+        if (VersionUtility::is14OrHigher()) {
             return $backendUser->checkRecordEditAccess($table, $record)->isAllowed;
         }
 
-        return $backendUser->recordEditAccessInternals($table, $record); // @phpstan-ignore method.deprecated (v13 compat)
+        /* @phpstan-ignore method.deprecated (Required for TYPO3 v13 compatibility) */
+        return $backendUser->recordEditAccessInternals($table, $record);
     }
 }

--- a/Classes/Utility/Compatibility/ButtonFactoryUtility.php
+++ b/Classes/Utility/Compatibility/ButtonFactoryUtility.php
@@ -38,7 +38,9 @@ class ButtonFactoryUtility
 
     private static function getComponentFactory(): object
     {
-        // Use dynamic class name to avoid autoload issues on TYPO3 13
-        return GeneralUtility::makeInstance('TYPO3\\CMS\\Backend\\Template\\Components\\ComponentFactory');
+        /** @var class-string $factoryClass */
+        $factoryClass = 'TYPO3\\CMS\\Backend\\Template\\Components\\ComponentFactory';
+
+        return GeneralUtility::makeInstance($factoryClass);
     }
 }


### PR DESCRIPTION
## Summary

- Replace runtime `method_exists()` probing with explicit `VersionUtility::is14OrHigher()` branching for `BackendUserAuthentication` edit-access checks, so PHPStan sees a clean call to `checkRecordEditAccess()` on v14
- Annotate the dynamic `ComponentFactory` class name as `class-string` so `GeneralUtility::makeInstance()` no longer triggers a `class-string<ComponentFactory>` type error

## Changes

- `Classes/Utility/Compatibility/BackendUserUtility.php` — use `VersionUtility::is14OrHigher()` instead of `method_exists()`; drop now-redundant `@phpstan-ignore function.alreadyNarrowedType`
- `Classes/Utility/Compatibility/ButtonFactoryUtility.php` — annotate dynamic ComponentFactory class name as `class-string` for `makeInstance()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined internal version compatibility detection mechanisms to utilize version-based branching, ensuring enhanced reliability and consistency across multiple system versions and deployment configurations.
  * Optimized component factory instantiation with improved initialization logic, resulting in better code maintainability, enhanced clarity, and overall improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->