### PR TITLE
feat: add extension title to composer description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "xima/xima-typo3-frontend-edit",
-	"description": "This extension provides an edit button for editors within frontend content elements.",
+	"description": "Frontend Edit - This extension provides an edit button for editors within frontend content elements.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
## Summary

- Prepend the extension title `Frontend Edit` to the composer description for clearer presentation in the TYPO3 Extension Manager and on Packagist

## Changes

- `composer.json` - Update `description` to lead with the extension title