### PR TITLE
feat: allow hiding new content menu button and confirm record deletion

### DIFF
--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -158,6 +158,7 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         array $contentElement,
         int $languageUid,
         string $returnUrlAnchor,
+        bool $showInsertButtons = true,
     ): void {
         $this->addButton($menuButton, 'div_action', ButtonType::Divider);
 
@@ -184,17 +185,20 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
 
         // New content after button — opens the native New Content Element Wizard
         // (type-picker grid) positioned after this element. Same route on v13/v14.
-        $newContentUrl = $this->urlBuilderService->buildNewContentWizardUrl(
-            (int) ($contentElement['pid'] ?? 0),
-            (int) ($contentElement['colPos'] ?? 0),
-            $languageUid,
-            $returnUrlAnchor,
-            uidAfter: (int) $contentElement['uid'],
-            containerUid: (int) ($contentElement['tx_container_parent'] ?? 0) > 0
-                ? (int) $contentElement['tx_container_parent']
-                : null,
-        );
-        $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
+        // Gated by the same setting as the hover insert buttons for consistency.
+        if ($showInsertButtons) {
+            $newContentUrl = $this->urlBuilderService->buildNewContentWizardUrl(
+                (int) ($contentElement['pid'] ?? 0),
+                (int) ($contentElement['colPos'] ?? 0),
+                $languageUid,
+                $returnUrlAnchor,
+                uidAfter: (int) $contentElement['uid'],
+                containerUid: (int) ($contentElement['tx_container_parent'] ?? 0) > 0
+                    ? (int) $contentElement['tx_container_parent']
+                    : null,
+            );
+            $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
+        }
 
         // Delete button
         $deleteUrl = $this->urlBuilderService->buildDeleteUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -117,7 +117,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
                 continue;
             }
 
-            $menuButton = $this->createMenuButton($contentElement, $languageUid, $pid, $returnUrlAnchor, $contentElementConfig, $request, $contextualUrl);
+            $menuButton = $this->createMenuButton($contentElement, $languageUid, $pid, $returnUrlAnchor, $contentElementConfig, $request, $contextualUrl, $showInsertButtons);
             $this->handleAdditionalData($menuButton, $contentElement, $contentElementConfig, $data, $languageUid, $returnUrlAnchor);
 
             /** @var FrontendEditDropdownModifyEvent $event */
@@ -221,6 +221,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         array $contentElementConfig,
         ServerRequestInterface $request,
         ?string $contextualUrl = null,
+        bool $showInsertButtons = true,
     ): Button {
         if (!$this->settingsService->isShowContextMenu($request)) {
             return $this->contentElementButtonBuilder->createSimpleEditButton(
@@ -236,7 +237,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
 
         $this->contentElementButtonBuilder->addInfoSection($menuButton, $contentElement, $contentElementConfig);
         $this->contentElementButtonBuilder->addEditSection($menuButton, $contentElement, $languageUid, $pid, $returnUrlAnchor, $contextualUrl);
-        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $languageUid, $returnUrlAnchor);
+        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $languageUid, $returnUrlAnchor, $showInsertButtons);
 
         return $menuButton;
     }

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -128,6 +128,7 @@ final readonly class ResourceRendererService
             'cancel' => $this->translate('delete.confirm.cancel', 'Cancel'),
             'delete' => $this->translate('delete.confirm.delete', 'Delete record (!)'),
             'success' => $this->translate('delete.success', 'Record deleted'),
