### PR TITLE
feat: create content from the frontend via the native New Content Element Wizard

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -124,11 +124,11 @@ readonly class AjaxController
 
         $dropdown = $this->contentElementMenuGenerator->getDropdown($pid, $returnUrl, $languageUid, $request, $data);
 
-        $emptyColumns = $this->emptyColumnService->getEmptyColumns($pid, $languageUid, $returnUrl, $data);
+        $columnTargets = $this->emptyColumnService->getColumnTargets($pid, $languageUid, $returnUrl, $data);
 
         return new JsonResponse(mb_convert_encoding([
             'contentElements' => $dropdown,
-            'emptyColumns' => $emptyColumns,
+            'columnTargets' => $columnTargets,
         ], 'UTF-8'));
     }
 

--- a/Classes/Service/Configuration/SettingsService.php
+++ b/Classes/Service/Configuration/SettingsService.php
@@ -127,6 +127,16 @@ final readonly class SettingsService
         return (bool) $settings->get('frontendEdit.showStickyToolbar', true);
     }
 
+    public function isShowInsertButtons(ServerRequestInterface $request): bool
+    {
+        $settings = $this->getSiteSettings($request);
+        if (null === $settings) {
+            return true;
+        }
+
+        return (bool) $settings->get('frontendEdit.showInsertButtons', true);
+    }
+
     public function getToolbarPosition(ServerRequestInterface $request): string
     {
         $validPositions = [

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -15,11 +15,11 @@ namespace Xima\XimaTypo3FrontendEdit\Service\Content;
 
 use Throwable;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
-use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\View\BackendLayoutView;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
 
 use function is_array;
 
@@ -35,7 +35,7 @@ final readonly class EmptyColumnService
 
     public function __construct(
         private ConnectionPool $connectionPool,
-        private UriBuilder $uriBuilder,
+        private UrlBuilderService $urlBuilderService,
         private LanguageServiceFactory $languageServiceFactory,
     ) {
         $this->containerFieldExists = $this->detectContainerField();
@@ -47,33 +47,31 @@ final readonly class EmptyColumnService
      * @param string       $returnUrl   Frontend URL to return to after editing
      * @param array<mixed> $requestData Raw request data from the AJAX call
      *
-     * @return list<array{colPos: int, newContentUrl: string, name?: string, containerUid?: int}>
+     * @return list<array{colPos: int, isEmpty: bool, newContentUrl: string, name?: string, containerUid?: int}>
      */
-    public function getEmptyColumns(int $pid, int $languageUid, string $returnUrl, array $requestData = []): array
+    public function getColumnTargets(int $pid, int $languageUid, string $returnUrl, array $requestData = []): array
     {
         return [
-            ...$this->findEmptyPageColumns($pid, $languageUid, $returnUrl),
-            ...$this->findEmptyContainerColumns($pid, $languageUid, $returnUrl, $this->extractContainerMarkers($requestData)),
+            ...$this->findPageColumnTargets($pid, $languageUid, $returnUrl),
+            ...$this->findContainerColumnTargets($pid, $languageUid, $returnUrl, $this->extractContainerMarkers($requestData)),
         ];
     }
 
     /**
-     * @return list<array{colPos: int, name: string, newContentUrl: string}>
+     * @return list<array{colPos: int, isEmpty: bool, name: string, newContentUrl: string}>
      */
-    private function findEmptyPageColumns(int $pid, int $languageUid, string $returnUrl): array
+    private function findPageColumnTargets(int $pid, int $languageUid, string $returnUrl): array
     {
         $result = [];
 
         foreach ($this->resolvePageColumns($pid) as $column) {
             $colPos = $column['colPos'];
-            if (!$this->isPageColumnEmpty($pid, $colPos, $languageUid)) {
-                continue;
-            }
             try {
                 $result[] = [
                     'colPos' => $colPos,
+                    'isEmpty' => $this->isPageColumnEmpty($pid, $colPos, $languageUid),
                     'name' => $column['name'],
-                    'newContentUrl' => $this->buildNewContentUrl($pid, $colPos, $languageUid, $returnUrl),
+                    'newContentUrl' => $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl),
                 ];
             } catch (RouteNotFoundException) {
             }
@@ -85,9 +83,9 @@ final readonly class EmptyColumnService
     /**
      * @param array<int, int[]> $containerMarkers
      *
-     * @return list<array{colPos: int, containerUid: int, newContentUrl: string}>
+     * @return list<array{colPos: int, isEmpty: bool, containerUid: int, newContentUrl: string}>
      */
-    private function findEmptyContainerColumns(int $pid, int $languageUid, string $returnUrl, array $containerMarkers): array
+    private function findContainerColumnTargets(int $pid, int $languageUid, string $returnUrl, array $containerMarkers): array
     {
         if (!$this->containerFieldExists || [] === $containerMarkers) {
             return [];
@@ -100,14 +98,12 @@ final readonly class EmptyColumnService
                 continue;
             }
             foreach ($colPositions as $colPos) {
-                if (!$this->isContainerColumnEmpty($containerUid, $colPos, $languageUid)) {
-                    continue;
-                }
                 try {
                     $result[] = [
                         'colPos' => $colPos,
+                        'isEmpty' => $this->isContainerColumnEmpty($containerUid, $colPos, $languageUid),
                         'containerUid' => $containerUid,
-                        'newContentUrl' => $this->buildNewContentUrl($pid, $colPos, $languageUid, $returnUrl, $containerUid),
+                        'newContentUrl' => $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl, containerUid: $containerUid),
                     ];
                 } catch (RouteNotFoundException) {
                 }
@@ -214,30 +210,6 @@ final readonly class EmptyColumnService
             )
             ->executeQuery()
             ->fetchOne();
-    }
-
-    /**
-     * @throws RouteNotFoundException
-     */
-    private function buildNewContentUrl(int $pid, int $colPos, int $languageUid, string $returnUrl, ?int $containerUid = null): string
-    {
-        $defVals = [
-            'colPos' => $colPos,
-            'sys_language_uid' => $languageUid,
-        ];
-
-        if (null !== $containerUid) {
-            $defVals['tx_container_parent'] = $containerUid;
-        }
-
-        return $this->uriBuilder->buildUriFromRoute(
-            'record_edit',
-            [
-                'edit' => ['tt_content' => [$pid => 'new']],
-                'defVals' => ['tt_content' => $defVals],
-                'returnUrl' => $returnUrl,
-            ],
-        )->__toString();
     }
 
     /**

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -190,6 +190,9 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
             $languageUid,
             $returnUrlAnchor,
             uidAfter: (int) $contentElement['uid'],
+            containerUid: (int) ($contentElement['tx_container_parent'] ?? 0) > 0
+                ? (int) $contentElement['tx_container_parent']
+                : null,
         );
         $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
 

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -182,16 +182,14 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         $historyUrl = $this->urlBuilderService->buildHistoryUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
         $this->addButton($menuButton, 'history', ButtonType::Link, url: $historyUrl, icon: 'actions-history');
 
-        // New content after button.
-        // URL builder returns a version-aware URL:
-        //  - v13.4: web_layout URL with hash for iframe_edit.js to auto-click the wizard
-        //  - v14.2+: record_edit URL with negative UID (standard backend new-after-element flow)
-        $newContentUrl = $this->urlBuilderService->buildNewContentAfterUrl(
-            (int) $contentElement['uid'],
+        // New content after button — opens the native New Content Element Wizard
+        // (type-picker grid) positioned after this element. Same route on v13/v14.
+        $newContentUrl = $this->urlBuilderService->buildNewContentWizardUrl(
             (int) ($contentElement['pid'] ?? 0),
             (int) ($contentElement['colPos'] ?? 0),
             $languageUid,
             $returnUrlAnchor,
+            uidAfter: (int) $contentElement['uid'],
         );
         $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
 

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -98,6 +98,12 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         // Check once if the contextual edit route exists (TYPO3 v14.2+)
         $contextualRouteAvailable = $this->urlBuilderService->isContextualEditRouteAvailable();
 
+        // Hover insert buttons (before/after each element). Precompute the
+        // previous-sibling uid per column so "before" can target the position
+        // after the previous element (first element → column top).
+        $showInsertButtons = $this->settingsService->isShowInsertButtons($request);
+        $previousSiblingByUid = $this->buildPreviousSiblingMap($filteredElements, $showInsertButtons);
+
         $result = [];
         foreach ($filteredElements as $contentElement) {
             $contentElementConfig = $this->contentElementRepository->getContentElementConfig(
@@ -125,6 +131,8 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
             $iconIdentifier = $contentElementConfig['icon'] ?? 'content-textpic';
             $contentElement['ctypeIcon'] = (string) $this->iconService->getIcon($iconIdentifier);
 
+            $this->addInsertButtonUrls($contentElement, $showInsertButtons, $previousSiblingByUid, $pid, $languageUid, $returnUrlAnchor);
+
             // Use potentially modified button from event listeners
             $result[$contentElement['uid']] = [
                 'element' => $contentElement,
@@ -133,6 +141,70 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         }
 
         return $this->renderMenuButtons($result);
+    }
+
+    /**
+     * Map each content element uid to the uid of its previous sibling within the
+     * same column (and container). Used to position the "insert before" button.
+     * Returns null for the first element of a column (→ insert at column top).
+     *
+     * @param array<int, array<string, mixed>> $elements
+     *
+     * @return array<int, int|null>
+     */
+    private function buildPreviousSiblingMap(array $elements, bool $enabled): array
+    {
+        if (!$enabled) {
+            return [];
+        }
+
+        $groups = [];
+        foreach ($elements as $element) {
+            $key = (int) ($element['colPos'] ?? 0).'_'.(int) ($element['tx_container_parent'] ?? 0);
+            $groups[$key][] = $element;
+        }
+
+        $previousByUid = [];
+        foreach ($groups as $group) {
+            usort($group, static fn (array $a, array $b): int => ((int) ($a['sorting'] ?? 0)) <=> ((int) ($b['sorting'] ?? 0)));
+            $previousUid = null;
+            foreach ($group as $element) {
+                $previousByUid[(int) $element['uid']] = $previousUid;
+                $previousUid = (int) $element['uid'];
+            }
+        }
+
+        return $previousByUid;
+    }
+
+    /**
+     * Add the "insert before" / "insert after" wizard URLs to a content element,
+     * consumed by the frontend hover buttons. "before" targets the position after
+     * the previous sibling (or the column top for the first element); "after"
+     * targets the position after this element.
+     *
+     * @param array<string, mixed> $contentElement
+     * @param array<int, int|null> $previousSiblingByUid
+     */
+    private function addInsertButtonUrls(array &$contentElement, bool $enabled, array $previousSiblingByUid, int $pid, int $languageUid, string $returnUrl): void
+    {
+        if (!$enabled) {
+            return;
+        }
+
+        $uid = (int) $contentElement['uid'];
+        $colPos = (int) ($contentElement['colPos'] ?? 0);
+        $containerUid = (int) ($contentElement['tx_container_parent'] ?? 0) > 0
+            ? (int) $contentElement['tx_container_parent']
+            : null;
+        $previousUid = $previousSiblingByUid[$uid] ?? null;
+
+        try {
+            $contentElement['newAfterUrl'] = $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl, uidAfter: $uid, containerUid: $containerUid);
+            $contentElement['newBeforeUrl'] = $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl, uidAfter: $previousUid, containerUid: $containerUid);
+        } catch (RouteNotFoundException) {
+            // Leave the URLs unset; the frontend simply skips the buttons.
+        }
     }
 
     /**

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -28,7 +28,6 @@ use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator;
-use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 use Xima\XimaTypo3FrontendEdit\Utility\ResourceUtility;
 
 use function sprintf;
@@ -63,10 +62,12 @@ final readonly class ResourceRendererService
             $nonceAttribute = '' !== $nonceValue ? ' nonce="'.$nonceValue.'"' : '';
             $resources = ResourceUtility::getResources(['nonce' => $nonceValue]);
 
-            // Iframe modal editor is a TYPO3 v13-only fallback, gated behind
-            // the same enableContextualEditing setting as the v14 sidebar.
-            $isIframeModalEnabled = !VersionUtility::is14OrHigher()
-                && $this->settingsService->isContextualEditingEnabled($request);
+            // The iframe modal hosts the New Content Element Wizard (web_layout +
+            // auto-click) on BOTH v13 and v14. On v13 it also handles editing; on
+            // v14 it loads alongside the contextual sidebar, which keeps handling
+            // edits while the modal only takes the new-content wizard links (see
+            // the FRONTEND_EDIT_SIDEBAR_EDIT flag and iframe_edit.js LinkInterceptor).
+            $isIframeModalEnabled = $this->settingsService->isContextualEditingEnabled($request);
 
             if ($isIframeModalEnabled) {
                 $this->addBackendStubs($resources, $nonceValue);
@@ -113,6 +114,12 @@ final readonly class ResourceRendererService
         $enableOutline = $this->jsBool($request, $this->settingsService->isEnableOutline(...));
         $enableScrollToElement = $this->jsBool($request, $this->settingsService->isEnableScrollToElement(...));
         $contextualEditing = $this->jsBool($request, $this->settingsService->isContextualEditingEnabled(...));
+        // True only when edits are routed to the contextual sidebar (v14.2+ with the
+        // route available). iframe_edit.js then restricts the modal to new-content
+        // wizard links; on v13 this stays false so the modal handles all edit links.
+        $sidebarEdit = (null !== $request
+            && $this->settingsService->isContextualEditingEnabled($request)
+            && $this->urlBuilderService->isContextualEditRouteAvailable()) ? 'true' : 'false';
         $isDisabled = $this->backendUserService->isFrontendEditDisabled() ? 'true' : 'false';
         $deleteLabels = json_encode([
             'title' => $this->translate('delete.confirm.title', 'Delete this record?'),
@@ -127,13 +134,14 @@ final readonly class ResourceRendererService
             'createContentIn' => $this->translate('column.createContentIn', 'Create new content in "%s" column'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $resources['settings_config'] = sprintf(
-            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s;</script>',
+            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_SIDEBAR_EDIT = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s;</script>',
             $nonceAttribute,
             $colorScheme,
             $showContextMenu,
             $enableOutline,
             $enableScrollToElement,
             $contextualEditing,
+            $sidebarEdit,
             $isDisabled,
             $deleteLabels,
             $columnLabels,

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -133,8 +133,11 @@ final readonly class ResourceRendererService
             'createContent' => $this->translate('column.createContent', 'Create new content'),
             'createContentIn' => $this->translate('column.createContentIn', 'Create new content in "%s" column'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
+        $notificationLabels = json_encode([
+            'contentCreated' => $this->translate('notification.contentCreated', 'Content element created'),
+        ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $resources['settings_config'] = sprintf(
-            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_SIDEBAR_EDIT = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s;</script>',
+            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_SIDEBAR_EDIT = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s; window.FRONTEND_EDIT_NOTIFICATION_LABELS = %s;</script>',
             $nonceAttribute,
             $colorScheme,
             $showContextMenu,
@@ -145,6 +148,7 @@ final readonly class ResourceRendererService
             $isDisabled,
             $deleteLabels,
             $columnLabels,
+            $notificationLabels,
         );
     }
 

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -113,6 +113,7 @@ final readonly class ResourceRendererService
         $showContextMenu = $this->jsBool($request, $this->settingsService->isShowContextMenu(...));
         $enableOutline = $this->jsBool($request, $this->settingsService->isEnableOutline(...));
         $enableScrollToElement = $this->jsBool($request, $this->settingsService->isEnableScrollToElement(...));
+        $showInsertButtons = $this->jsBool($request, $this->settingsService->isShowInsertButtons(...));
         $contextualEditing = $this->jsBool($request, $this->settingsService->isContextualEditingEnabled(...));
         // True only when edits are routed to the contextual sidebar (v14.2+ with the
         // route available). iframe_edit.js then restricts the modal to new-content
@@ -132,12 +133,14 @@ final readonly class ResourceRendererService
         $columnLabels = json_encode([
             'createContent' => $this->translate('column.createContent', 'Create new content'),
             'createContentIn' => $this->translate('column.createContentIn', 'Create new content in "%s" column'),
+            'insertBefore' => $this->translate('column.insertBefore', 'Create new content before'),
+            'insertAfter' => $this->translate('column.insertAfter', 'Create new content after'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $notificationLabels = json_encode([
             'contentCreated' => $this->translate('notification.contentCreated', 'Content element created'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $resources['settings_config'] = sprintf(
-            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_SIDEBAR_EDIT = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s; window.FRONTEND_EDIT_NOTIFICATION_LABELS = %s;</script>',
+            '<script%s>window.FRONTEND_EDIT_COLOR_SCHEME = "%s"; window.FRONTEND_EDIT_SHOW_CONTEXT_MENU = %s; window.FRONTEND_EDIT_ENABLE_OUTLINE = %s; window.FRONTEND_EDIT_ENABLE_SCROLL_TO_ELEMENT = %s; window.FRONTEND_EDIT_CONTEXTUAL_EDITING = %s; window.FRONTEND_EDIT_SIDEBAR_EDIT = %s; window.FRONTEND_EDIT_DISABLED = %s; window.FRONTEND_EDIT_DELETE_LABELS = %s; window.FRONTEND_EDIT_COLUMN_LABELS = %s; window.FRONTEND_EDIT_NOTIFICATION_LABELS = %s; window.FRONTEND_EDIT_SHOW_INSERT_BUTTONS = %s;</script>',
             $nonceAttribute,
             $colorScheme,
             $showContextMenu,
@@ -149,6 +152,7 @@ final readonly class ResourceRendererService
             $deleteLabels,
             $columnLabels,
             $notificationLabels,
+            $showInsertButtons,
         );
     }
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -148,8 +148,8 @@ final readonly class UrlBuilderService
      * Hash params consumed by iframe_edit.js autoClickWizardButton():
      *   colPos (required), afterUid (insert after element), container (container colPos parent).
      *
-     * @param int|null $uidAfter    Insert after this content element; null appends to the column.
-     * @param int|null $containerUid Parent container UID for EXT:container columns.
+     * @param int|null $uidAfter     insert after this content element; null appends to the column
+     * @param int|null $containerUid parent container UID for EXT:container columns
      *
      * @throws RouteNotFoundException
      */

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -24,7 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-final readonly class UrlBuilderService
+readonly class UrlBuilderService
 {
     private UriBuilder $uriBuilder;
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -24,7 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-readonly class UrlBuilderService
+final readonly class UrlBuilderService
 {
     private UriBuilder $uriBuilder;
 

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -165,6 +165,41 @@ final readonly class UrlBuilderService
     }
 
     /**
+     * Build URL to TYPO3's native New Content Element Wizard.
+     *
+     * Version-agnostic: the same backend route renders the wizard on v13 (inside
+     * the iframe modal) and v14 (inside the contextual sidebar). Passing a colPos
+     * skips the wizard's position-selection step and goes straight to the type grid.
+     *
+     * @param int|null $uidAfter Insert after this content element (uid_pid = -uid);
+     *                           null appends to the end of the column (uid_pid = pid).
+     *
+     * @throws RouteNotFoundException
+     */
+    public function buildNewContentWizardUrl(
+        int $pid,
+        int $colPos,
+        int $languageUid,
+        string $returnUrl,
+        ?int $uidAfter = null,
+        ?int $containerUid = null,
+    ): string {
+        $parameters = [
+            'id' => $pid,
+            'colPos' => $colPos,
+            'sys_language_uid' => $languageUid,
+            'uid_pid' => null !== $uidAfter ? -$uidAfter : $pid,
+            'returnUrl' => $returnUrl,
+        ];
+
+        if (null !== $containerUid) {
+            $parameters['tx_container_parent'] = $containerUid;
+        }
+
+        return $this->uriBuilder->buildUriFromRoute('new_content_element_wizard', $parameters)->__toString();
+    }
+
+    /**
      * Check if the contextual edit route exists (TYPO3 v14.2+).
      */
     public function isContextualEditRouteAvailable(): bool

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -135,14 +135,21 @@ final readonly class UrlBuilderService
     }
 
     /**
-     * Build URL to TYPO3's native New Content Element Wizard.
+     * Build URL to open TYPO3's native New Content Element Wizard.
      *
-     * Version-agnostic: the same backend route renders the wizard on v13 (inside
-     * the iframe modal) and v14 (inside the contextual sidebar). Passing a colPos
-     * skips the wizard's position-selection step and goes straight to the type grid.
+     * The wizard route (new_content_element_wizard) is an AJAX-modal fragment,
+     * not a navigable page — TYPO3 core only ever opens it via
+     * Modal.advanced({type: 'ajax'}) from an already-bootstrapped backend page.
+     * Loading it directly yields a blank page. So instead we return a web_layout
+     * (page module) URL with a hash fragment: iframe_edit.js loads the fully
+     * bootstrapped page module inside the modal and auto-clicks the matching
+     * wizard button, which opens the native wizard. Same mechanism on v13 and v14.
      *
-     * @param int|null $uidAfter Insert after this content element (uid_pid = -uid);
-     *                           null appends to the end of the column (uid_pid = pid).
+     * Hash params consumed by iframe_edit.js autoClickWizardButton():
+     *   colPos (required), afterUid (insert after element), container (container colPos parent).
+     *
+     * @param int|null $uidAfter    Insert after this content element; null appends to the column.
+     * @param int|null $containerUid Parent container UID for EXT:container columns.
      *
      * @throws RouteNotFoundException
      */
@@ -154,19 +161,15 @@ final readonly class UrlBuilderService
         ?int $uidAfter = null,
         ?int $containerUid = null,
     ): string {
-        $parameters = [
-            'id' => $pid,
-            'colPos' => $colPos,
-            'sys_language_uid' => $languageUid,
-            'uid_pid' => null !== $uidAfter ? -$uidAfter : $pid,
-            'returnUrl' => $returnUrl,
-        ];
-
+        $hash = 'colPos='.$colPos;
+        if (null !== $uidAfter) {
+            $hash .= '&afterUid='.$uidAfter;
+        }
         if (null !== $containerUid) {
-            $parameters['tx_container_parent'] = $containerUid;
+            $hash .= '&container='.$containerUid;
         }
 
-        return $this->uriBuilder->buildUriFromRoute('new_content_element_wizard', $parameters)->__toString();
+        return $this->buildPageLayoutUrlWithHash($pid, $languageUid, $returnUrl, $hash);
     }
 
     /**
@@ -256,4 +259,26 @@ final readonly class UrlBuilderService
         return $this->uriBuilder->buildUriFromRoute($route, $parameters)->__toString();
     }
 
+    /**
+     * Build a web_layout URL with a hash fragment for iframe_edit.js wizard auto-click.
+     *
+     * TYPO3's UriBuilder doesn't support hash fragments (they're client-side only),
+     * so we append them manually. The hash is parsed by iframe_edit.js to determine
+     * which "new content" wizard button to auto-click inside the iframe.
+     *
+     * @throws RouteNotFoundException
+     */
+    private function buildPageLayoutUrlWithHash(int $pid, int $languageUid, string $returnUrl, string $hash): string
+    {
+        $url = $this->uriBuilder->buildUriFromRoute(
+            'web_layout',
+            [
+                'id' => $pid,
+                'language' => $languageUid,
+                'returnUrl' => $returnUrl,
+            ],
+        )->__toString();
+
+        return $url.'#'.$hash;
+    }
 }

