### PR TITLE
fix: add target-language attribute to de.locallang.xlf for TYPO3 v14 compatibility

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-	<file source-language="en" datatype="plaintext" original="messages">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>
 			<trans-unit id="edit_menu">


### PR DESCRIPTION
## Summary

- German frontend-edit dropdown labels rendered empty on TYPO3 v14
- Root cause: `de.locallang.xlf` was missing the `target-language` attribute on its `<file>` element

## Background

TYPO3 v14 replaced the deprecated `XliffParser` with a Symfony-based `XliffLoader` that decides whether a file is the default template or a translation **solely** by the presence of the `target-language` attribute:

```php
// XliffLoader::parseXliff1()
$isDefaultLanguage = !isset($fileTag['target-language']);
```

Without the attribute, v14 treats the German file as an English template, reads the empty `<source />` instead of `<target>`, and returns empty strings. TYPO3 v13's parser derived the language from the filename, so the missing attribute went unnoticed.

Verified against TYPO3 14.3.4: labels now resolve correctly (e.g. `edit_menu` → "Bearbeitungsmenü", `move` → "Verschieben", `delete` → "Löschen").

## Changes

- `Resources/Private/Language/de.locallang.xlf` — add `target-language="de"` to the `<file>` element (`de.locallang_sitesettings.xlf` already had it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation metadata for German language content to better align with localization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->