+            'successMessage' => $this->translate('delete.success.message', 'The record was successfully deleted. The page will reload shortly.'),
             'error' => $this->translate('delete.error', 'Could not delete the record'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $columnLabels = json_encode([

--- a/Documentation/Configuration/SiteSettings.rst
+++ b/Documentation/Configuration/SiteSettings.rst
@@ -57,6 +57,23 @@ Appearance Settings
         frontendEdit:
           showContextMenu: true
 
+..  confval:: frontendEdit.showInsertButtons
+
+    :type: bool
+    :Default: true
+
+    ..  versionadded:: 2.3.0
+
+    Show the ``+`` buttons above and below each content element on hover to insert a
+    new element before or after it via the New Content Element Wizard. This setting
+    also controls the **New content after** entry in the Edit Menu. Disable to hide
+    both.
+
+    ..  code-block:: yaml
+
+        frontendEdit:
+          showInsertButtons: true
+
 ..  confval:: frontendEdit.showStickyToolbar
 
     :type: bool

--- a/Documentation/Usage/EditMenu.rst
+++ b/Documentation/Usage/EditMenu.rst
@@ -26,6 +26,11 @@ Clicking this button opens the Edit Menu with various actions:
     :alt: Edit Menu
 
 ..  note::
+    The **New content after** entry can be hidden via the
+    :confval:`frontendEdit.showInsertButtons` site setting, which also controls the
+    hover insert buttons.
+
+..  note::
     The Edit Menu is only displayed if the backend user has the necessary
     permissions to edit the content element.
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -103,6 +103,10 @@
 				<source />
 				<target>Datensatz gelöscht</target>
 			</trans-unit>
+			<trans-unit id="delete.success.message">
+				<source />
+				<target>Der Datensatz wurde erfolgreich gelöscht. Die Seite wird in Kürze neu geladen.</target>
+			</trans-unit>
 			<trans-unit id="delete.error">
 				<source />
 				<target>Der Datensatz konnte nicht gelöscht werden</target>

--- a/Resources/Private/Language/de.locallang_sitesettings.xlf
+++ b/Resources/Private/Language/de.locallang_sitesettings.xlf
@@ -176,8 +176,8 @@
 				<target>Einfügen-Buttons beim Hover anzeigen</target>
 			</trans-unit>
 			<trans-unit id="settings.description.frontendEdit.showInsertButtons">
-				<source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard.</source>
-				<target>Zeigt beim Hover über jedem Inhaltselement "+"-Buttons oben und unten an, um per New Content Element Wizard ein neues Element davor oder danach einzufügen.</target>
+				<source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard. Also controls the "new content after" entry in the content element context menu.</source>
+				<target>Zeigt beim Hover über jedem Inhaltselement "+"-Buttons oben und unten an, um per New Content Element Wizard ein neues Element davor oder danach einzufügen. Steuert zusätzlich den Eintrag "Neuen Inhalt danach" im Kontextmenü des Inhaltselements.</target>
 			</trans-unit>
 
 			<trans-unit id="settings.frontendEdit.filter.ignoreUids">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -78,6 +78,9 @@
 			<trans-unit id="delete.success">
 				<source>Record deleted</source>
 			</trans-unit>
+			<trans-unit id="delete.success.message">
+				<source>The record was successfully deleted. The page will reload shortly.</source>
+			</trans-unit>
 			<trans-unit id="delete.error">
 				<source>Could not delete the record</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_sitesettings.xlf
+++ b/Resources/Private/Language/locallang_sitesettings.xlf
@@ -109,7 +109,7 @@
                 <source>Show insert buttons on hover</source>
             </trans-unit>
             <trans-unit id="settings.description.frontendEdit.showInsertButtons">
-                <source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard.</source>
+                <source>Shows "+" buttons above and below each content element on hover to insert a new element before or after it via the New Content Element Wizard. Also controls the "new content after" entry in the content element context menu.</source>
             </trans-unit>
 
             <trans-unit id="settings.frontendEdit.enableOutline">

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -276,7 +276,7 @@
       fetch(url, { method: 'GET', credentials: 'include', redirect: 'manual' })
         .then((response) => {
           if (response.type === 'opaqueredirect' || response.ok) {
-            Notification.show({ title: l.success || 'Record deleted', message: '', severity: 'ok' });
+            Notification.show({ title: l.success || 'Record deleted', message: l.successMessage || '', severity: 'ok' });
             setTimeout(() => window.location.reload(), 1500);
           } else {
             Notification.show({ title: l.error || 'Could not delete the record', message: '', severity: 'error' });

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -208,4 +208,18 @@ final class ContentElementButtonBuilderTest extends TestCase
         self::assertArrayHasKey('history', $children);
         self::assertArrayHasKey('new_content_after', $children);
     }
+
+    #[Test]
+    public function addActionSectionOmitsNewContentButtonWhenInsertButtonsDisabled(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], 0, '/return', false);
+
+        $children = $menuButton->getChildren();
+        self::assertArrayNotHasKey('new_content_after', $children);
+        self::assertArrayHasKey('hide', $children);
+        self::assertArrayHasKey('delete', $children);
+    }
 }


### PR DESCRIPTION
## Summary

- Make the **New content after** entry in the content element Edit Menu respect the existing `frontendEdit.showInsertButtons` site setting, so it can be hidden together with the hover insert buttons for consistent configuration
- Show a descriptive confirmation message in the success notification after a record is deleted from the frontend

## Changes

- `Classes/Service/Menu/ContentElementButtonBuilder.php` - Gate the `new_content_after` button behind a `showInsertButtons` flag
- `Classes/Service/Menu/ContentElementMenuGenerator.php` - Pass `showInsertButtons` through to the action section builder
- `Classes/Service/Ui/ResourceRendererService.php` - Provide the delete success message label to the frontend
- `Resources/Public/JavaScript/frontend_edit.js` - Show the delete success message in the notification
- `Resources/Private/Language/*sitesettings.xlf` - Extend `showInsertButtons` description (EN + DE)
- `Resources/Private/Language/locallang.xlf`, `de.locallang.xlf` - Add `delete.success.message` label (EN + DE)
- `Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php` - Cover the hidden-button case
- `Documentation/Configuration/SiteSettings.rst`, `Documentation/Usage/EditMenu.rst` - Document `showInsertButtons` and its effect on the menu entry

## Test plan

- [x] `vendor/bin/phpunit` (unit tests green)
- [x] PHPStan level 8 clean
- [x] PHP CS Fixer clean
- [ ] Manually verify `showInsertButtons: false` hides both hover buttons and the menu entry
- [ ] Manually verify the delete confirmation message appears after deleting a record

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a site setting to control whether insert buttons are shown in the editor.
  * Delete actions now display a clearer success message after completion.

* **Bug Fixes**
  * The “New content after” menu entry now follows the insert-button setting, keeping the menu consistent with the visible hover controls.

* **Documentation**
  * Updated site setting and Edit Menu docs to explain the new behavior.

* **Tests**
  * Added coverage for hiding the “New content after” option when insert buttons are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->