--- a/Classes/Service/Ui/UrlBuilderService.php
+++ b/Classes/Service/Ui/UrlBuilderService.php
@@ -16,7 +16,6 @@ namespace Xima\XimaTypo3FrontendEdit\Service\Ui;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 
 /**
  * UrlBuilderService.
@@ -133,35 +132,6 @@ final readonly class UrlBuilderService
                 'returnUrl' => $returnUrl,
             ],
         )->__toString();
-    }
-
-    /**
-     * Build URL to create a new content element after an existing one.
-     *
-     * - On TYPO3 v13.4: returns a web_layout URL with a hash fragment so
-     *   iframe_edit.js can auto-click the correct wizard button.
-     * - On TYPO3 v14.2+: returns the native record_edit URL since the
-     *   contextual sidebar handles the new-content flow directly.
-     *
-     * @throws RouteNotFoundException
-     */
-    public function buildNewContentAfterUrl(int $uid, int $pid, int $colPos, int $languageUid, string $returnUrl): string
-    {
-        if (VersionUtility::is14OrHigher()) {
-            return $this->uriBuilder->buildUriFromRoute(
-                'record_edit',
-                [
-                    'edit' => [
-                        'tt_content' => [-$uid => 'new'],
-                        'language' => $languageUid,
-                    ],
-                    'returnUrl' => $returnUrl,
-                ],
-            )->__toString();
-        }
-
-        // v13: hash params tell iframe_edit.js which wizard button to auto-click
-        return $this->buildPageLayoutUrlWithHash($pid, $languageUid, $returnUrl, 'colPos='.$colPos.'&afterUid='.$uid);
     }
 
     /**
@@ -286,26 +256,4 @@ final readonly class UrlBuilderService
         return $this->uriBuilder->buildUriFromRoute($route, $parameters)->__toString();
     }
 
-    /**
-     * Build a web_layout URL with a hash fragment for iframe_edit.js wizard auto-click.
-     *
-     * TYPO3's UriBuilder doesn't support hash fragments (they're client-side only),
-     * so we append them manually. The hash is parsed by iframe_edit.js to determine
-     * which "new content" wizard button to auto-click inside the iframe.
-     *
-     * @throws RouteNotFoundException
-     */
-    private function buildPageLayoutUrlWithHash(int $pid, int $languageUid, string $returnUrl, string $hash): string
-    {
-        $url = $this->uriBuilder->buildUriFromRoute(
-            'web_layout',
-            [
-                'id' => $pid,
-                'language' => $languageUid,
-                'returnUrl' => $returnUrl,
-            ],
-        )->__toString();
-
-        return $url.'#'.$hash;
-    }
 }

