### PR TITLE
chore(config): downgrade DDEV PHP version from 8.3 to 8.2

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: xima-typo3-frontend-edit
 type: php
 docroot: .
-php_version: "8.3"
+php_version: "8.2"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"


### PR DESCRIPTION
## Summary

- Align DDEV local dev environment with the extension's minimum supported PHP version (8.2+)

## Changes

- `.ddev/config.yaml` — set `php_version` from `8.3` to `8.2`