### PR TITLE
chore(ci): switch release workflow to reusable-github-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ter-publish:
-    uses: maikschneider/reusable-workflows/.github/workflows/release.yml@main
+    uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

- Point the release workflow at the new `konradmichalik/reusable-github-actions` repository
- Use the dedicated `release-typo3.yml` reusable workflow

## Changes

- `.github/workflows/release.yml` - Update reusable workflow reference to `konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation to integrate with a new deployment service for managing software releases and publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->