--- a/Configuration/Sets/XimaTypo3FrontendEdit/settings.definitions.yaml
+++ b/Configuration/Sets/XimaTypo3FrontendEdit/settings.definitions.yaml
@@ -64,6 +64,13 @@ settings:
     description: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.description.frontendEdit.enableContextualEditing
     category: frontendEdit.appearance
 
+  frontendEdit.showInsertButtons:
+    default: true
+    type: bool
+    label: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.frontendEdit.showInsertButtons
+    description: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.description.frontendEdit.showInsertButtons
+    category: frontendEdit.appearance
+
   frontendEdit.enableFlashMessages:
     default: true
     type: bool

--- a/Documentation/DeveloperCorner/EmptyColumns.rst
+++ b/Documentation/DeveloperCorner/EmptyColumns.rst
@@ -130,3 +130,4 @@ Container support requires the `b13/container <https://github.com/b13/container>
     View the sources on GitHub:
 
     -   `ColumnTargetViewHelper <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/ViewHelpers/ColumnTargetViewHelper.php>`__
+    -   `EmptyColumnService <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/Service/Content/EmptyColumnService.php>`__

--- a/Documentation/DeveloperCorner/EmptyColumns.rst
+++ b/Documentation/DeveloperCorner/EmptyColumns.rst
@@ -76,8 +76,17 @@ Place the marker after the content rendering for each column:
 
 A "+" button always appears at the marker position — whether the column is empty or already contains content. Clicking it opens TYPO3's native **New Content Element Wizard** to choose a content type, then creates the new element in that column.
 
-- **TYPO3 v13**: The wizard opens in a slide-in iframe modal.
-- **TYPO3 v14**: The wizard opens in the native contextual sidebar.
+.. note::
+
+   This feature requires contextual editing to be enabled
+   (``frontendEdit.enableContextualEditing: true`` in the site settings) — the
+   wizard is hosted inside the slide-in iframe modal that this setting activates.
+
+On both **TYPO3 v13 and v14** the wizard opens in the slide-in iframe modal: the
+page module is loaded inside the modal and the matching wizard button is
+auto-clicked, so the editor sees TYPO3's real wizard. On v14 the contextual
+editing sidebar continues to handle editing of existing elements; creating new
+content uses the modal.
 
 Container columns
 -----------------
@@ -114,8 +123,8 @@ How it works
 1. The ViewHelper renders :html:`<div data-xfe-colpos="0" hidden></div>` (invisible, no layout impact)
 2. The extension's JavaScript scans the page for these markers after loading
 3. A "+" button is injected at each marker position, regardless of whether the column already contains content
-4. Clicking the button opens TYPO3's native New Content Element Wizard with the correct colPos pre-filled
-5. The wizard lets the editor choose a content type before the record editor opens (v13: iframe modal, v14: contextual sidebar)
+4. Clicking the button opens the page module inside the iframe modal and auto-clicks the matching wizard button, so TYPO3's native New Content Element Wizard appears with the correct colPos pre-filled
+5. The wizard lets the editor choose a content type before the record editor opens — inside the iframe modal on both v13 and v14
 
 Container support requires the `b13/container <https://github.com/b13/container>`__ extension. The service automatically detects whether it is installed. Without it, only page columns are supported and container markers are silently ignored.
 

--- a/Documentation/DeveloperCorner/EmptyColumns.rst
+++ b/Documentation/DeveloperCorner/EmptyColumns.rst
@@ -2,17 +2,17 @@
 
 ..  _empty-columns:
 
-=============
-Empty Columns
-=============
+==============
+Column Targets
+==============
 
-The extension can display "Create new content" buttons for empty columns directly in the frontend. This allows editors to add content without switching to the TYPO3 backend.
+The extension can display "Create new content" buttons for columns directly in the frontend — both for empty columns and at the end of columns that already contain content. This allows editors to add content without switching to the TYPO3 backend.
 
 ..  figure:: /Images/empty-column.jpg
     :alt: Empty column marker showing a "Create new content" button in the frontend
     :class: with-shadow
 
-    A "Create new content" button appears in empty columns when frontend editing is enabled
+    A "Create new content" button appears in empty columns and at the end of filled columns when frontend editing is enabled
 
 It works in two steps:
 
@@ -74,9 +74,10 @@ Place the marker after the content rendering for each column:
     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1'}" />
     <xfe:columnTarget colPos="1" />
 
-When colPos 0 or 1 is empty, a "+" button appears at the marker position. Clicking it opens the TYPO3 record editor to create a new content element in that column.
+A "+" button always appears at the marker position — whether the column is empty or already contains content. Clicking it opens TYPO3's native **New Content Element Wizard** to choose a content type, then creates the new element in that column.
 
-When the column has content, the marker stays hidden and has no effect on the page.
+- **TYPO3 v13**: The wizard opens in a slide-in iframe modal.
+- **TYPO3 v14**: The wizard opens in the native contextual sidebar.
 
 Container columns
 -----------------
@@ -112,9 +113,9 @@ How it works
 
 1. The ViewHelper renders :html:`<div data-xfe-colpos="0" hidden></div>` (invisible, no layout impact)
 2. The extension's JavaScript scans the page for these markers after loading
-3. An AJAX request to the backend checks which columns are empty
-4. For each empty column that has a matching marker, a "+" button is injected
-5. The button opens the TYPO3 record editor with the correct colPos pre-filled
+3. A "+" button is injected at each marker position, regardless of whether the column already contains content
+4. Clicking the button opens TYPO3's native New Content Element Wizard with the correct colPos pre-filled
+5. The wizard lets the editor choose a content type before the record editor opens (v13: iframe modal, v14: contextual sidebar)
 
 Container support requires the `b13/container <https://github.com/b13/container>`__ extension. The service automatically detects whether it is installed. Without it, only page columns are supported and container markers are silently ignored.
 
@@ -129,4 +130,3 @@ Container support requires the `b13/container <https://github.com/b13/container>
     View the sources on GitHub:
 
     -   `ColumnTargetViewHelper <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/ViewHelpers/ColumnTargetViewHelper.php>`__
-    -   `EmptyColumnService <https://github.com/xima-media/xima-typo3-frontend-edit/blob/main/Classes/Service/Content/EmptyColumnService.php>`__

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -10,7 +10,7 @@ Three opportunities exist to extend the Edit Menu with custom entries:
 
 - Use an :ref:`event <events>` to modify the Edit Menu directly
 - Use a :ref:`viewhelper <data-attributes>` to extend the Edit Menu with data entries
-- Use :ref:`empty column markers <empty-columns>` to add "Create new content" buttons for empty columns
+- Use :ref:`column target markers <empty-columns>` to add "Create new content" buttons for empty columns and at the end of filled columns
 
 Additionally, you can provide a :ref:`custom css <custom-styling>` file to adjust the styling.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The extension injects a small JavaScript into the frontend that generates action
   - **[Edit Menu](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html)** - Quick access to edit, hide, delete, and move content elements
   - **[Delete Confirmation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html#delete-confirmation)** - Confirmation dialog before deleting records *(new in v2.3)*
   - **[Inline Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)** *(experimental)* - Edit content directly in the frontend
+  - **New Content Wizard** - Create new content elements via TYPO3's native New Content Element Wizard (v13: iframe modal, v14: contextual sidebar)
 - **Page Toolbar**
   - **[Toolbar](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/Toolbar.html)** - Page-level actions and toggle for frontend editing
   - **Dark/Light Mode** - Automatic or manual color scheme selection
@@ -40,7 +41,7 @@ The extension injects a small JavaScript into the frontend that generates action
   - **[UserTSconfig](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/UserTSconfig.html)** - Disable frontend editing per user or user group
 - **Developer**
   - **[PSR-14 Events](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/Events.html)** - Customize menus with custom actions
-  - **ViewHelpers** - [Data attributes](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/DataAttributes.html) for related records, [empty column buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html) for new content *(new in v2.3)*
+  - **ViewHelpers** - [Data attributes](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/DataAttributes.html) for related records, [column target buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html) for new content (empty columns and end-of-column) *(new in v2.3)*
 
 > [!NOTE]
 > **New in v2.3.0 — Inline Editing** *(experimental)*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The extension injects a small JavaScript into the frontend that generates action
   - **[Edit Menu](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html)** - Quick access to edit, hide, delete, and move content elements
   - **[Delete Confirmation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html#delete-confirmation)** - Confirmation dialog before deleting records *(new in v2.3)*
   - **[Inline Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)** *(experimental)* - Edit content directly in the frontend
-  - **New Content Wizard** - Create new content elements via TYPO3's native New Content Element Wizard (v13: iframe modal, v14: contextual sidebar)
+  - **New Content Wizard** - Create new content elements via TYPO3's native New Content Element Wizard, hosted in the slide-in iframe modal on both v13 and v14 (requires `frontendEdit.enableContextualEditing`)
 - **Page Toolbar**
   - **[Toolbar](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/Toolbar.html)** - Page-level actions and toggle for frontend editing
   - **Dark/Light Mode** - Automatic or manual color scheme selection

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -115,6 +115,10 @@
 				<source />
 				<target>Neuen Inhalt in Spalte "%s" erstellen</target>
 			</trans-unit>
+			<trans-unit id="notification.contentCreated">
+				<source />
+				<target>Inhaltselement angelegt</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -115,6 +115,14 @@
 				<source />
 				<target>Neuen Inhalt in Spalte "%s" erstellen</target>
 			</trans-unit>
+			<trans-unit id="column.insertBefore">
+				<source />
+				<target>Neuen Inhalt davor erstellen</target>
+			</trans-unit>
+			<trans-unit id="column.insertAfter">
+				<source />
+				<target>Neuen Inhalt danach erstellen</target>
+			</trans-unit>
 			<trans-unit id="notification.contentCreated">
 				<source />
 				<target>Inhaltselement angelegt</target>

--- a/Resources/Private/Language/de.locallang_sitesettings.xlf
+++ b/Resources/Private/Language/de.locallang_sitesettings.xlf
@@ -171,6 +171,15 @@
 				<target>Öffnet Inhaltselement-Bearbeitungsformulare in einem Seitenpanel anstatt zum Backend zu navigieren. Erfordert TYPO3 v14.2+. Diese Funktion ist experimentell und kann sich in zukünftigen Versionen ändern.</target>
 			</trans-unit>
 
+			<trans-unit id="settings.frontendEdit.showInsertButtons">
+				<source>Show insert buttons on hover</source>
+				<target>Einfügen-Buttons beim Hover anzeigen</target>
+			</trans-unit>
+			<trans-unit id="settings.description.frontendEdit.showInsertButtons">
+				<source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard.</source>
+				<target>Zeigt beim Hover über jedem Inhaltselement "+"-Buttons oben und unten an, um per New Content Element Wizard ein neues Element davor oder danach einzufügen.</target>
+			</trans-unit>
+
 			<trans-unit id="settings.frontendEdit.filter.ignoreUids">
 				<source>Ignore UIDs</source>
 				<target>UIDs ignorieren</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -87,6 +87,9 @@
 			<trans-unit id="column.createContentIn">
 				<source>Create new content in "%s" column</source>
 			</trans-unit>
+			<trans-unit id="notification.contentCreated">
+				<source>Content element created</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -87,6 +87,12 @@
 			<trans-unit id="column.createContentIn">
 				<source>Create new content in "%s" column</source>
 			</trans-unit>
+			<trans-unit id="column.insertBefore">
+				<source>Create new content before</source>
+			</trans-unit>
+			<trans-unit id="column.insertAfter">
+				<source>Create new content after</source>
+			</trans-unit>
 			<trans-unit id="notification.contentCreated">
 				<source>Content element created</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_sitesettings.xlf
+++ b/Resources/Private/Language/locallang_sitesettings.xlf
@@ -105,6 +105,13 @@
                 <source>Opens content element edit forms in a sidebar panel instead of navigating to the backend. Requires TYPO3 v14.2+. This feature is experimental and may change in future versions.</source>
             </trans-unit>
 
+            <trans-unit id="settings.frontendEdit.showInsertButtons">
+                <source>Show insert buttons on hover</source>
+            </trans-unit>
+            <trans-unit id="settings.description.frontendEdit.showInsertButtons">
+                <source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard.</source>
+            </trans-unit>
+
             <trans-unit id="settings.frontendEdit.enableOutline">
                 <source>Enable Outline</source>
             </trans-unit>

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1036,6 +1036,11 @@
     font-weight: 400;
 }
 
+.frontend-edit__column-btn--append {
+    display: inline-flex;
+    width: auto;
+}
+
 /* ==========================================================================
    Contextual Edit Sidebar (Experimental)
    ========================================================================== */

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1041,6 +1041,65 @@
     width: auto;
 }
 
+/* Hover insert buttons (before/after a content element).
+   Live in the overlay layer so they render above the dashed outline and stay
+   reachable; shown together with the toolbar when the overlay is active. */
+.frontend-edit__insert-btn {
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    color: var(--xfe-toolbar-text);
+    background: var(--xfe-toolbar-bg);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, box-shadow 0.15s ease;
+}
+
+.frontend-edit__insert-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Centered ON the dashed outline (top/bottom edge). The pointer tracker keeps
+   the highlight stable while the cursor is over a button, so straddling the
+   edge no longer causes flicker. */
+.frontend-edit__insert-btn--before {
+    top: 0;
+}
+
+.frontend-edit__insert-btn--after {
+    top: 100%;
+}
+
+.frontend-edit__overlay--active .frontend-edit__insert-btn {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* Same hover feedback as the Edit / More Actions buttons: a translucent overlay
+   on top of the toolbar background. */
+.frontend-edit__insert-btn:hover {
+    box-shadow: inset 0 0 0 999px var(--xfe-toolbar-btn-hover);
+}
+
+.frontend-edit__insert-btn:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+    outline: 2px solid var(--xfe-outline-color);
+    outline-offset: 2px;
+}
+
 /* ==========================================================================
    Contextual Edit Sidebar (Experimental)
    ========================================================================== */

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -18,6 +18,7 @@
   const ICONS = {
     edit: '<svg viewBox="0 0 32 32" fill="currentColor"><path d="M4.834,29.665L25.007,29.665C26.561,29.663 27.839,28.385 27.841,26.831L27.841,16.157C27.841,15.608 27.39,15.157 26.841,15.157C26.292,15.157 25.841,15.608 25.841,16.157L25.841,26.831C25.84,27.288 25.464,27.664 25.007,27.665L4.834,27.665C4.377,27.664 4.001,27.288 4,26.831L4,7.651C4.001,7.194 4.377,6.818 4.834,6.817L16,6.817C16.549,6.817 17,6.366 17,5.817C17,5.268 16.549,4.817 16,4.817L4.834,4.817C3.28,4.819 2.002,6.097 2,7.651L2,26.831C2.002,28.385 3.28,29.663 4.834,29.665Z" fill-rule="nonzero"/><path d="M8.582,19.343L7.912,22.691C7.894,22.781 7.885,22.873 7.885,22.965C7.885,23.726 8.51,24.352 9.271,24.352C9.363,24.352 9.454,24.343 9.544,24.325L12.895,23.655C13.539,23.527 14.131,23.211 14.595,22.747L28.845,8.494C29.473,7.825 29.823,6.941 29.823,6.024C29.823,4.044 28.195,2.416 26.215,2.416C25.298,2.416 24.414,2.766 23.745,3.394L9.49,17.645C9.025,18.108 8.709,18.699 8.582,19.343ZM10.543,19.734C10.594,19.478 10.72,19.244 10.904,19.059L25.157,4.806C25.458,4.509 25.864,4.343 26.286,4.343C27.168,4.343 27.894,5.069 27.894,5.951C27.894,6.373 27.728,6.779 27.431,7.08L13.178,21.332C12.993,21.517 12.758,21.643 12.502,21.694L10.054,22.184L10.543,19.734Z" fill-rule="nonzero"/></svg>',
     kebab: '<svg viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="2.5" r="1.5"/><circle cx="8" cy="8" r="1.5"/><circle cx="8" cy="13.5" r="1.5"/></svg>',
+    add: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
     check: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 111.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>',
     warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>',
     error: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-1.4A5.6 5.6 0 1 0 8 2.4a5.6 5.6 0 0 0 0 11.2zM7.3 5h1.4v4.2H7.3V5zm0 5.6h1.4V12H7.3v-1.4z"/></svg>',
@@ -505,6 +506,9 @@
     container: null,
     overlays: new Map(), // Map<targetElement, {toolbar, outline}>
     scrollRAF: null,
+    activeElement: null,
+    pointerRAF: null,
+    lastPointer: { x: 0, y: 0 },
 
     /**
      * Check if a content element is nested inside another content element
@@ -535,6 +539,75 @@
 
       // Setup scroll/resize handlers
       this.setupEventHandlers();
+
+      // Single source of truth for which element is highlighted: the element the
+      // cursor is geometrically inside. This avoids mouseenter/leave races between
+      // adjacent elements and their overlay buttons — the highlight stays put
+      // until the cursor actually crosses into another element's box.
+      this.setupPointerTracking();
+    },
+
+    setupPointerTracking() {
+      const onMove = (e) => {
+        this.lastPointer = { x: e.clientX, y: e.clientY };
+        if (this.pointerRAF) return;
+        this.pointerRAF = requestAnimationFrame(() => {
+          this.pointerRAF = null;
+          this.updateActiveFromPointer();
+        });
+      };
+      document.addEventListener('mousemove', onMove, { passive: true });
+    },
+
+    updateActiveFromPointer() {
+      const { x, y } = this.lastPointer;
+      const el = document.elementFromPoint(x, y);
+
+      // While the cursor is over an overlay control (toolbar, insert button) or
+      // an open dropdown, keep the current highlight — same as Edit/More Actions.
+      if (el && el.closest('.frontend-edit__toolbar, .frontend-edit__insert-btn, .frontend-edit__dropdown')) {
+        return;
+      }
+
+      const next = this.resolveRegisteredElement(el);
+      if (next === this.activeElement) return;
+
+      // Hysteresis: keep the current element highlighted while the cursor is
+      // still within its box (≈ the dashed outline), so the highlight only
+      // switches when the cursor actually crosses the outline — symmetrically in
+      // every direction. (Without this, the wide top toolbar bridges upward hover
+      // but the narrow bottom button does not, so downward switched too early.)
+      // Moving into a nested child element still takes over immediately.
+      const enteringNested = next && this.activeElement && this.activeElement.contains(next);
+      if (!enteringNested && this.activeElement && this.rectContains(this.activeElement, x, y)) {
+        return;
+      }
+
+      if (this.activeElement) {
+        this.setActive(this.activeElement, false);
+        Dropdown.closeAll();
+      }
+      if (next) {
+        this.setActive(next, true);
+      }
+      this.activeElement = next;
+    },
+
+    rectContains(el, x, y, margin = 2) {
+      const r = el.getBoundingClientRect();
+      return x >= r.left - margin && x <= r.right + margin && y >= r.top - margin && y <= r.bottom + margin;
+    },
+
+    /**
+     * Walk up from a node to the nearest registered content element (innermost
+     * first, so nested elements highlight correctly). Returns null if none.
+     */
+    resolveRegisteredElement(node) {
+      while (node) {
+        if (this.overlays.has(node)) return node;
+        node = node.parentElement;
+      }
+      return null;
     },
 
     setupEventHandlers() {
@@ -574,10 +647,16 @@
       toolbar.style.pointerEvents = 'auto';
 
       overlay.appendChild(toolbar);
+
+      // Hover insert buttons (before/after), placed in the overlay layer so they
+      // render above the dashed outline and stay reachable via the hover bridge.
+      const insertButtons = UI.createInsertButtons(contentElement);
+      insertButtons.forEach(btn => overlay.appendChild(btn));
+
       this.container.appendChild(overlay);
 
       // Store reference
-      this.overlays.set(targetElement, { overlay, toolbar, outline, uid });
+      this.overlays.set(targetElement, { overlay, toolbar, outline, uid, insertButtons });
 
       // Initial position
       this.updatePosition(targetElement);
@@ -633,11 +712,6 @@
       } else {
         data.overlay.classList.remove('frontend-edit__overlay--active');
       }
-    },
-
-    getToolbar(targetElement) {
-      const data = this.overlays.get(targetElement);
-      return data?.toolbar;
     }
   };
 
@@ -759,6 +833,41 @@
       }
 
       return btn;
+    },
+
+    /**
+     * Build the hover "insert" buttons (before/after) for a content element,
+     * to be placed in the overlay layer. Returns [] when the feature is off or
+     * the backend supplied no URLs.
+     *
+     * @returns {HTMLAnchorElement[]}
+     */
+    createInsertButtons(contentElement) {
+      if (window.FRONTEND_EDIT_SHOW_INSERT_BUTTONS === false) return [];
+      const data = contentElement.element || {};
+      const labels = window.FRONTEND_EDIT_COLUMN_LABELS || {};
+      const tooltips = {
+        before: labels.insertBefore || 'Create new content before',
+        after: labels.insertAfter || 'Create new content after',
+      };
+
+      const make = (url, position) => {
+        const link = document.createElement('a');
+        link.href = url;
+        link.className = `frontend-edit__insert-btn frontend-edit__insert-btn--${position}`;
+        // pointer-events are gated by CSS (none when the overlay is inactive,
+        // auto when active) so hidden buttons of other elements aren't hoverable.
+        link.setAttribute('aria-label', tooltips[position]);
+        link.dataset.tooltip = tooltips[position];
+        link.innerHTML = ICONS.add;
+        Tooltip.attach(link);
+        return link;
+      };
+
+      const buttons = [];
+      if (data.newBeforeUrl && this.isValidUrl(data.newBeforeUrl)) buttons.push(make(data.newBeforeUrl, 'before'));
+      if (data.newAfterUrl && this.isValidUrl(data.newAfterUrl)) buttons.push(make(data.newAfterUrl, 'after'));
+      return buttons;
     },
 
     createKebabButton(uid) {
@@ -1123,6 +1232,7 @@
       });
     },
 
+
     setupContentElement(targetElement, uid, contentElement, showContextMenu, enableOutline) {
       const hasMenuChildren = contentElement.menu.children && Object.keys(contentElement.menu.children).length > 0;
       const effectiveShowContextMenu = showContextMenu && hasMenuChildren && !contentElement.menu.url;
@@ -1137,9 +1247,8 @@
         document.body.appendChild(dropdown);
         this.setupKebabEvents(toolbar, dropdown);
       }
-
-      // Setup hover events
-      this.setupHoverEvents(targetElement, dropdown);
+      // Hover highlighting is handled centrally by OverlayManager's pointer
+      // tracking (no per-element mouseenter/leave needed).
     },
 
     setupKebabEvents(toolbar, dropdown) {
@@ -1161,48 +1270,6 @@
           if (firstItem) firstItem.focus();
         }
       });
-    },
-
-    setupHoverEvents(targetElement, dropdown) {
-      targetElement.addEventListener('mouseenter', () => {
-        OverlayManager.setActive(targetElement, true);
-      });
-
-      targetElement.addEventListener('mouseleave', (e) => {
-        if (dropdown?.contains(e.relatedTarget)) return;
-
-        const toolbar = OverlayManager.getToolbar(targetElement);
-        if (toolbar?.contains(e.relatedTarget)) return;
-
-        OverlayManager.setActive(targetElement, false);
-        if (dropdown) Dropdown.closeAll();
-      });
-
-      // Keep active when hovering toolbar
-      const toolbar = OverlayManager.getToolbar(targetElement);
-      if (toolbar) {
-        toolbar.addEventListener('mouseenter', () => {
-          OverlayManager.setActive(targetElement, true);
-        });
-
-        toolbar.addEventListener('mouseleave', (e) => {
-          if (targetElement.contains(e.relatedTarget)) return;
-          if (dropdown?.contains(e.relatedTarget)) return;
-
-          OverlayManager.setActive(targetElement, false);
-          if (dropdown) Dropdown.closeAll();
-        });
-      }
-
-      if (dropdown) {
-        dropdown.addEventListener('mouseleave', (e) => {
-          if (targetElement.contains(e.relatedTarget)) return;
-          if (toolbar?.contains(e.relatedTarget)) return;
-
-          Dropdown.closeAll();
-          OverlayManager.setActive(targetElement, false);
-        });
-      }
     }
   };
 
@@ -1252,7 +1319,7 @@
 
         const icon = document.createElement('span');
         icon.className = 'frontend-edit__column-btn-icon';
-        icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>';
+        icon.innerHTML = ICONS.add;
         link.appendChild(icon);
 
         if (col.isEmpty) {

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1029,15 +1029,15 @@
 
         const data = await response.json();
 
-        // Handle wrapped response { contentElements, emptyColumns }
+        // Handle wrapped response { contentElements, columnTargets }
         if (data.contentElements !== undefined) {
-          Logger.log(`Backend response received with ${Object.keys(data.contentElements).length} content element(s) and ${(data.emptyColumns || []).length} empty column(s)`);
+          Logger.log(`Backend response received with ${Object.keys(data.contentElements).length} content element(s) and ${(data.columnTargets || []).length} column target(s)`);
           return data;
         }
 
         // Fallback for legacy response (plain content elements object)
         Logger.log(`Backend response received with ${Object.keys(data).length} content element(s)`);
-        return { contentElements: data, emptyColumns: [] };
+        return { contentElements: data, columnTargets: [] };
       } catch (error) {
         Notification.show({ title: 'Frontend Edit', message: 'Failed to load edit information', severity: 'error' });
         Logger.log('Failed to fetch content elements', { error: error.message }, 'error');
@@ -1189,21 +1189,22 @@
   };
 
   /**
-   * Empty Column Renderer - Matches AJAX emptyColumns data against
+   * Column Target Renderer - Matches AJAX columnTargets data against
    * [data-xfe-colpos] markers placed by the integrator in Fluid templates
-   * and injects "+" buttons client-side.
+   * and injects "+" buttons client-side. Empty columns show the full label;
+   * filled columns get a compact "+" at the column end.
    */
-  const EmptyColumnRenderer = {
-    render(emptyColumns) {
-      if (!emptyColumns || emptyColumns.length === 0) return;
+  const ColumnTargetRenderer = {
+    render(columnTargets) {
+      if (!columnTargets || columnTargets.length === 0) return;
 
-      Logger.log(`Processing ${emptyColumns.length} empty column(s)`);
+      Logger.log(`Processing ${columnTargets.length} column target(s)`);
       let rendered = 0;
 
       const columnLabels = window.FRONTEND_EDIT_COLUMN_LABELS || {};
       const buttonLabel = columnLabels.createContent || 'Create new content';
 
-      emptyColumns.forEach(col => {
+      columnTargets.forEach(col => {
         let selector = `[data-xfe-colpos="${col.colPos}"]`;
         if (col.containerUid) {
           selector += `[data-xfe-container="${col.containerUid}"]`;
@@ -1219,13 +1220,15 @@
           Logger.log(`Invalid URL for colPos ${col.colPos}`, null, 'warn');
           return;
         }
+
         const tooltipText = col.name
           ? (columnLabels.createContentIn || 'Create new content in "%s" column').replace('%s', col.name)
           : buttonLabel;
 
         const link = document.createElement('a');
         link.href = col.newContentUrl;
-        link.className = 'frontend-edit__column-btn';
+        link.className = 'frontend-edit__column-btn'
+          + (col.isEmpty ? ' frontend-edit__column-btn--empty' : ' frontend-edit__column-btn--append');
         link.setAttribute('aria-label', tooltipText);
         link.dataset.tooltip = tooltipText;
 
@@ -1234,10 +1237,12 @@
         icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>';
         link.appendChild(icon);
 
-        const label = document.createElement('span');
-        label.className = 'frontend-edit__column-btn-label';
-        label.textContent = col.name || buttonLabel;
-        link.appendChild(label);
+        if (col.isEmpty) {
+          const label = document.createElement('span');
+          label.className = 'frontend-edit__column-btn-label';
+          label.textContent = col.name || buttonLabel;
+          link.appendChild(label);
+        }
 
         marker.innerHTML = '';
         marker.appendChild(link);
@@ -1245,10 +1250,10 @@
         Tooltip.attach(link);
 
         rendered++;
-        Logger.log(`Empty column button rendered for colPos ${col.colPos}`, { name: col.name, url: col.newContentUrl });
+        Logger.log(`Column target button rendered for colPos ${col.colPos}`, { name: col.name, isEmpty: col.isEmpty, url: col.newContentUrl });
       });
 
-      Logger.log(`Empty column rendering complete: ${rendered}/${emptyColumns.length} buttons placed`);
+      Logger.log(`Column target rendering complete: ${rendered}/${columnTargets.length} buttons placed`);
     }
   };
 
@@ -1314,7 +1319,7 @@
           const response = await DataService.fetchContentElements(dataItems);
 
           Renderer.render(response.contentElements || {});
-          EmptyColumnRenderer.render(response.emptyColumns || []);
+          ColumnTargetRenderer.render(response.columnTargets || []);
           Dropdown.setupGlobalHandler();
           DeleteHandler.init();
         }

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -298,11 +298,29 @@
      * Initialize notifications by reading flash messages from DOM
      */
     init() {
+      // If the previous action was a "new content" create flow, relabel the
+      // backend's generic success flash ("Record saved") to a create-specific
+      // message. Consumed unconditionally so the flag never leaks to a later load.
+      // Only OK-severity messages are relabelled; warnings/errors pass through.
+      let createdFlow = false;
+      try {
+        if (sessionStorage.getItem('xfe-content-created')) {
+          sessionStorage.removeItem('xfe-content-created');
+          createdFlow = true;
+        }
+      } catch (_) { /* sessionStorage unavailable */ }
+
       const dataElement = document.querySelector('.frontend-edit-flash-messages');
       if (!dataElement) return;
 
       try {
-        const messages = JSON.parse(dataElement.textContent || '[]');
+        let messages = JSON.parse(dataElement.textContent || '[]');
+        if (createdFlow) {
+          const labels = window.FRONTEND_EDIT_NOTIFICATION_LABELS || {};
+          messages = messages.map(msg => String(msg.severity || '').toUpperCase() === 'OK'
+            ? { title: labels.contentCreated || 'Content element created', message: msg.message, severity: msg.severity }
+            : msg);
+        }
         if (messages.length > 0) {
           Logger.log(`Found ${messages.length} flash message(s) to display`);
           messages.forEach((msg, index) => {

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -713,12 +713,24 @@
   const LinkInterceptor = {
     init() {
       document.addEventListener('click', (e) => {
-        const target =
-          e.target.closest('.frontend-edit__btn--edit') ||
-          e.target.closest('.frontend-edit__dropdown a:not(.hide):not(.delete)') ||
-          e.target.closest('.frontend-edit__sticky-dropdown a') ||
-          e.target.closest('.frontend-edit__column-btn') ||
-          e.target.closest('.frontend-edit__open-modal');
+        let target;
+
+        if (window.FRONTEND_EDIT_SIDEBAR_EDIT === true) {
+          // v14.2+: the contextual sidebar handles editing. The modal only takes
+          // the New Content Element Wizard links — web_layout URLs carrying a
+          // #colPos hash (see UrlBuilderService.buildNewContentWizardUrl). Edit
+          // links are left untouched so the sidebar handler can act on them.
+          const link = e.target.closest('a[href]');
+          target = (link && link.href.includes('#colPos=')) ? link : null;
+        } else {
+          // v13 (no sidebar): the modal handles all frontend-edit links.
+          target =
+            e.target.closest('.frontend-edit__btn--edit') ||
+            e.target.closest('.frontend-edit__dropdown a:not(.hide):not(.delete)') ||
+            e.target.closest('.frontend-edit__sticky-dropdown a') ||
+            e.target.closest('.frontend-edit__column-btn') ||
+            e.target.closest('.frontend-edit__open-modal');
+        }
 
         if (target?.href && isBackendUrl(target.href)) {
           e.preventDefault();

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -741,6 +741,7 @@
             e.target.closest('.frontend-edit__dropdown a:not(.hide):not(.delete)') ||
             e.target.closest('.frontend-edit__sticky-dropdown a') ||
             e.target.closest('.frontend-edit__column-btn') ||
+            e.target.closest('.frontend-edit__insert-btn') ||
             e.target.closest('.frontend-edit__open-modal');
         }
 

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -43,10 +43,6 @@
   const WIZARD_PATCH_POLL_MS = 100;           // every 100ms
   const WIZARD_PATCH_TIMEOUT_MS = 5000;       // give up after 5s
 
-  // Fixed wait before auto-clicking a wizard button (give the wizard
-  // time to render its items after the page loads).
-  const WIZARD_CLICK_DELAY_MS = 800;
-
   const WIZARD_SELECTORS = 'typo3-backend-new-record-wizard, typo3-backend-new-content-element-wizard';
 
   /**
@@ -176,7 +172,6 @@
       }
 
       this.getOrCreate();
-      IframeHandler._wizardAutoClicked = false;
       const { iframe } = this;
       const loader = this.element.querySelector('.frontend-edit__modal-loader');
 
@@ -257,7 +252,6 @@
     onLoad(iframe) {
       this.overrideContentContainer(iframe);
       this.ensureBackendModules(iframe);
-      this.autoClickWizardButton(iframe);
       this.patchWizardComponents(iframe);
       this.interceptIframeClicks(iframe);
       this.detectFrontendNavigation(iframe);
@@ -343,57 +337,6 @@
         Logger.log('ContentContainer.setUrl overridden');
         return true;
       }, CONTENT_CONTAINER_POLL_MS, CONTENT_CONTAINER_TIMEOUT_MS);
-    },
-
-    // ── Wizard auto-click ──────────────────────────────────────────
-
-    _wizardAutoClicked: false,
-
-    autoClickWizardButton(iframe) {
-      try {
-        if (this._wizardAutoClicked) return;
-
-        const currentUrl = (iframe.contentWindow?.location.href || iframe.src || '');
-        const hashPart = currentUrl.split('#')[1];
-        if (!hashPart) return;
-
-        const params = new URLSearchParams(hashPart);
-        const colPos = params.get('colPos');
-        const container = params.get('container');
-        const afterUid = params.get('afterUid');
-        if (!colPos) return;
-
-        Logger.log('Auto-click wizard detected', { colPos, container, afterUid });
-
-        setTimeout(() => {
-          try {
-            const buttons = iframe.contentWindow.document.querySelectorAll(
-              'typo3-backend-new-content-element-wizard-button'
-            );
-            for (const btn of buttons) {
-              if (this.matchesWizardButton(btn.getAttribute('url') || '', colPos, container, afterUid)) {
-                this._wizardAutoClicked = true;
-                btn.click();
-                return;
-              }
-            }
-          } catch (e) { Logger.log('Error clicking wizard button', e, 'error'); }
-        }, WIZARD_CLICK_DELAY_MS);
-      } catch (_) { /* ignore */ }
-    },
-
-    matchesWizardButton(btnUrl, colPos, container, afterUid) {
-      const colPosMatch = btnUrl.match(/colPos=(\d+)/);
-
-      if (afterUid) {
-        const m = btnUrl.match(/uid_pid=-(\d+)/);
-        return m && m[1] === afterUid && colPosMatch && colPosMatch[1] === colPos;
-      }
-      if (container) {
-        const m = btnUrl.match(/tx_container_parent=(\d+)/);
-        return colPosMatch && colPosMatch[1] === colPos && m && m[1] === container;
-      }
-      return colPosMatch && colPosMatch[1] === colPos && !btnUrl.includes('tx_container_parent');
     },
 
     // ── Wizard component patching ──────────────────────────────────
@@ -633,12 +576,6 @@
           Logger.log('Detected frontend URL in iframe');
           this.closeAndReload();
           return;
-        }
-        // After a wizard auto-click + save cycle, navigating back to
-        // web_layout means the record was saved — close and reload.
-        if (this._wizardAutoClicked && isPageLayoutPath(currentHref, iframe.contentWindow.location.origin)) {
-          Logger.log('Detected page layout after wizard save — closing modal');
-          this.closeAndReload();
         }
       } catch (_) { /* cross-origin */ }
     },

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -43,6 +43,10 @@
   const WIZARD_PATCH_POLL_MS = 100;           // every 100ms
   const WIZARD_PATCH_TIMEOUT_MS = 5000;       // give up after 5s
 
+  // Fixed wait before auto-clicking a wizard button (give the wizard
+  // time to render its items after the page loads).
+  const WIZARD_CLICK_DELAY_MS = 800;
+
   const WIZARD_SELECTORS = 'typo3-backend-new-record-wizard, typo3-backend-new-content-element-wizard';
 
   /**
@@ -172,6 +176,7 @@
       }
 
       this.getOrCreate();
+      IframeHandler._wizardAutoClicked = false;
       const { iframe } = this;
       const loader = this.element.querySelector('.frontend-edit__modal-loader');
 
@@ -252,6 +257,7 @@
     onLoad(iframe) {
       this.overrideContentContainer(iframe);
       this.ensureBackendModules(iframe);
+      this.autoClickWizardButton(iframe);
       this.patchWizardComponents(iframe);
       this.interceptIframeClicks(iframe);
       this.detectFrontendNavigation(iframe);
@@ -337,6 +343,57 @@
         Logger.log('ContentContainer.setUrl overridden');
         return true;
       }, CONTENT_CONTAINER_POLL_MS, CONTENT_CONTAINER_TIMEOUT_MS);
+    },
+
+    // ── Wizard auto-click ──────────────────────────────────────────
+
+    _wizardAutoClicked: false,
+
+    autoClickWizardButton(iframe) {
+      try {
+        if (this._wizardAutoClicked) return;
+
+        const currentUrl = (iframe.contentWindow?.location.href || iframe.src || '');
+        const hashPart = currentUrl.split('#')[1];
+        if (!hashPart) return;
+
+        const params = new URLSearchParams(hashPart);
+        const colPos = params.get('colPos');
+        const container = params.get('container');
+        const afterUid = params.get('afterUid');
+        if (!colPos) return;
+
+        Logger.log('Auto-click wizard detected', { colPos, container, afterUid });
+
+        setTimeout(() => {
+          try {
+            const buttons = iframe.contentWindow.document.querySelectorAll(
+              'typo3-backend-new-content-element-wizard-button'
+            );
+            for (const btn of buttons) {
+              if (this.matchesWizardButton(btn.getAttribute('url') || '', colPos, container, afterUid)) {
+                this._wizardAutoClicked = true;
+                btn.click();
+                return;
+              }
+            }
+          } catch (e) { Logger.log('Error clicking wizard button', e, 'error'); }
+        }, WIZARD_CLICK_DELAY_MS);
+      } catch (_) { /* ignore */ }
+    },
+
+    matchesWizardButton(btnUrl, colPos, container, afterUid) {
+      const colPosMatch = btnUrl.match(/colPos=(\d+)/);
+
+      if (afterUid) {
+        const m = btnUrl.match(/uid_pid=-(\d+)/);
+        return m && m[1] === afterUid && colPosMatch && colPosMatch[1] === colPos;
+      }
+      if (container) {
+        const m = btnUrl.match(/tx_container_parent=(\d+)/);
+        return colPosMatch && colPosMatch[1] === colPos && m && m[1] === container;
+      }
+      return colPosMatch && colPosMatch[1] === colPos && !btnUrl.includes('tx_container_parent');
     },
 
     // ── Wizard component patching ──────────────────────────────────
@@ -576,6 +633,12 @@
           Logger.log('Detected frontend URL in iframe');
           this.closeAndReload();
           return;
+        }
+        // After a wizard auto-click + save cycle, navigating back to
+        // web_layout means the record was saved — close and reload.
+        if (this._wizardAutoClicked && isPageLayoutPath(currentHref, iframe.contentWindow.location.origin)) {
+          Logger.log('Detected page layout after wizard save — closing modal');
+          this.closeAndReload();
         }
       } catch (_) { /* cross-origin */ }
     },

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -177,6 +177,9 @@
 
       this.getOrCreate();
       IframeHandler._wizardAutoClicked = false;
+      // A modal opened with a #colPos hash is a "new content" (create) flow;
+      // remembered so the post-save success flash can be relabelled "created".
+      IframeHandler._createFlow = url.includes('#colPos=');
       const { iframe } = this;
       const loader = this.element.querySelector('.frontend-edit__modal-loader');
 
@@ -348,6 +351,7 @@
     // ── Wizard auto-click ──────────────────────────────────────────
 
     _wizardAutoClicked: false,
+    _createFlow: false,
 
     autoClickWizardButton(iframe) {
       try {
@@ -683,6 +687,14 @@
     closeAndReload(scrollToEdited = false) {
       let uid = null;
       if (scrollToEdited) uid = this.getEditedElementUid();
+
+      // Carry the create-flow intent across the reload. If a save actually
+      // happened, the backend's "Record saved" success flash will be present
+      // on the next load and Notification.init() relabels it to "created".
+      // On cancel there is no success flash, so nothing is relabelled.
+      if (this._createFlow) {
+        try { sessionStorage.setItem('xfe-content-created', '1'); } catch (_) { /* unavailable */ }
+      }
 
       // Show modal loader in case it wasn't shown yet (e.g. close without save)
       this.showModalLoader();

--- a/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
+++ b/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
@@ -16,9 +16,12 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder};
+use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
 
@@ -39,8 +42,14 @@ final class EmptyColumnServiceTest extends TestCase
 
     protected function setUp(): void
     {
+        // Mock UriBuilder singleton so real UrlBuilderService picks it up
+        $uriBuilderMock = $this->createMock(UriBuilder::class);
+        $uriBuilderMock->method('buildUriFromRoute')
+            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+
         $this->connectionPool = $this->createMock(ConnectionPool::class);
-        $this->urlBuilderService = $this->createMock(UrlBuilderService::class);
+        $this->urlBuilderService = new UrlBuilderService();
         $this->languageServiceFactory = $this->createMock(LanguageServiceFactory::class);
 
         // Mock schema manager to simulate missing tx_container_parent field
@@ -51,11 +60,15 @@ final class EmptyColumnServiceTest extends TestCase
         $this->connectionPool->method('getConnectionForTable')->willReturn($connection);
     }
 
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
     #[Test]
     public function getColumnTargetsMarksFilledColumnsAsNotEmpty(): void
     {
         $this->mockQueryBuilderWithCount(3);
-        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -74,7 +87,6 @@ final class EmptyColumnServiceTest extends TestCase
     public function getColumnTargetsMarksEmptyColumnsAsEmpty(): void
     {
         $this->mockQueryBuilderWithCount(0);
-        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -92,7 +104,6 @@ final class EmptyColumnServiceTest extends TestCase
     public function getColumnTargetsIgnoresContainerMarkersWithoutContainerField(): void
     {
         $this->mockQueryBuilderWithCount(1);
-        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -126,7 +137,6 @@ final class EmptyColumnServiceTest extends TestCase
 
         // All columns empty
         $this->mockQueryBuilderWithCountForPool($connectionPool, 0);
-        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $connectionPool,

--- a/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
+++ b/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
@@ -16,12 +16,11 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
-use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder};
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
 
 /**
  * EmptyColumnServiceTest.
@@ -34,14 +33,14 @@ final class EmptyColumnServiceTest extends TestCase
 {
     private ConnectionPool $connectionPool;
 
-    private UriBuilder $uriBuilder;
+    private UrlBuilderService $urlBuilderService;
 
     private LanguageServiceFactory $languageServiceFactory;
 
     protected function setUp(): void
     {
         $this->connectionPool = $this->createMock(ConnectionPool::class);
-        $this->uriBuilder = $this->createMock(UriBuilder::class);
+        $this->urlBuilderService = $this->createMock(UrlBuilderService::class);
         $this->languageServiceFactory = $this->createMock(LanguageServiceFactory::class);
 
         // Mock schema manager to simulate missing tx_container_parent field
@@ -53,50 +52,51 @@ final class EmptyColumnServiceTest extends TestCase
     }
 
     #[Test]
-    public function getEmptyColumnsReturnsEmptyArrayWhenAllColumnsHaveContent(): void
+    public function getColumnTargetsMarksFilledColumnsAsNotEmpty(): void
     {
-        $this->mockQueryBuilderWithCount(1);
+        $this->mockQueryBuilderWithCount(3);
+        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->uriBuilder,
+            $this->urlBuilderService,
             $this->languageServiceFactory,
         );
 
-        $result = $service->getEmptyColumns(1, 0, '/return');
-
-        self::assertSame([], $result);
-    }
-
-    #[Test]
-    public function getEmptyColumnsReturnsColumnsWithNewContentUrl(): void
-    {
-        $this->mockQueryBuilderWithCount(0);
-        $this->uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/record/edit'));
-
-        $service = new EmptyColumnService(
-            $this->connectionPool,
-            $this->uriBuilder,
-            $this->languageServiceFactory,
-        );
-
-        $result = $service->getEmptyColumns(1, 0, '/return');
+        $result = $service->getColumnTargets(1, 0, '/return');
 
         self::assertNotEmpty($result);
-        self::assertArrayHasKey('colPos', $result[0]);
+        self::assertFalse($result[0]['isEmpty']);
         self::assertArrayHasKey('newContentUrl', $result[0]);
-        self::assertArrayHasKey('name', $result[0]);
-        self::assertSame('/typo3/record/edit', $result[0]['newContentUrl']);
     }
 
     #[Test]
-    public function getEmptyColumnsIgnoresContainerMarkersWithoutContainerField(): void
+    public function getColumnTargetsMarksEmptyColumnsAsEmpty(): void
     {
-        $this->mockQueryBuilderWithCount(1);
+        $this->mockQueryBuilderWithCount(0);
+        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->uriBuilder,
+            $this->urlBuilderService,
+            $this->languageServiceFactory,
+        );
+
+        $result = $service->getColumnTargets(1, 0, '/return');
+
+        self::assertNotEmpty($result);
+        self::assertTrue($result[0]['isEmpty']);
+    }
+
+    #[Test]
+    public function getColumnTargetsIgnoresContainerMarkersWithoutContainerField(): void
+    {
+        $this->mockQueryBuilderWithCount(1);
+        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
+
+        $service = new EmptyColumnService(
+            $this->connectionPool,
+            $this->urlBuilderService,
             $this->languageServiceFactory,
         );
 
@@ -106,14 +106,15 @@ final class EmptyColumnServiceTest extends TestCase
             ],
         ];
 
-        $result = $service->getEmptyColumns(1, 0, '/return', $requestData);
+        $result = $service->getColumnTargets(1, 0, '/return', $requestData);
 
         // Container markers should be ignored since tx_container_parent field does not exist
-        self::assertSame([], $result);
+        $containerResults = array_filter($result, static fn (array $r): bool => isset($r['containerUid']));
+        self::assertEmpty($containerResults);
     }
 
     #[Test]
-    public function getEmptyColumnsHandlesContainerMarkersWhenFieldExists(): void
+    public function getColumnTargetsHandlesContainerMarkersWhenFieldExists(): void
     {
         // Mock schema manager to simulate tx_container_parent field exists
         $connectionPool = $this->createMock(ConnectionPool::class);
@@ -125,11 +126,11 @@ final class EmptyColumnServiceTest extends TestCase
 
         // All columns empty
         $this->mockQueryBuilderWithCountForPool($connectionPool, 0);
-        $this->uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/record/edit'));
+        $this->urlBuilderService->method('buildNewContentWizardUrl')->willReturn('/typo3/record/content/wizard/new');
 
         $service = new EmptyColumnService(
             $connectionPool,
-            $this->uriBuilder,
+            $this->urlBuilderService,
             $this->languageServiceFactory,
         );
 
@@ -139,17 +140,18 @@ final class EmptyColumnServiceTest extends TestCase
             ],
         ];
 
-        $result = $service->getEmptyColumns(1, 0, '/return', $requestData);
+        $result = $service->getColumnTargets(1, 0, '/return', $requestData);
 
         $containerResults = array_filter($result, static fn (array $r): bool => isset($r['containerUid']));
         self::assertNotEmpty($containerResults);
         $first = array_values($containerResults)[0];
         self::assertSame(200, $first['colPos']);
         self::assertSame(42, $first['containerUid']);
+        self::assertTrue($first['isEmpty']);
     }
 
     #[Test]
-    public function getEmptyColumnsFiltersInvalidContainerMarkers(): void
+    public function getColumnTargetsFiltersInvalidContainerMarkers(): void
     {
         // Mock schema manager with container field
         $connectionPool = $this->createMock(ConnectionPool::class);
@@ -159,15 +161,12 @@ final class EmptyColumnServiceTest extends TestCase
         $connection->method('createSchemaManager')->willReturn($schemaManager);
         $connectionPool->method('getConnectionForTable')->willReturn($connection);
 
-        // Keep page columns non-empty, but make any unexpected container lookup observable
+        // Keep page columns non-empty
         $this->mockQueryBuilderWithCountForPool($connectionPool, 1);
-        $this->uriBuilder
-            ->expects(self::never())
-            ->method('buildUriFromRoute');
 
         $service = new EmptyColumnService(
             $connectionPool,
-            $this->uriBuilder,
+            $this->urlBuilderService,
             $this->languageServiceFactory,
         );
 
@@ -179,7 +178,7 @@ final class EmptyColumnServiceTest extends TestCase
             ],
         ];
 
-        $result = $service->getEmptyColumns(1, 0, '/return', $requestData);
+        $result = $service->getColumnTargets(1, 0, '/return', $requestData);
 
         $containerResults = array_filter($result, static fn (array $r): bool => isset($r['containerUid']));
         self::assertEmpty($containerResults);

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
-use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
 
 /**
  * UrlBuilderServiceTest.
@@ -133,41 +132,6 @@ final class UrlBuilderServiceTest extends TestCase
         $result = $service->buildHistoryUrl(1, 'tt_content', '/return');
 
         self::assertSame('/typo3/record_history', $result);
-    }
-
-    #[Test]
-    public function buildNewContentAfterUrlReturnsRecordEditUrlOnV14(): void
-    {
-        if (!VersionUtility::is14OrHigher()) {
-            self::markTestSkipped('TYPO3 v14+ only');
-        }
-
-        $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('record_edit', self::callback(static fn (array $params): bool => isset($params['edit']['tt_content'][-1]) && 'new' === $params['edit']['tt_content'][-1]))
-            ->willReturn(new Uri('/typo3/record/edit'));
-
-        $service = new UrlBuilderService();
-        $result = $service->buildNewContentAfterUrl(1, 5, 0, 2, '/return');
-
-        self::assertSame('/typo3/record/edit', $result);
-    }
-
-    #[Test]
-    public function buildNewContentAfterUrlReturnsHashedWebLayoutUrlOnV13(): void
-    {
-        if (VersionUtility::is14OrHigher()) {
-            self::markTestSkipped('TYPO3 v13 only');
-        }
-
-        $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn (array $params): bool => 5 === ($params['id'] ?? null) && 2 === ($params['language'] ?? null) && '/return' === ($params['returnUrl'] ?? null)))
-            ->willReturn(new Uri('/typo3/module/web/layout'));
-
-        $service = new UrlBuilderService();
-        $result = $service->buildNewContentAfterUrl(1, 5, 0, 2, '/return');
-
-        // Hash fragment carries colPos + afterUid for the iframe wizard auto-click
-        self::assertSame('/typo3/module/web/layout#colPos=0&afterUid=1', $result);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -213,46 +213,43 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildNewContentWizardUrlAppendsToColumnWhenNoUidAfter(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
+            ->with('web_layout', self::callback(static fn (array $p): bool =>
                 5 === $p['id']
-                && 0 === $p['colPos']
-                && 2 === $p['sys_language_uid']
-                && 5 === $p['uid_pid']
-                && '/return' === $p['returnUrl']
-                && !isset($p['tx_container_parent'])))
-            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+                && 2 === $p['language']
+                && '/return' === $p['returnUrl']))
+            ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
         $result = $service->buildNewContentWizardUrl(5, 0, 2, '/return');
 
-        self::assertSame('/typo3/record/content/wizard/new', $result);
+        // No afterUid / container → only colPos in the hash (auto-click the column's wizard button)
+        self::assertSame('/typo3/module/web/layout#colPos=0', $result);
     }
 
     #[Test]
-    public function buildNewContentWizardUrlUsesNegativeUidPidWhenInsertingAfterElement(): void
+    public function buildNewContentWizardUrlAddsAfterUidToHashWhenInsertingAfterElement(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
-                -42 === $p['uid_pid'] && 3 === $p['colPos']))
-            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+            ->with('web_layout', self::callback(static fn (array $p): bool =>
+                5 === $p['id'] && 0 === $p['language'] && '/return' === $p['returnUrl']))
+            ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
         $result = $service->buildNewContentWizardUrl(5, 3, 0, '/return', uidAfter: 42);
 
-        self::assertSame('/typo3/record/content/wizard/new', $result);
+        self::assertSame('/typo3/module/web/layout#colPos=3&afterUid=42', $result);
     }
 
     #[Test]
-    public function buildNewContentWizardUrlAddsContainerParentWhenGiven(): void
+    public function buildNewContentWizardUrlAddsContainerToHashWhenGiven(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
-                200 === ($p['tx_container_parent'] ?? null)))
-            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+            ->with('web_layout', self::anything())
+            ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();
         $result = $service->buildNewContentWizardUrl(5, 1, 0, '/return', containerUid: 200);
 
-        self::assertSame('/typo3/record/content/wizard/new', $result);
+        self::assertSame('/typo3/module/web/layout#colPos=1&container=200', $result);
     }
 }

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -244,4 +244,51 @@ final class UrlBuilderServiceTest extends TestCase
 
         self::assertSame('/typo3/ajax/frontend-edit/edit-information', $result);
     }
+
+    #[Test]
+    public function buildNewContentWizardUrlAppendsToColumnWhenNoUidAfter(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
+                5 === $p['id']
+                && 0 === $p['colPos']
+                && 2 === $p['sys_language_uid']
+                && 5 === $p['uid_pid']
+                && '/return' === $p['returnUrl']
+                && !isset($p['tx_container_parent'])))
+            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildNewContentWizardUrl(5, 0, 2, '/return');
+
+        self::assertSame('/typo3/record/content/wizard/new', $result);
+    }
+
+    #[Test]
+    public function buildNewContentWizardUrlUsesNegativeUidPidWhenInsertingAfterElement(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
+                -42 === $p['uid_pid'] && 3 === $p['colPos']))
+            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildNewContentWizardUrl(5, 3, 0, '/return', uidAfter: 42);
+
+        self::assertSame('/typo3/record/content/wizard/new', $result);
+    }
+
+    #[Test]
+    public function buildNewContentWizardUrlAddsContainerParentWhenGiven(): void
+    {
+        $this->uriBuilderMock->method('buildUriFromRoute')
+            ->with('new_content_element_wizard', self::callback(static fn (array $p): bool =>
+                200 === ($p['tx_container_parent'] ?? null)))
+            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
+
+        $service = new UrlBuilderService();
+        $result = $service->buildNewContentWizardUrl(5, 1, 0, '/return', containerUid: 200);
+
+        self::assertSame('/typo3/record/content/wizard/new', $result);
+    }
 }

--- a/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
+++ b/Tests/Unit/Service/Ui/UrlBuilderServiceTest.php
@@ -213,8 +213,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildNewContentWizardUrlAppendsToColumnWhenNoUidAfter(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn (array $p): bool =>
-                5 === $p['id']
+            ->with('web_layout', self::callback(static fn (array $p): bool => 5 === $p['id']
                 && 2 === $p['language']
                 && '/return' === $p['returnUrl']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
@@ -230,8 +229,7 @@ final class UrlBuilderServiceTest extends TestCase
     public function buildNewContentWizardUrlAddsAfterUidToHashWhenInsertingAfterElement(): void
     {
         $this->uriBuilderMock->method('buildUriFromRoute')
-            ->with('web_layout', self::callback(static fn (array $p): bool =>
-                5 === $p['id'] && 0 === $p['language'] && '/return' === $p['returnUrl']))
+            ->with('web_layout', self::callback(static fn (array $p): bool => 5 === $p['id'] && 0 === $p['language'] && '/return' === $p['returnUrl']))
             ->willReturn(new Uri('/typo3/module/web/layout'));
 
         $service = new UrlBuilderService();


### PR DESCRIPTION
<img width="960" height="742" alt="new-content-element-wizard" src="https://github.com/user-attachments/assets/89c25e8e-012f-4a42-954e-4757a8102252" />


## Summary

- Create new content elements directly from the frontend via TYPO3's **native New Content Element Wizard** (the real type picker), on **TYPO3 v13 and v14**.
- Entry points:
  - **New content after** in the element edit menu
  - **"+ content"** in empty columns and at the **end of filled columns** (via the `ColumnTarget` ViewHelper marker)
  - **Hover "+" buttons** above/below every element to insert **before/after** it (optional, new setting `frontendEdit.showInsertButtons`, default on)
- After saving a newly created element, the generic backend success flash (`Record saved`) is relabelled to **"Content element created"** (record-name kept; warnings/errors pass through unchanged).

## How it works

The `new_content_element_wizard` route is an **AJAX-modal fragment**, not a navigable page (TYPO3 core only opens it via `Modal.advanced({type:'ajax'})`). So the wizard is opened by loading the page module inside the frontend-edit iframe modal and auto-clicking the matching wizard button — the same mechanism on v13 and v14. On v14 the contextual sidebar continues to handle editing existing elements; new content uses the modal.

The element-hover highlighting was reworked to a single geometry-based pointer tracker (the highlight follows the element the cursor is inside and only switches when crossing the outline), which also keeps the insert buttons behaving like the Edit / More Actions buttons.

## Requirements / Notes

- The new-content flow is hosted in the iframe modal, so it **requires `frontendEdit.enableContextualEditing`** to be enabled.
- Container columns (EXT:container) pass `tx_container_parent` through to the wizard — verify per setup.

## Changes

- `Classes/Service/Ui/UrlBuilderService.php` — `buildNewContentWizardUrl()`, the single source for every new-content URL (web_layout + hash for the iframe auto-click)
- `Classes/Service/Menu/ContentElementButtonBuilder.php` — "new content after" uses the wizard URL
- `Classes/Service/Menu/ContentElementMenuGenerator.php` — per-element `newBeforeUrl`/`newAfterUrl` (previous-sibling lookup for "before")
- `Classes/Service/Content/EmptyColumnService.php` — emits wizard targets for empty **and** filled columns
- `Classes/Service/Ui/ResourceRendererService.php`, `SettingsService.php`, `settings.definitions.yaml` — `showInsertButtons` setting, JS flags, labels
- `Resources/Public/JavaScript/frontend_edit.js` — geometry-based hover tracker, column-target & insert-button renderers, create-flash relabel
- `Resources/Public/JavaScript/iframe_edit.js` — load the wizard page module + auto-click; v14 modal coexistence
- `Resources/Public/Css/FrontendEdit.css`, language files, `Documentation/` — styling, labels, docs

## Test plan

- v13 and v14, frontend edit active, `enableContextualEditing` on:
  - New-content-after / empty column / end-of-column / hover before+after → wizard opens in the modal → pick type → save → returns to the frontend with "Content element created"
  - Edit existing element still opens the contextual sidebar (v14)
- Unit: `UrlBuilderServiceTest`, `EmptyColumnServiceTest`; full suite green, PHPStan level 8 clean

## Follow-ups (not in this PR)

- Automated E2E (Playwright) journey for the wizard flow
- Optional: decouple the new-content flow from `enableContextualEditing`
