### PR TITLE
test: raise coverage to 92% with unit and functional test suites

### DIFF
--- a/Classes/Repository/ContentElementRepository.php
+++ b/Classes/Repository/ContentElementRepository.php
@@ -126,12 +126,14 @@ final readonly class ContentElementRepository
     ): array|false {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
 
+        $parentField = $GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField'] ?? 'l10n_parent';
+
         return $queryBuilder
             ->select('*')
             ->from($table)
             ->where(
                 $queryBuilder->expr()->eq(
-                    'l10n_parent',
+                    $parentField,
                     $queryBuilder->createNamedParameter($parentUid, Connection::PARAM_INT),
                 ),
                 $queryBuilder->expr()->eq(

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\{ServerRequest, Stream};
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Controller\AjaxController;
+
+/**
+ * AjaxControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class AjaxControllerTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'xima/xima-typo3-frontend-edit',
+    ];
+
+    private AjaxController $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__.'/Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/pages.csv');
+
+        $this->subject = $this->get(AjaxController::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function toggleActionReturns403WithoutBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->subject->toggleAction();
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->decode($response)['success']);
+    }
+
+    #[Test]
+    public function toggleActionEnablesDisabledStateOnFirstCall(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->toggleAction();
+
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($payload['success']);
+        self::assertTrue($payload['disabled']);
+    }
+
+    #[Test]
+    public function toggleActionTogglesBackWhenAlreadyDisabled(): void
+    {
+        $backendUser = $this->setUpBackendUser(1);
+        $backendUser->uc[Configuration::UC_KEY_DISABLED] = true;
+
+        $payload = $this->decode($this->subject->toggleAction());
+
+        self::assertTrue($payload['success']);
+        self::assertFalse($payload['disabled']);
+    }
+
+    #[Test]
+    public function toggleActionPersistsStateToUserConfiguration(): void
+    {
+        $backendUser = $this->setUpBackendUser(1);
+
+        $this->subject->toggleAction();
+
+        self::assertTrue((bool) $backendUser->uc[Configuration::UC_KEY_DISABLED]);
+    }
+
+    #[Test]
+    public function editInformationActionReturnsEmptyArrayWithoutBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '1', 'returnUrl' => '/']));
+
+        self::assertSame([], $this->decode($response));
+    }
+
+    #[Test]
+    public function editInformationActionReturns400OnInvalidPid(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '0', 'returnUrl' => '/']));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertArrayHasKey('error', $this->decode($response));
+    }
+
+    #[Test]
+    public function editInformationActionReturns400OnMissingPid(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['returnUrl' => '/']));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function editInformationActionReturns400OnInvalidLanguage(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest([
+            'pid' => '1',
+            'language' => '-5',
+            'returnUrl' => '/',
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function editInformationActionReturns400OnMissingReturnUrl(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '1']));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertArrayHasKey('error', $this->decode($response));
+    }
+
+    #[Test]
+    public function editInformationActionReturns400OnInvalidJsonBody(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $request = $this->createRequest(['pid' => '1', 'returnUrl' => '/'])
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->stream('{invalid json'));
+
+        $response = $this->subject->editInformationAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('Invalid request data', $this->decode($response)['error']);
+    }
+
+    #[Test]
+    public function editInformationActionReturnsEmptyArrayWhenPageAccessDenied(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '999', 'returnUrl' => '/']));
+
+        self::assertSame([], $this->decode($response));
+    }
+
+    #[Test]
+    public function editInformationActionReturnsDropdownStructureOnValidRequest(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '1', 'returnUrl' => '/']));
+
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayHasKey('contentElements', $payload);
+        self::assertArrayHasKey('columnTargets', $payload);
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function createRequest(array $queryParams): ServerRequestInterface
+    {
+        return (new ServerRequest('https://example.com/', 'GET'))
+            ->withQueryParams($queryParams);
+    }
+
+    private function stream(string $content): Stream
+    {
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($content);
+        $stream->rewind();
+
+        return $stream;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(\Psr\Http\Message\ResponseInterface $response): array
+    {
+        $response->getBody()->rewind();
+
+        return json_decode($response->getBody()->getContents(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/Tests/Functional/Controller/Fixtures/be_users.csv
+++ b/Tests/Functional/Controller/Fixtures/be_users.csv
@@ -1,0 +1,3 @@
+"be_users"
+,"uid","pid","username","admin","disable","deleted"
+,1,0,"admin",1,0,0

--- a/Tests/Functional/Controller/Fixtures/pages.csv
+++ b/Tests/Functional/Controller/Fixtures/pages.csv
@@ -1,0 +1,3 @@
+"pages"
+,"uid","pid","doktype","title","deleted","hidden","perms_userid","perms_groupid","perms_user","perms_group","perms_everybody"
+,1,0,1,"Root",0,0,1,0,31,31,31

--- a/Tests/Functional/Middleware/Fixtures/be_users.csv
+++ b/Tests/Functional/Middleware/Fixtures/be_users.csv
@@ -1,0 +1,4 @@
+"be_users"
+,"uid","pid","username","admin","disable","deleted","TSconfig"
+,1,0,"admin",1,0,0,""
+,2,0,"disabled_fe",1,0,0,"tx_ximatypo3frontendedit.disabled = 1"

--- a/Tests/Functional/Middleware/ToolRendererMiddlewareTest.php
+++ b/Tests/Functional/Middleware/ToolRendererMiddlewareTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Functional\Middleware;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\{HtmlResponse, ServerRequest};
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use Xima\XimaTypo3FrontendEdit\Middleware\ToolRendererMiddleware;
+
+/**
+ * ToolRendererMiddlewareTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ToolRendererMiddlewareTest extends FunctionalTestCase
+{
+    public const HTML = '<html><body><h1>Page</h1></body></html>';
+    protected array $testExtensionsToLoad = [
+        'xima/xima-typo3-frontend-edit',
+    ];
+
+    private ToolRendererMiddleware $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__.'/Fixtures/be_users.csv');
+
+        $this->subject = $this->get(ToolRendererMiddleware::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function processReturnsUnchangedResponseWhenFeatureDisabled(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: false),
+            $this->createHandler(),
+        );
+
+        self::assertSame(self::HTML, $this->readBody($response));
+    }
+
+    #[Test]
+    public function processReturnsUnchangedResponseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: true),
+            $this->createHandler(),
+        );
+
+        self::assertSame(self::HTML, $this->readBody($response));
+    }
+
+    #[Test]
+    public function processReturnsUnchangedResponseWhenDisabledViaUserTsConfig(): void
+    {
+        $this->setUpBackendUser(2);
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: true),
+            $this->createHandler(),
+        );
+
+        self::assertSame(self::HTML, $this->readBody($response));
+    }
+
+    #[Test]
+    public function processInjectsResourcesBeforeBodyClosingTag(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: true),
+            $this->createHandler(),
+        );
+
+        $body = $this->readBody($response);
+
+        self::assertStringContainsString('</body>', $body);
+        self::assertStringContainsString('<h1>Page</h1>', $body);
+        self::assertNotSame(self::HTML, $body);
+        self::assertStringEndsWith('</body></html>', $body);
+    }
+
+    private function createRequest(bool $enabled): ServerRequestInterface
+    {
+        $site = new Site('test', 1, [
+            'base' => 'https://example.com/',
+            'settings' => [
+                'frontendEdit' => [
+                    'enabled' => $enabled,
+                    'enableFlashMessages' => false,
+                    'enableContextualEditing' => false,
+                ],
+            ],
+        ]);
+
+        return (new ServerRequest('https://example.com/', 'GET'))
+            ->withAttribute('site', $site);
+    }
+
+    private function createHandler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new HtmlResponse(ToolRendererMiddlewareTest::HTML);
+            }
+        };
+    }
+
+    private function readBody(ResponseInterface $response): string
+    {
+        $response->getBody()->rewind();
+
+        return $response->getBody()->getContents();
+    }
+}

--- a/Tests/Functional/Repository/ContentElementRepositoryTest.php
+++ b/Tests/Functional/Repository/ContentElementRepositoryTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Functional\Repository;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
+
+/**
+ * ContentElementRepositoryTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ContentElementRepositoryTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'xima/xima-typo3-frontend-edit',
+    ];
+
+    private ContentElementRepository $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__.'/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/tt_content.csv');
+
+        $this->subject = $this->get(ContentElementRepository::class);
+    }
+
+    #[Test]
+    public function fetchContentElementsReturnsVisibleDefaultLanguageAndAllLanguageRecords(): void
+    {
+        $result = $this->subject->fetchContentElements(2, 0);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+        sort($uids);
+
+        self::assertSame([1, 2, 6], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsExcludesHiddenDeletedAndForeignPageRecords(): void
+    {
+        $result = $this->subject->fetchContentElements(2, 0);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertNotContains(4, $uids);
+        self::assertNotContains(5, $uids);
+        self::assertNotContains(7, $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsReturnsTranslatedRecordForGivenLanguage(): void
+    {
+        $result = $this->subject->fetchContentElements(2, 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+        sort($uids);
+
+        self::assertSame([3, 6], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsReturnsEmptyArrayForPageWithoutContent(): void
+    {
+        self::assertSame([], $this->subject->fetchContentElements(999, 0));
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsReturnsEmptyArrayForEmptyInput(): void
+    {
+        self::assertSame([], $this->subject->fetchContentElementsByUids([], 0));
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsReturnsMatchingRecordsAcrossPages(): void
+    {
+        $result = $this->subject->fetchContentElementsByUids([1, 7], 0);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+        sort($uids);
+
+        self::assertSame([1, 7], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsWithoutMultilingualContentReturnsOnlyGivenLanguage(): void
+    {
+        $result = $this->subject->fetchContentElementsByUids([1, 6], 0, false);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([1], $uids);
+    }
+
+    #[Test]
+    public function getTranslatedRecordReturnsTranslationRow(): void
+    {
+        $record = $this->subject->getTranslatedRecord('pages', 2, 1);
+
+        self::assertIsArray($record);
+        self::assertSame(5, (int) $record['uid']);
+    }
+
+    #[Test]
+    public function getTranslatedRecordReturnsFalseWhenNoTranslationExists(): void
+    {
+        self::assertFalse($this->subject->getTranslatedRecord('pages', 3, 1));
+    }
+
+    #[Test]
+    public function getTranslatedRecordResolvesTtContentViaTransOrigPointerField(): void
+    {
+        $record = $this->subject->getTranslatedRecord('tt_content', 1, 1);
+
+        self::assertIsArray($record);
+        self::assertSame(3, (int) $record['uid']);
+        self::assertSame('Translated DE', $record['header']);
+    }
+
+    #[Test]
+    public function getTranslatedRecordReturnsFalseForUntranslatedTtContent(): void
+    {
+        self::assertFalse($this->subject->getTranslatedRecord('tt_content', 2, 1));
+    }
+
+    #[Test]
+    public function getPageDoktypeReturnsDoktype(): void
+    {
+        self::assertSame(254, $this->subject->getPageDoktype(4));
+    }
+
+    #[Test]
+    public function getPageDoktypeReturnsNullForMissingPage(): void
+    {
+        self::assertNull($this->subject->getPageDoktype(999));
+    }
+
+    #[Test]
+    public function isSubpageOfReturnsTrueForAncestor(): void
+    {
+        self::assertTrue($this->subject->isSubpageOf(3, 1));
+    }
+
+    #[Test]
+    public function isSubpageOfReturnsFalseForUnrelatedPage(): void
+    {
+        self::assertFalse($this->subject->isSubpageOf(2, 4));
+    }
+
+    #[Test]
+    public function isSubpageOfUsesCacheOnRepeatedCalls(): void
+    {
+        self::assertTrue($this->subject->isSubpageOf(3, 1));
+        self::assertTrue($this->subject->isSubpageOf(3, 1));
+    }
+
+    #[Test]
+    public function isSubpageOfAnyReturnsTrueWhenOneMatches(): void
+    {
+        self::assertTrue($this->subject->isSubpageOfAny(3, [99, 1]));
+    }
+
+    #[Test]
+    public function isSubpageOfAnyReturnsFalseWhenNoneMatch(): void
+    {
+        self::assertFalse($this->subject->isSubpageOfAny(3, [98, 99]));
+    }
+
+    #[Test]
+    public function getContentElementConfigReturnsFalseForUnknownCType(): void
+    {
+        self::assertFalse($this->subject->getContentElementConfig('does_not_exist', ''));
+    }
+
+    #[Test]
+    public function getContentElementConfigReturnsItemForKnownCType(): void
+    {
+        $config = $this->subject->getContentElementConfig('text', '');
+
+        self::assertIsArray($config);
+        self::assertSame('text', $config['value']);
+    }
+
+    #[Test]
+    public function getContentElementConfigUsesCacheOnRepeatedCalls(): void
+    {
+        $first = $this->subject->getContentElementConfig('text', '');
+        $second = $this->subject->getContentElementConfig('text', '');
+
+        self::assertSame($first, $second);
+    }
+}

--- a/Tests/Functional/Repository/Fixtures/pages.csv
+++ b/Tests/Functional/Repository/Fixtures/pages.csv
@@ -1,0 +1,7 @@
+"pages"
+,"uid","pid","doktype","title","sys_language_uid","l10n_parent","deleted","hidden"
+,1,0,1,"Root",0,0,0,0
+,2,1,1,"Subpage",0,0,0,0
+,3,2,1,"Subsubpage",0,0,0,0
+,4,1,254,"Folder",0,0,0,0
+,5,1,1,"Subpage DE",1,2,0,0

--- a/Tests/Functional/Repository/Fixtures/tt_content.csv
+++ b/Tests/Functional/Repository/Fixtures/tt_content.csv
@@ -1,0 +1,9 @@
+"tt_content"
+,"uid","pid","sys_language_uid","l18n_parent","CType","header","hidden","deleted"
+,1,2,0,0,"text","Default EN",0,0
+,2,2,0,0,"textmedia","Second EN",0,0
+,3,2,1,1,"text","Translated DE",0,0
+,4,2,0,0,"text","Hidden",1,0
+,5,2,0,0,"text","Deleted",0,1
+,6,2,-1,0,"text","All languages",0,0
+,7,3,0,0,"text","Other page",0,0

--- a/Tests/Functional/SmokeTest.php
+++ b/Tests/Functional/SmokeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * SmokeTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class SmokeTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'xima/xima-typo3-frontend-edit',
+    ];
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $packageManager = GeneralUtility::makeInstance(PackageManager::class);
+
+        self::assertTrue($packageManager->isPackageActive('xima_typo3_frontend_edit'));
+    }
+}

--- a/Tests/Unit/EventListener/ModifyButtonBarEventListenerTest.php
+++ b/Tests/Unit/EventListener/ModifyButtonBarEventListenerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Template\Components\{ButtonBar, ModifyButtonBarEvent};
+use TYPO3\CMS\Backend\Template\Components\Buttons\InputButton;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\EventListener\ModifyButtonBarEventListener;
+
+/**
+ * ModifyButtonBarEventListenerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ModifyButtonBarEventListener::class)]
+final class ModifyButtonBarEventListenerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenSaveAndCloseButtonDisabled(): void
+    {
+        $listener = $this->createListener(['enableSaveAndCloseButton' => false]);
+        $event = $this->createEvent([]);
+
+        $listener($event);
+
+        self::assertSame([], $event->getButtons());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenConfigurationKeyMissing(): void
+    {
+        $listener = $this->createListener([]);
+        $event = $this->createEvent([]);
+
+        $listener($event);
+
+        self::assertSame([], $event->getButtons());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenRequestIsNotServerRequest(): void
+    {
+        $listener = $this->createListener(['enableSaveAndCloseButton' => true]);
+        $GLOBALS['TYPO3_REQUEST'] = null;
+        $event = $this->createEvent([]);
+
+        $listener($event);
+
+        self::assertSame([], $event->getButtons());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenQueryParameterMissing(): void
+    {
+        $listener = $this->createListener(['enableSaveAndCloseButton' => true]);
+        $this->registerRequest([]);
+        $event = $this->createEvent([]);
+
+        $listener($event);
+
+        self::assertSame([], $event->getButtons());
+    }
+
+    #[Test]
+    public function invokeDoesNotAddButtonWhenSaveButtonMissing(): void
+    {
+        $listener = $this->createListener(['enableSaveAndCloseButton' => true]);
+        $this->registerRequest(['tx_ximatypo3frontendedit' => '1']);
+        $event = $this->createEvent([]);
+
+        $listener($event);
+
+        self::assertArrayNotHasKey(ButtonBar::BUTTON_POSITION_LEFT, $event->getButtons());
+    }
+
+    #[Test]
+    public function invokeAddsSaveAndCloseButtonWhenSaveButtonPresent(): void
+    {
+        $listener = $this->createListener(['enableSaveAndCloseButton' => true]);
+        $this->registerRequest(['tx_ximatypo3frontendedit' => '1']);
+        $this->registerServices();
+
+        $saveButton = (new InputButton())->setName('_savedok')->setValue('1')->setForm('EditDocumentController');
+        $buttons = [ButtonBar::BUTTON_POSITION_LEFT => [2 => [0 => $saveButton]]];
+        $buttonBar = $this->createMock(ButtonBar::class);
+        $buttonBar->method('makeInputButton')->willReturn(new InputButton());
+        $event = new ModifyButtonBarEvent($buttons, $buttonBar);
+
+        $listener($event);
+
+        $resultButtons = $event->getButtons()[ButtonBar::BUTTON_POSITION_LEFT][2];
+        self::assertCount(2, $resultButtons);
+        self::assertSame('_saveandclosedok', $resultButtons[1]->getName());
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createListener(array $configuration): ModifyButtonBarEventListener
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($configuration);
+
+        return new ModifyButtonBarEventListener($extensionConfiguration);
+    }
+
+    /**
+     * @param array<string, mixed> $buttons
+     */
+    private function createEvent(array $buttons): ModifyButtonBarEvent
+    {
+        return new ModifyButtonBarEvent($buttons, $this->createMock(ButtonBar::class));
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function registerRequest(array $queryParams): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn($queryParams);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+    }
+
+    private function registerServices(): void
+    {
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->method('getIcon')->willReturn($this->createMock(Icon::class));
+        GeneralUtility::addInstance(IconFactory::class, $iconFactory);
+        GeneralUtility::setSingletonInstance(PageRenderer::class, $this->createMock(PageRenderer::class));
+
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturn('Save and close');
+        $GLOBALS['LANG'] = $languageService;
+    }
+}

--- a/Tests/Unit/EventListener/ModifyButtonBarEventListenerTest.php
+++ b/Tests/Unit/EventListener/ModifyButtonBarEventListenerTest.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\EventListener;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
 use TYPO3\CMS\Backend\Template\Components\{ButtonBar, ModifyButtonBarEvent};
 use TYPO3\CMS\Backend\Template\Components\Buttons\InputButton;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -109,7 +110,12 @@ final class ModifyButtonBarEventListenerTest extends TestCase
         $buttons = [ButtonBar::BUTTON_POSITION_LEFT => [2 => [0 => $saveButton]]];
         $buttonBar = $this->createMock(ButtonBar::class);
         $buttonBar->method('makeInputButton')->willReturn(new InputButton());
-        $event = new ModifyButtonBarEvent($buttons, $buttonBar);
+        $eventArgs = [$buttons, $buttonBar];
+        $eventReflection = new ReflectionClass(ModifyButtonBarEvent::class);
+        if ($eventReflection->getConstructor()->getNumberOfParameters() >= 3) {
+            $eventArgs[] = $this->createMock(ServerRequestInterface::class);
+        }
+        $event = $eventReflection->newInstanceArgs($eventArgs);
 
         $listener($event);
 
@@ -134,7 +140,13 @@ final class ModifyButtonBarEventListenerTest extends TestCase
      */
     private function createEvent(array $buttons): ModifyButtonBarEvent
     {
-        return new ModifyButtonBarEvent($buttons, $this->createMock(ButtonBar::class));
+        $args = [$buttons, $this->createMock(ButtonBar::class)];
+        $reflection = new ReflectionClass(ModifyButtonBarEvent::class);
+        if ($reflection->getConstructor()->getNumberOfParameters() >= 3) {
+            $args[] = $this->createMock(ServerRequestInterface::class);
+        }
+
+        return $reflection->newInstanceArgs($args);
     }
 
     /**
@@ -157,5 +169,12 @@ final class ModifyButtonBarEventListenerTest extends TestCase
         $languageService = $this->createMock(LanguageService::class);
         $languageService->method('sL')->willReturn('Save and close');
         $GLOBALS['LANG'] = $languageService;
+
+        $componentFactoryClass = 'TYPO3\\CMS\\Backend\\Template\\Components\\ComponentFactory';
+        if (class_exists($componentFactoryClass)) {
+            $componentFactory = $this->createMock($componentFactoryClass);
+            $componentFactory->method('createInputButton')->willReturn(new InputButton());
+            GeneralUtility::addInstance($componentFactoryClass, $componentFactory);
+        }
     }
 }

--- a/Tests/Unit/EventListener/PageLayoutScrollEventListenerTest.php
+++ b/Tests/Unit/EventListener/PageLayoutScrollEventListenerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Template\Components\{ButtonBar, ModifyButtonBarEvent};
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\EventListener\PageLayoutScrollEventListener;
+
+/**
+ * PageLayoutScrollEventListenerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(PageLayoutScrollEventListener::class)]
+final class PageLayoutScrollEventListenerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['TYPO3_REQUEST']);
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenRequestIsNotServerRequest(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = null;
+        $pageRenderer = $this->registerPageRenderer();
+        $pageRenderer->expects(self::never())->method('loadJavaScriptModule');
+
+        (new PageLayoutScrollEventListener())($this->createEvent());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenScrollToElementParameterMissing(): void
+    {
+        $this->registerRequest([], null);
+        $pageRenderer = $this->registerPageRenderer();
+        $pageRenderer->expects(self::never())->method('loadJavaScriptModule');
+
+        (new PageLayoutScrollEventListener())($this->createEvent());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenRouteIsNotRoute(): void
+    {
+        $this->registerRequest(['scrollToElement' => '5'], new stdClass());
+        $pageRenderer = $this->registerPageRenderer();
+        $pageRenderer->expects(self::never())->method('loadJavaScriptModule');
+
+        (new PageLayoutScrollEventListener())($this->createEvent());
+    }
+
+    #[Test]
+    public function invokeReturnsEarlyWhenRouteIsNotWebLayout(): void
+    {
+        $route = $this->createMock(Route::class);
+        $route->method('getOption')->with('_identifier')->willReturn('web_list');
+        $this->registerRequest(['scrollToElement' => '5'], $route);
+        $pageRenderer = $this->registerPageRenderer();
+        $pageRenderer->expects(self::never())->method('loadJavaScriptModule');
+
+        (new PageLayoutScrollEventListener())($this->createEvent());
+    }
+
+    #[Test]
+    public function invokeLoadsJavaScriptModuleOnWebLayoutRoute(): void
+    {
+        $route = $this->createMock(Route::class);
+        $route->method('getOption')->with('_identifier')->willReturn('web_layout');
+        $this->registerRequest(['scrollToElement' => '5'], $route);
+        $pageRenderer = $this->registerPageRenderer();
+        $pageRenderer->expects(self::once())
+            ->method('loadJavaScriptModule')
+            ->with('@xima/ximatypo3frontendedit/scroll_to_element.js');
+
+        (new PageLayoutScrollEventListener())($this->createEvent());
+    }
+
+    private function createEvent(): ModifyButtonBarEvent
+    {
+        return new ModifyButtonBarEvent([], $this->createMock(ButtonBar::class));
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function registerRequest(array $queryParams, mixed $route): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn($queryParams);
+        $request->method('getAttribute')->with('route')->willReturn($route);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+    }
+
+    private function registerPageRenderer(): PageRenderer
+    {
+        $pageRenderer = $this->createMock(PageRenderer::class);
+        GeneralUtility::setSingletonInstance(PageRenderer::class, $pageRenderer);
+
+        return $pageRenderer;
+    }
+}

--- a/Tests/Unit/EventListener/PageLayoutScrollEventListenerTest.php
+++ b/Tests/Unit/EventListener/PageLayoutScrollEventListenerTest.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\EventListener;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
 use stdClass;
 use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Template\Components\{ButtonBar, ModifyButtonBarEvent};
@@ -96,7 +97,13 @@ final class PageLayoutScrollEventListenerTest extends TestCase
 
     private function createEvent(): ModifyButtonBarEvent
     {
-        return new ModifyButtonBarEvent([], $this->createMock(ButtonBar::class));
+        $args = [[], $this->createMock(ButtonBar::class)];
+        $reflection = new ReflectionClass(ModifyButtonBarEvent::class);
+        if ($reflection->getConstructor()->getNumberOfParameters() >= 3) {
+            $args[] = $this->createMock(ServerRequestInterface::class);
+        }
+
+        return $reflection->newInstanceArgs($args);
     }
 
     /**

--- a/Tests/Unit/Service/Configuration/SettingsServiceTest.php
+++ b/Tests/Unit/Service/Configuration/SettingsServiceTest.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Configuration;
+
+use Exception;
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Settings\SettingsInterface;
+use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
+use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
+
+/**
+ * SettingsServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(SettingsService::class)]
+final class SettingsServiceTest extends TestCase
+{
+    #[Test]
+    public function isEnabledReturnsFalseWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertFalse($service->isEnabled($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isEnabledReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.enabled' => false]);
+
+        self::assertFalse($service->isEnabled($request));
+    }
+
+    #[Test]
+    public function isEnabledDefaultsToTrue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings([]);
+
+        self::assertTrue($service->isEnabled($request));
+    }
+
+    #[Test]
+    public function getIgnoredPidsReturnsEmptyArrayWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertSame([], $service->getIgnoredPids($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function getIgnoredPidsParsesCommaDelimitedString(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignorePids' => '1, 2 ,3']);
+
+        self::assertSame(['1', '2', '3'], array_values($service->getIgnoredPids($request)));
+    }
+
+    #[Test]
+    public function getIgnoredPidsReturnsEmptyArrayForEmptyValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignorePids' => '']);
+
+        self::assertSame([], $service->getIgnoredPids($request));
+    }
+
+    #[Test]
+    public function getIgnoredPidsFiltersEmptyItems(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignorePids' => '1,,2']);
+
+        self::assertSame(['1', '2'], array_values($service->getIgnoredPids($request)));
+    }
+
+    #[Test]
+    public function getIgnoredPidsReturnsEmptyArrayWhenSettingThrows(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithThrowingSettings();
+
+        self::assertSame([], $service->getIgnoredPids($request));
+    }
+
+    #[Test]
+    public function getIgnoredDoktypesReturnsIntegers(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignoreDoktypes' => '3,254']);
+
+        self::assertSame([3, 254], array_values($service->getIgnoredDoktypes($request)));
+    }
+
+    #[Test]
+    public function getIgnoredCTypesParsesValues(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignoreCTypes' => 'text,html']);
+
+        self::assertSame(['text', 'html'], array_values($service->getIgnoredCTypes($request)));
+    }
+
+    #[Test]
+    public function getIgnoredListTypesParsesValues(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignoreListTypes' => 'news_pi1']);
+
+        self::assertSame(['news_pi1'], array_values($service->getIgnoredListTypes($request)));
+    }
+
+    #[Test]
+    public function getIgnoredUidsReturnsIntegers(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.filter.ignoreUids' => '5,6']);
+
+        self::assertSame([5, 6], array_values($service->getIgnoredUids($request)));
+    }
+
+    #[Test]
+    public function getColorSchemeReturnsAutoWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertSame('auto', $service->getColorScheme($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function getColorSchemeReturnsValidScheme(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.colorScheme' => 'dark']);
+
+        self::assertSame('dark', $service->getColorScheme($request));
+    }
+
+    #[Test]
+    public function getColorSchemeFallsBackToAutoForInvalidValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.colorScheme' => 'neon']);
+
+        self::assertSame('auto', $service->getColorScheme($request));
+    }
+
+    #[Test]
+    public function isShowContextMenuReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isShowContextMenu($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isShowContextMenuReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.showContextMenu' => false]);
+
+        self::assertFalse($service->isShowContextMenu($request));
+    }
+
+    #[Test]
+    public function isShowStickyToolbarReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isShowStickyToolbar($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isShowStickyToolbarReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.showStickyToolbar' => false]);
+
+        self::assertFalse($service->isShowStickyToolbar($request));
+    }
+
+    #[Test]
+    public function isShowInsertButtonsReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isShowInsertButtons($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isShowInsertButtonsReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.showInsertButtons' => false]);
+
+        self::assertFalse($service->isShowInsertButtons($request));
+    }
+
+    #[Test]
+    public function getToolbarPositionReturnsDefaultWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertSame('bottom-right', $service->getToolbarPosition($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function getToolbarPositionReturnsValidPosition(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.toolbarPosition' => 'top-left']);
+
+        self::assertSame('top-left', $service->getToolbarPosition($request));
+    }
+
+    #[Test]
+    public function getToolbarPositionFallsBackForInvalidPosition(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.toolbarPosition' => 'middle']);
+
+        self::assertSame('bottom-right', $service->getToolbarPosition($request));
+    }
+
+    #[Test]
+    public function isEnableOutlineReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isEnableOutline($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isEnableOutlineReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.enableOutline' => false]);
+
+        self::assertFalse($service->isEnableOutline($request));
+    }
+
+    #[Test]
+    public function isEnableScrollToElementReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isEnableScrollToElement($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isEnableScrollToElementReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.enableScrollToElement' => false]);
+
+        self::assertFalse($service->isEnableScrollToElement($request));
+    }
+
+    #[Test]
+    public function isContextualEditingEnabledReturnsFalseWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertFalse($service->isContextualEditingEnabled($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isContextualEditingEnabledReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.enableContextualEditing' => true]);
+
+        self::assertTrue($service->isContextualEditingEnabled($request));
+    }
+
+    #[Test]
+    public function isEnableFlashMessagesReturnsTrueWhenNoSite(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+
+        self::assertTrue($service->isEnableFlashMessages($this->createRequestWithoutSite()));
+    }
+
+    #[Test]
+    public function isEnableFlashMessagesReturnsSettingValue(): void
+    {
+        $service = new SettingsService($this->createMock(ExtensionConfiguration::class));
+        $request = $this->createRequestWithSettings(['frontendEdit.enableFlashMessages' => false]);
+
+        self::assertFalse($service->isEnableFlashMessages($request));
+    }
+
+    #[Test]
+    public function isFrontendDebugModeEnabledReturnsTrueWhenConfigured(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['frontendDebugMode' => true]);
+
+        $service = new SettingsService($extensionConfiguration);
+
+        self::assertTrue($service->isFrontendDebugModeEnabled());
+    }
+
+    #[Test]
+    public function isFrontendDebugModeEnabledReturnsFalseByDefault(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([]);
+
+        $service = new SettingsService($extensionConfiguration);
+
+        self::assertFalse($service->isFrontendDebugModeEnabled());
+    }
+
+    #[Test]
+    public function isFrontendDebugModeEnabledReturnsFalseOnException(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willThrowException(new Exception('boom'));
+
+        $service = new SettingsService($extensionConfiguration);
+
+        self::assertFalse($service->isFrontendDebugModeEnabled());
+    }
+
+    private function createRequestWithoutSite(): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->with('site')->willReturn(null);
+
+        return $request;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function createRequestWithSettings(array $settings): ServerRequestInterface
+    {
+        $settingsInterface = $this->createMock(SettingsInterface::class);
+        $settingsInterface->method('has')->willReturn(false);
+        $settingsInterface->method('getIdentifiers')->willReturn([]);
+        $siteSettings = new SiteSettings($settingsInterface, [], $settings);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($siteSettings);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->with('site')->willReturn($site);
+
+        return $request;
+    }
+
+    private function createRequestWithThrowingSettings(): ServerRequestInterface
+    {
+        $settingsInterface = $this->createMock(SettingsInterface::class);
+        $settingsInterface->method('has')
+            ->willThrowException(new ThrowingContainerException('missing'));
+
+        $siteSettings = new SiteSettings($settingsInterface, [], []);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($siteSettings);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->with('site')->willReturn($site);
+
+        return $request;
+    }
+}
+
+/**
+ * ThrowingContainerException.
+ *
+ * @internal
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ThrowingContainerException extends Exception implements NotFoundExceptionInterface {}

--- a/Tests/Unit/Service/Content/ContentElementFilterTest.php
+++ b/Tests/Unit/Service/Content/ContentElementFilterTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
+
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder};
+use TYPO3\CMS\Core\Settings\SettingsInterface;
+use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
+use TYPO3\CMS\Core\Utility\{GeneralUtility, RootlineUtility};
+use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
+use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
+use Xima\XimaTypo3FrontendEdit\Service\Content\ContentElementFilter;
+
+/**
+ * ContentElementFilterTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ContentElementFilter::class)]
+final class ContentElementFilterTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
+    #[Test]
+    public function filterContentElementsIncludesAccessibleElements(): void
+    {
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $backendUser = $this->createBackendUser(true);
+        $elements = [
+            ['uid' => 1, 'CType' => 'text', 'list_type' => ''],
+            ['uid' => 2, 'CType' => 'html', 'list_type' => ''],
+        ];
+
+        $result = $filter->filterContentElements($elements, $backendUser, $this->createRequest([]));
+
+        self::assertCount(2, $result);
+    }
+
+    #[Test]
+    public function filterContentElementsExcludesElementsWithoutEditAccess(): void
+    {
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $backendUser = $this->createBackendUser(false);
+        $elements = [['uid' => 1, 'CType' => 'text', 'list_type' => '']];
+
+        $result = $filter->filterContentElements($elements, $backendUser, $this->createRequest([]));
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function filterContentElementsExcludesIgnoredUids(): void
+    {
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $backendUser = $this->createBackendUser(true);
+        $elements = [
+            ['uid' => 1, 'CType' => 'text', 'list_type' => ''],
+            ['uid' => 2, 'CType' => 'text', 'list_type' => ''],
+        ];
+
+        $request = $this->createRequest(['frontendEdit.filter.ignoreUids' => '1']);
+        $result = $filter->filterContentElements($elements, $backendUser, $request);
+
+        self::assertCount(1, $result);
+        self::assertSame(2, $result[0]['uid']);
+    }
+
+    #[Test]
+    public function filterContentElementsExcludesIgnoredCTypes(): void
+    {
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $backendUser = $this->createBackendUser(true);
+        $elements = [
+            ['uid' => 1, 'CType' => 'text', 'list_type' => ''],
+            ['uid' => 2, 'CType' => 'html', 'list_type' => ''],
+        ];
+
+        $request = $this->createRequest(['frontendEdit.filter.ignoreCTypes' => 'html']);
+        $result = $filter->filterContentElements($elements, $backendUser, $request);
+
+        self::assertCount(1, $result);
+        self::assertSame('text', $result[0]['CType']);
+    }
+
+    #[Test]
+    public function filterContentElementsExcludesIgnoredListTypes(): void
+    {
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $backendUser = $this->createBackendUser(true);
+        $elements = [
+            ['uid' => 1, 'CType' => 'list', 'list_type' => 'news_pi1'],
+            ['uid' => 2, 'CType' => 'list', 'list_type' => 'other'],
+        ];
+
+        $request = $this->createRequest(['frontendEdit.filter.ignoreListTypes' => 'news_pi1']);
+        $result = $filter->filterContentElements($elements, $backendUser, $request);
+
+        self::assertCount(1, $result);
+        self::assertSame('other', $result[0]['list_type']);
+    }
+
+    #[Test]
+    public function isPageIgnoredReturnsTrueWhenSubpageOfIgnoredPid(): void
+    {
+        $this->registerRootline([['uid' => 10], ['uid' => 5]]);
+
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        $request = $this->createRequest(['frontendEdit.filter.ignorePids' => '5']);
+        self::assertTrue($filter->isPageIgnored(10, $request));
+    }
+
+    #[Test]
+    public function isPageIgnoredReturnsTrueWhenDoktypeIgnored(): void
+    {
+        $this->registerRootline([['uid' => 10]]);
+
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(['doktype' => 254]),
+        );
+
+        $request = $this->createRequest([
+            'frontendEdit.filter.ignorePids' => '5',
+            'frontendEdit.filter.ignoreDoktypes' => '254',
+        ]);
+        self::assertTrue($filter->isPageIgnored(10, $request));
+    }
+
+    #[Test]
+    public function isPageIgnoredReturnsFalseWhenDoktypeNotIgnored(): void
+    {
+        $this->registerRootline([['uid' => 10]]);
+
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(['doktype' => 1]),
+        );
+
+        $request = $this->createRequest([
+            'frontendEdit.filter.ignorePids' => '5',
+            'frontendEdit.filter.ignoreDoktypes' => '254',
+        ]);
+        self::assertFalse($filter->isPageIgnored(10, $request));
+    }
+
+    #[Test]
+    public function isPageIgnoredReturnsFalseWhenDoktypeIsNull(): void
+    {
+        $this->registerRootline([['uid' => 10]]);
+
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(false),
+        );
+
+        $request = $this->createRequest([
+            'frontendEdit.filter.ignorePids' => '5',
+            'frontendEdit.filter.ignoreDoktypes' => '254',
+        ]);
+        self::assertFalse($filter->isPageIgnored(10, $request));
+    }
+
+    #[Test]
+    public function isPageIgnoredReturnsFalseWhenNoDoktypesConfigured(): void
+    {
+        $this->registerRootline([['uid' => 10]]);
+
+        $filter = new ContentElementFilter(
+            $this->createSettingsService(),
+            $this->createRepository(),
+        );
+
+        self::assertFalse($filter->isPageIgnored(10, $this->createRequest([])));
+    }
+
+    private function createBackendUser(bool $hasAccess): BackendUserAuthentication
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->method('recordEditAccessInternals')->willReturn($hasAccess);
+
+        return $backendUser;
+    }
+
+    private function createSettingsService(): SettingsService
+    {
+        return new SettingsService($this->createMock(ExtensionConfiguration::class));
+    }
+
+    /**
+     * @param array<string, mixed>|false|null $doktypeRow
+     */
+    private function createRepository(array|false|null $doktypeRow = null): ContentElementRepository
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+
+        if (null !== $doktypeRow) {
+            $result = $this->createMock(Result::class);
+            $result->method('fetchAssociative')->willReturn($doktypeRow);
+
+            $queryBuilder = $this->createMock(QueryBuilder::class);
+            $queryBuilder->method('select')->willReturnSelf();
+            $queryBuilder->method('from')->willReturnSelf();
+            $queryBuilder->method('where')->willReturnSelf();
+            $queryBuilder->method('createNamedParameter')->willReturn(':dcValue');
+            $queryBuilder->method('executeQuery')->willReturn($result);
+            $queryBuilder->method('expr')->willReturn($this->createMock(ExpressionBuilder::class));
+
+            $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+        }
+
+        return new ContentElementRepository($connectionPool);
+    }
+
+    /**
+     * @param array<int, array<string, int>> $rootLine
+     */
+    private function registerRootline(array $rootLine): void
+    {
+        $rootlineUtility = $this->createMock(RootlineUtility::class);
+        $rootlineUtility->method('get')->willReturn($rootLine);
+        GeneralUtility::addInstance(RootlineUtility::class, $rootlineUtility);
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function createRequest(array $settings): ServerRequestInterface
+    {
+        $settingsInterface = $this->createMock(SettingsInterface::class);
+        $settingsInterface->method('has')->willReturn(false);
+        $settingsInterface->method('getIdentifiers')->willReturn([]);
+        $siteSettings = new SiteSettings($settingsInterface, [], $settings);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($siteSettings);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->with('site')->willReturn($site);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Service/Content/ContentElementFilterTest.php
+++ b/Tests/Unit/Service/Content/ContentElementFilterTest.php
@@ -221,6 +221,9 @@ final class ContentElementFilterTest extends TestCase
     private function createBackendUser(bool $hasAccess): BackendUserAuthentication
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);
+        if (method_exists(BackendUserAuthentication::class, 'checkRecordEditAccess')) {
+            $backendUser->method('checkRecordEditAccess')->willReturn(new \TYPO3\CMS\Core\Authentication\AccessCheckResult($hasAccess));
+        }
         $backendUser->method('recordEditAccessInternals')->willReturn($hasAccess);
 
         return $backendUser;

--- a/Tests/Unit/Service/Menu/AbstractMenuButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/AbstractMenuButtonBuilderTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\AbstractMenuButtonBuilder;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+
+/**
+ * AbstractMenuButtonBuilderTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(AbstractMenuButtonBuilder::class)]
+final class AbstractMenuButtonBuilderTest extends TestCase
+{
+    private Icon $iconMock;
+
+    private IconService $iconService;
+
+    protected function setUp(): void
+    {
+        $this->iconMock = $this->createMock(Icon::class);
+        $iconFactoryMock = $this->createMock(IconFactory::class);
+        $iconFactoryMock->method('getIcon')->willReturn($this->iconMock);
+        $this->iconService = new IconService($iconFactoryMock);
+
+        $uriBuilderMock = $this->createMock(UriBuilder::class);
+        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function addButtonAppendsButtonWithProvidedValues(): void
+    {
+        $builder = $this->createBuilder();
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addButton($menuButton, 'edit', ButtonType::Link, 'Edit label', '/edit', 'actions-edit');
+
+        $child = $menuButton->getChildren()['edit'];
+        self::assertSame('Edit label', $child->getLabel());
+        self::assertSame(ButtonType::Link, $child->getType());
+        self::assertSame('/edit', $child->getUrl());
+        self::assertSame($this->iconMock, $child->getIcon());
+    }
+
+    #[Test]
+    public function addButtonUsesFallbackLabelWhenLabelMissing(): void
+    {
+        $builder = $this->createBuilder();
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addButton($menuButton, 'delete', ButtonType::Link);
+
+        $child = $menuButton->getChildren()['delete'];
+        self::assertStringContainsString('locallang.xlf:delete', $child->getLabel());
+        self::assertNull($child->getIcon());
+        self::assertNull($child->getUrl());
+    }
+
+    #[Test]
+    public function getLanguageServiceReturnsGlobalLanguageService(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $GLOBALS['LANG'] = $languageService;
+
+        $builder = $this->createBuilder();
+
+        self::assertSame($languageService, $builder->exposeLanguageService());
+    }
+
+    private function createBuilder(): TestableMenuButtonBuilder
+    {
+        return new TestableMenuButtonBuilder($this->iconService, new UrlBuilderService());
+    }
+}
+
+/**
+ * TestableMenuButtonBuilder.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class TestableMenuButtonBuilder extends AbstractMenuButtonBuilder
+{
+    public function exposeLanguageService(): LanguageService
+    {
+        return $this->getLanguageService();
+    }
+}

--- a/Tests/Unit/Service/Menu/AbstractMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/AbstractMenuGeneratorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test};
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\AbstractMenuGenerator;
+
+/**
+ * AbstractMenuGeneratorTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(AbstractMenuGenerator::class)]
+final class AbstractMenuGeneratorTest extends TestCase
+{
+    /**
+     * @return array<string, array{config: array<string, mixed>, expected: bool}>
+     */
+    public static function linkTargetBlankDataProvider(): array
+    {
+        return [
+            'string one enables' => ['config' => ['linkTargetBlank' => '1'], 'expected' => true],
+            'string true enables' => ['config' => ['linkTargetBlank' => 'true'], 'expected' => true],
+            'boolean true enables' => ['config' => ['linkTargetBlank' => true], 'expected' => true],
+            'auto disables' => ['config' => ['linkTargetBlank' => 'auto'], 'expected' => false],
+            'string zero disables' => ['config' => ['linkTargetBlank' => '0'], 'expected' => false],
+            'missing key defaults to auto' => ['config' => [], 'expected' => false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('linkTargetBlankDataProvider')]
+    public function isLinkTargetBlankReturnsExpectedResult(array $config, bool $expected): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($config);
+
+        $generator = $this->createGenerator($extensionConfiguration);
+
+        self::assertSame($expected, $generator->exposeIsLinkTargetBlank());
+    }
+
+    #[Test]
+    public function isLinkTargetBlankReturnsFalseOnException(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willThrowException(new RuntimeException('missing'));
+
+        $generator = $this->createGenerator($extensionConfiguration);
+
+        self::assertFalse($generator->exposeIsLinkTargetBlank());
+    }
+
+    private function createGenerator(ExtensionConfiguration $extensionConfiguration): AbstractMenuGenerator
+    {
+        return new class($extensionConfiguration) extends AbstractMenuGenerator {
+            public function exposeIsLinkTargetBlank(): bool
+            {
+                return $this->isLinkTargetBlank();
+            }
+        };
+    }
+}

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -105,6 +105,9 @@ final class AdditionalDataHandlerTest extends TestCase
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1];
+        if (method_exists(BackendUserAuthentication::class, 'checkRecordEditAccess')) {
+            $backendUser->method('checkRecordEditAccess')->willReturn(new \TYPO3\CMS\Core\Authentication\AccessCheckResult(false));
+        }
         $backendUser->method('recordEditAccessInternals')->willReturn(false);
         $GLOBALS['BE_USER'] = $backendUser;
 
@@ -236,6 +239,9 @@ final class AdditionalDataHandlerTest extends TestCase
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1];
+        if (method_exists(BackendUserAuthentication::class, 'checkRecordEditAccess')) {
+            $backendUser->method('checkRecordEditAccess')->willReturn(new \TYPO3\CMS\Core\Authentication\AccessCheckResult(true));
+        }
         $backendUser->method('recordEditAccessInternals')->willReturn(true);
         $GLOBALS['BE_USER'] = $backendUser;
     }
@@ -246,9 +252,26 @@ final class AdditionalDataHandlerTest extends TestCase
     private function registerRecordLookup(array|false $record): void
     {
         $GLOBALS['TCA']['pages'] = ['ctrl' => []];
+        $this->registerTcaSchemaFactory();
         GeneralUtility::addInstance(
             ConnectionPool::class,
             $this->createConnectionPoolReturning($record),
+        );
+    }
+
+    private function registerTcaSchemaFactory(): void
+    {
+        if (!class_exists(\TYPO3\CMS\Core\Schema\TcaSchemaFactory::class)) {
+            return;
+        }
+
+        $schemaFactory = $this->createMock(\TYPO3\CMS\Core\Schema\TcaSchemaFactory::class);
+        $schemaFactory->method('has')->willReturn(true);
+        $schemaFactory->method('get')->willReturn($this->createMock(\TYPO3\CMS\Core\Schema\TcaSchema::class));
+        GeneralUtility::addInstance(\TYPO3\CMS\Core\Schema\TcaSchemaFactory::class, $schemaFactory);
+        GeneralUtility::addInstance(
+            \TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction::class,
+            $this->createMock(\TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction::class),
         );
     }
 

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
+
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder, Restriction\DefaultRestrictionContainer};
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
+use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\AdditionalDataHandler;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+
+/**
+ * AdditionalDataHandlerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(AdditionalDataHandler::class)]
+final class AdditionalDataHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $uriBuilder = $this->createMock(UriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['BE_USER'], $GLOBALS['TCA']);
+    }
+
+    #[Test]
+    public function handleDataDoesNothingForEmptyEntries(): void
+    {
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $handler->handleData($button, [], ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertSame([], $button->getChildren());
+    }
+
+    #[Test]
+    public function handleDataAddsDividerAndSkipsInvalidEntries(): void
+    {
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => null, 'table' => 'pages', 'uid' => 1, 'url' => null, 'icon' => null],
+            ['label' => '', 'table' => 'pages', 'uid' => 1, 'url' => null, 'icon' => null],
+            ['label' => 'No target', 'table' => null, 'uid' => null, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        $children = $button->getChildren();
+        self::assertArrayHasKey('div_data', $children);
+        self::assertCount(1, $children);
+        self::assertSame(ButtonType::Divider, $children['div_data']->getType());
+    }
+
+    #[Test]
+    public function handleDataSkipsEntryWithoutTableAndUidResolution(): void
+    {
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Url only', 'table' => null, 'uid' => null, 'url' => '/some/url', 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        $children = $button->getChildren();
+        self::assertArrayHasKey('div_data', $children);
+        self::assertArrayNotHasKey('data_0', $children);
+    }
+
+    #[Test]
+    public function handleDataSkipsEntryWhenNoEditAccess(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('recordEditAccessInternals')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        $children = $button->getChildren();
+        self::assertArrayHasKey('div_data', $children);
+        self::assertArrayNotHasKey('data_0', $children);
+    }
+
+    #[Test]
+    public function handleDataAddsButtonForResolvedRecord(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => 'content-image'],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        $children = $button->getChildren();
+        self::assertArrayHasKey('data_0', $children);
+        self::assertSame(ButtonType::Link, $children['data_0']->getType());
+    }
+
+    #[Test]
+    public function handleDataUsesEntryUrlWhenPresent(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => '/custom/url', 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertSame('/custom/url', $button->getChildren()['data_0']->getUrl());
+    }
+
+    #[Test]
+    public function handleDataSkipsWhenRecordNotFound(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(false);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
+    public function handleDataResolvesTranslatedRecord(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $repository = new ContentElementRepository(
+            $this->createConnectionPoolReturning(['uid' => 99, 'sys_language_uid' => 1]),
+        );
+
+        $handler = new AdditionalDataHandler(
+            new BackendUserService(),
+            new UrlBuilderService(),
+            new IconService($this->createIconFactory()),
+            $repository,
+        );
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 1, '#anchor');
+
+        self::assertArrayHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
+    public function handleDataSkipsWhenTranslationMissing(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $repository = new ContentElementRepository(
+            $this->createConnectionPoolReturning(false),
+        );
+
+        $handler = new AdditionalDataHandler(
+            new BackendUserService(),
+            new UrlBuilderService(),
+            new IconService($this->createIconFactory()),
+            $repository,
+        );
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 1, '#anchor');
+
+        self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    private function registerBackendUserWithAccess(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('recordEditAccessInternals')->willReturn(true);
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    /**
+     * @param array<string, mixed>|false $record
+     */
+    private function registerRecordLookup(array|false $record): void
+    {
+        $GLOBALS['TCA']['pages'] = ['ctrl' => []];
+        GeneralUtility::addInstance(
+            ConnectionPool::class,
+            $this->createConnectionPoolReturning($record),
+        );
+    }
+
+    /**
+     * @param array<string, mixed>|false $record
+     */
+    private function createConnectionPoolReturning(array|false $record): ConnectionPool
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn($record);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($this->createMock(DefaultRestrictionContainer::class));
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('andWhere')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($this->createMock(ExpressionBuilder::class));
+        $queryBuilder->method('createNamedParameter')->willReturn(':dcValue');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        return $connectionPool;
+    }
+
+    private function createIconFactory(): IconFactory
+    {
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->method('getIcon')->willReturn($this->createMock(Icon::class));
+
+        return $iconFactory;
+    }
+
+    private function createButton(): Button
+    {
+        return new Button('root', ButtonType::Link);
+    }
+
+    private function createHandler(BackendUserService $backendUserService): AdditionalDataHandler
+    {
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->method('getIcon')->willReturn($this->createMock(Icon::class));
+
+        return new AdditionalDataHandler(
+            $backendUserService,
+            new UrlBuilderService(),
+            new IconService($iconFactory),
+            new ContentElementRepository($this->createMock(ConnectionPool::class)),
+        );
+    }
+}

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,17 +21,24 @@ use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDropdownModifyEvent;
 use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Content\ContentElementFilter;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\{AdditionalDataHandler, ContentElementButtonBuilder, ContentElementMenuGenerator};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
 
 /**
  * ContentElementMenuGeneratorTest.
@@ -46,12 +54,18 @@ final class ContentElementMenuGeneratorTest extends TestCase
         $uriBuilderMock = $this->createMock(UriBuilder::class);
         $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
         GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
+
+        for ($i = 0; $i < 10; ++$i) {
+            $versionMock = $this->createMock(Typo3Version::class);
+            $versionMock->method('getMajorVersion')->willReturn(13);
+            GeneralUtility::addInstance(Typo3Version::class, $versionMock);
+        }
     }
 
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        unset($GLOBALS['BE_USER'], $GLOBALS['LANG']);
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG'], $GLOBALS['TCA']);
     }
 
     #[Test]
@@ -111,6 +125,150 @@ final class ContentElementMenuGeneratorTest extends TestCase
         self::assertSame([], $result);
     }
 
+    #[Test]
+    public function getDropdownReturnsEmptyArrayWhenNoContentElementsFound(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $connectionPool = $this->createConnectionPoolReturning([]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownReturnsRenderedMenuForContentElement(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(42);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return#c99', 0, $this->createRequestMock());
+
+        self::assertArrayHasKey(42, $result);
+        self::assertArrayHasKey('element', $result[42]);
+        self::assertArrayHasKey('menu', $result[42]);
+        self::assertIsArray($result[42]['menu']);
+        self::assertSame('Text & Media', $result[42]['element']['ctypeLabel']);
+        self::assertArrayHasKey('ctypeIcon', $result[42]['element']);
+    }
+
+    #[Test]
+    public function getDropdownFallsBackToCtypeWhenLabelIsEmpty(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService(emptyLabels: true);
+        $this->setUpTca(label: '');
+
+        $element = $this->createContentElementRecord(7);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertSame('textmedia', $result[7]['element']['ctypeLabel']);
+    }
+
+    #[Test]
+    public function getDropdownSkipsElementWithoutMatchingTcaConfig(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca(ctypeValue: 'some_other_type');
+
+        $element = $this->createContentElementRecord(11);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownUsesUidBasedFetchingWhenUidsProvided(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(55);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock(), ['_uids' => [55, 55, 'invalid', -3]]);
+
+        self::assertArrayHasKey(55, $result);
+    }
+
+    #[Test]
+    public function getDropdownEmptyUidsFallsBackToPidBasedFetching(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(60);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock(), ['_uids' => ['not-an-int']]);
+
+        self::assertArrayHasKey(60, $result);
+    }
+
+    #[Test]
+    public function getDropdownFiltersOutElementWithoutEditAccess(): void
+    {
+        $this->setUpAuthenticatedBackendUser(hasEditAccess: false);
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(70);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function getDropdownRespectsEventListenerModifiedButton(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(88);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+
+        $replacementButton = new Button('replaced', \Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType::Link, '/replaced');
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher->method('dispatch')->willReturnCallback(
+            static function (FrontendEditDropdownModifyEvent $event) use ($replacementButton): FrontendEditDropdownModifyEvent {
+                $event->setMenuButton($replacementButton);
+
+                return $event;
+            },
+        );
+
+        $generator = $this->createGenerator($connectionPool, $eventDispatcher);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertArrayHasKey(88, $result);
+        self::assertSame('/replaced', $result[88]['menu']['url']);
+    }
+
     private function createRequestMock(): ServerRequestInterface
     {
         $request = $this->createMock(ServerRequestInterface::class);
@@ -119,8 +277,107 @@ final class ContentElementMenuGeneratorTest extends TestCase
         return $request;
     }
 
-    private function createGenerator(): ContentElementMenuGenerator
+    /**
+     * @return array<string, mixed>
+     */
+    private function createContentElementRecord(int $uid): array
     {
+        return [
+            'uid' => $uid,
+            'pid' => 1,
+            'CType' => 'textmedia',
+            'list_type' => '',
+            'header' => 'Some header',
+            'colPos' => 0,
+            'sorting' => 100,
+            'tx_container_parent' => 0,
+            'l10n_source' => 0,
+            'sys_language_uid' => 0,
+        ];
+    }
+
+    private function setUpAuthenticatedBackendUser(bool $hasEditAccess = true): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1, 'admin' => 1];
+        $backendUser->uc = [];
+        $backendUser->method('recordEditAccessInternals')->willReturn($hasEditAccess);
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    private function setUpLanguageService(bool $emptyLabels = false): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturnCallback(
+            static function (string $input) use ($emptyLabels): string {
+                if ($emptyLabels) {
+                    return '';
+                }
+
+                return match ($input) {
+                    'my_label' => 'Text & Media',
+                    default => $input,
+                };
+            },
+        );
+        $GLOBALS['LANG'] = $languageService;
+    }
+
+    private function setUpTca(string $ctypeValue = 'textmedia', string $label = 'my_label'): void
+    {
+        $GLOBALS['TCA'] = [
+            'tt_content' => [
+                'columns' => [
+                    'CType' => [
+                        'config' => [
+                            'items' => [
+                                [
+                                    'value' => $ctypeValue,
+                                    'label' => $label,
+                                    'icon' => 'content-textmedia',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $records
+     */
+    private function createConnectionPoolReturning(array $records): ConnectionPool
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($records);
+
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('eq');
+        $expressionBuilder->method('in')->willReturn('in');
+        $expressionBuilder->method('or')->willReturn(
+            $this->createMock(\TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression::class),
+        );
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('andWhere')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn('param');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        return $connectionPool;
+    }
+
+    private function createGenerator(
+        ?ConnectionPool $connectionPool = null,
+        ?EventDispatcher $eventDispatcher = null,
+    ): ContentElementMenuGenerator {
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($this->createMock(Icon::class));
         $iconService = new IconService($iconFactoryMock);
@@ -129,12 +386,14 @@ final class ContentElementMenuGeneratorTest extends TestCase
         $contentElementButtonBuilder = new ContentElementButtonBuilder($iconService, $urlBuilderService);
 
         $settingsService = (new ReflectionClass(SettingsService::class))->newInstanceWithoutConstructor();
-        $contentElementRepository = (new ReflectionClass(ContentElementRepository::class))->newInstanceWithoutConstructor();
+
+        $contentElementRepository = new ContentElementRepository($connectionPool ?? $this->createMock(ConnectionPool::class));
+
         $contentElementFilter = new ContentElementFilter($settingsService, $contentElementRepository);
         $additionalDataHandler = (new ReflectionClass(AdditionalDataHandler::class))->newInstanceWithoutConstructor();
 
         return new ContentElementMenuGenerator(
-            $this->createMock(EventDispatcher::class),
+            $eventDispatcher ?? $this->createDefaultEventDispatcher(),
             $backendUserService,
             $contentElementFilter,
             $contentElementButtonBuilder,
@@ -145,5 +404,13 @@ final class ContentElementMenuGeneratorTest extends TestCase
             $urlBuilderService,
             $this->createMock(ExtensionConfiguration::class),
         );
+    }
+
+    private function createDefaultEventDispatcher(): EventDispatcher
+    {
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+        return $eventDispatcher;
     }
 }

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,13 +21,19 @@ use stdClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
+use Xima\XimaTypo3FrontendEdit\Event\FrontendEditPageDropdownModifyEvent;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\{PageButtonBuilder, PageMenuGenerator};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
 
 /**
  * PageMenuGeneratorTest.
@@ -47,6 +54,7 @@ final class PageMenuGeneratorTest extends TestCase
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
+        unset($GLOBALS['LANG'], $GLOBALS['TCA']);
     }
 
     #[Test]
@@ -97,19 +105,152 @@ final class PageMenuGeneratorTest extends TestCase
         self::assertSame([], $result);
     }
 
-    private function createGenerator(): PageMenuGenerator
+    #[Test]
+    public function getDropdownReturnsRenderedMenuForPageWithRecord(): void
     {
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $connectionPool = $this->createConnectionPoolReturning(['uid' => 5, 'title' => 'My Page', 'doktype' => 1]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown($this->createRequest(5));
+
+        self::assertArrayHasKey('label', $result);
+        self::assertArrayHasKey('children', $result);
+        self::assertArrayHasKey('info_header', $result['children']);
+        self::assertArrayHasKey('edit_page_properties', $result['children']);
+        self::assertArrayHasKey('targetBlank', $result);
+    }
+
+    #[Test]
+    public function getDropdownSkipsInfoSectionWhenPageRecordNotFound(): void
+    {
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $connectionPool = $this->createConnectionPoolReturning(false);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown($this->createRequest(9));
+
+        self::assertArrayHasKey('children', $result);
+        self::assertArrayNotHasKey('info_header', $result['children']);
+        self::assertArrayHasKey('edit_page_properties', $result['children']);
+    }
+
+    #[Test]
+    public function getDropdownRespectsEventListenerModifiedButton(): void
+    {
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $connectionPool = $this->createConnectionPoolReturning(['uid' => 3, 'title' => 'Page', 'doktype' => 1]);
+
+        $replacement = new Button('replaced', ButtonType::Link, '/replaced-page');
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher->method('dispatch')->willReturnCallback(
+            static function (FrontendEditPageDropdownModifyEvent $event) use ($replacement): FrontendEditPageDropdownModifyEvent {
+                $event->setMenuButton($replacement);
+
+                return $event;
+            },
+        );
+
+        $generator = $this->createGenerator($connectionPool, $eventDispatcher);
+        $result = $generator->getDropdown($this->createRequest(3));
+
+        self::assertSame('/replaced-page', $result['url']);
+        self::assertArrayHasKey('targetBlank', $result);
+    }
+
+    private function createRequest(int $pageId): ServerRequestInterface
+    {
+        $routing = $this->createMock(PageArguments::class);
+        $routing->method('getPageId')->willReturn($pageId);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnMap([
+            ['routing', null, $routing],
+            ['language', null, null],
+        ]);
+        $request->method('getUri')->willReturn(new Uri('https://example.com/page'));
+
+        return $request;
+    }
+
+    private function setUpLanguageService(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturnArgument(0);
+        $GLOBALS['LANG'] = $languageService;
+    }
+
+    private function setUpTca(): void
+    {
+        $GLOBALS['TCA'] = [
+            'pages' => [
+                'ctrl' => [
+                    'typeicon_classes' => [1 => 'apps-pagetree-page-default'],
+                ],
+                'columns' => [
+                    'doktype' => [
+                        'config' => [
+                            'items' => [
+                                ['value' => 1, 'label' => 'Standard'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|false $record
+     */
+    private function createConnectionPoolReturning(array|false $record): ConnectionPool
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn($record);
+
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('eq');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn('param');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        return $connectionPool;
+    }
+
+    private function createGenerator(
+        ?ConnectionPool $connectionPool = null,
+        ?EventDispatcher $eventDispatcher = null,
+    ): PageMenuGenerator {
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($this->createMock(Icon::class));
         $iconService = new IconService($iconFactoryMock);
         $urlBuilderService = new UrlBuilderService();
         $pageButtonBuilder = new PageButtonBuilder($iconService, $urlBuilderService);
 
+        if (null === $eventDispatcher) {
+            $eventDispatcher = $this->createMock(EventDispatcher::class);
+            $eventDispatcher->method('dispatch')->willReturnArgument(0);
+        }
+
         return new PageMenuGenerator(
             $pageButtonBuilder,
-            $this->createMock(EventDispatcher::class),
+            $eventDispatcher,
             $this->createMock(ExtensionConfiguration::class),
-            $this->createMock(ConnectionPool::class),
+            $connectionPool ?? $this->createMock(ConnectionPool::class),
             $urlBuilderService,
         );
     }

--- a/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
+++ b/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
+use Xima\XimaTypo3FrontendEdit\Service\Ui\BackendSettingsService;
+
+/**
+ * BackendSettingsServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(BackendSettingsService::class)]
+final class BackendSettingsServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $uriBuilder = $this->createMock(UriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/ajax/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
+
+        $packageManager = $this->createMock(PackageManager::class);
+        $packageManager->method('resolvePackagePath')
+            ->willReturnCallback(static fn (string $path): string => '/var/www/html/public/'.ltrim(str_replace('EXT:', 'typo3conf/ext/', $path), '/'));
+        ExtensionManagementUtility::setPackageManager($packageManager);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['LANG'], $GLOBALS['TYPO3_CONF_VARS']);
+    }
+
+    #[Test]
+    public function getSettingsScriptRendersJsonAndStubScriptTag(): void
+    {
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('id="frontend-edit-backend-stubs-data"', $result);
+        self::assertStringContainsString('backend_stubs.js', $result);
+        self::assertStringContainsString('ajaxUrls', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptContainsResolvedAjaxUrls(): void
+    {
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('typo3', $result);
+        self::assertStringContainsString('filestorage_tree_data', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptAddsNonceAttribute(): void
+    {
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript('abc123');
+
+        self::assertStringContainsString('nonce="abc123"', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptOmitsNonceWhenEmpty(): void
+    {
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript('');
+
+        self::assertStringNotContainsString('nonce=', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptSkipsMissingAjaxRoutes(): void
+    {
+        $uriBuilder = $this->createMock(UriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')
+            ->willThrowException(new RouteNotFoundException('missing'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
+
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('"ajaxUrls":[]', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptIncludesLanguageLabelsWhenLanguageServiceAvailable(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturn('Translated');
+        $GLOBALS['LANG'] = $languageService;
+
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('Translated', $result);
+        self::assertStringContainsString('tree.networkError', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptFallsBackToKeyWhenLabelEmpty(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturn('');
+        $GLOBALS['LANG'] = $languageService;
+
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('tree.loading', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptReturnsEmptyLangWhenNoLanguageService(): void
+    {
+        unset($GLOBALS['LANG']);
+
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('"lang":[]', $result);
+    }
+
+    #[Test]
+    public function getSettingsScriptUsesConfiguredDateFormat(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] = 'd.m.Y';
+
+        $service = new BackendSettingsService();
+
+        $result = $service->getSettingsScript();
+
+        self::assertStringContainsString('d.m.Y', $result);
+    }
+}

--- a/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
+++ b/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
@@ -20,9 +20,11 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Package\{PackageInterface, PackageManager};
 use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\BackendSettingsService;
+
+use function dirname;
 
 /**
  * BackendSettingsServiceTest.
@@ -39,9 +41,16 @@ final class BackendSettingsServiceTest extends TestCase
         $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/ajax/mock'));
         GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
 
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getPackagePath')->willReturn(dirname(__DIR__, 4).'/');
+
         $packageManager = $this->createMock(PackageManager::class);
         $packageManager->method('resolvePackagePath')
             ->willReturnCallback(static fn (string $path): string => '/var/www/html/public/'.ltrim(str_replace('EXT:', 'typo3conf/ext/', $path), '/'));
+        $packageManager->method('isPackageActive')->willReturn(true);
+        $packageManager->method('getPackage')->willReturn($package);
+        $packageManager->method('getActivePackages')->willReturn([]);
+        GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
         ExtensionManagementUtility::setPackageManager($packageManager);
 
         Environment::initialize(

--- a/Tests/Unit/Service/Ui/FlashMessageServiceTest.php
+++ b/Tests/Unit/Service/Ui/FlashMessageServiceTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\FlashMessageService;
+
+/**
+ * FlashMessageServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(FlashMessageService::class)]
+final class FlashMessageServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+    }
+
+    #[Test]
+    public function collectFromSessionReturnsEmptyArrayWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        self::assertSame([], $service->collectFromSession());
+    }
+
+    #[Test]
+    public function collectFromSessionReturnsEmptyArrayWhenUserDataMissing(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        self::assertSame([], $service->collectFromSession());
+    }
+
+    #[Test]
+    public function collectFromSessionReturnsEmptyArrayWhenQueuesEmpty(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturn([]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        self::assertSame([], $service->collectFromSession());
+    }
+
+    #[Test]
+    public function collectFromSessionParsesMessagesAndClearsQueues(): void
+    {
+        $notification = json_encode([
+            'title' => 'Saved',
+            'message' => 'Record saved',
+            'severity' => ContextualFeedbackSeverity::OK->value,
+        ]);
+
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturnMap([
+            [FlashMessageQueue::NOTIFICATION_QUEUE, [$notification]],
+            [FlashMessageQueue::FLASHMESSAGE_QUEUE, []],
+        ]);
+        $backendUser->expects(self::once())
+            ->method('setAndSaveSessionData')
+            ->with(FlashMessageQueue::NOTIFICATION_QUEUE, null);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        $result = $service->collectFromSession();
+
+        self::assertCount(1, $result);
+        self::assertSame('Saved', $result[0]['title']);
+        self::assertSame('Record saved', $result[0]['message']);
+        self::assertSame(ContextualFeedbackSeverity::OK->name, $result[0]['severity']);
+    }
+
+    #[Test]
+    public function collectFromSessionUsesDefaultsForMissingFields(): void
+    {
+        $message = json_encode(['foo' => 'bar']);
+
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturnMap([
+            [FlashMessageQueue::NOTIFICATION_QUEUE, [$message]],
+            [FlashMessageQueue::FLASHMESSAGE_QUEUE, []],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        $result = $service->collectFromSession();
+
+        self::assertCount(1, $result);
+        self::assertSame('', $result[0]['title']);
+        self::assertSame('', $result[0]['message']);
+        self::assertSame(ContextualFeedbackSeverity::OK->name, $result[0]['severity']);
+    }
+
+    #[Test]
+    public function collectFromSessionFallsBackToOkForInvalidSeverity(): void
+    {
+        $message = json_encode(['title' => 'T', 'message' => 'M', 'severity' => 9999]);
+
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturnMap([
+            [FlashMessageQueue::NOTIFICATION_QUEUE, [$message]],
+            [FlashMessageQueue::FLASHMESSAGE_QUEUE, []],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        $result = $service->collectFromSession();
+
+        self::assertSame(ContextualFeedbackSeverity::OK->name, $result[0]['severity']);
+    }
+
+    #[Test]
+    public function collectFromSessionLogsWarningForMalformedJson(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturnMap([
+            [FlashMessageQueue::NOTIFICATION_QUEUE, ['{invalid json']],
+            [FlashMessageQueue::FLASHMESSAGE_QUEUE, []],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $service = new FlashMessageService($logger);
+
+        self::assertSame([], $service->collectFromSession());
+    }
+
+    #[Test]
+    public function collectFromSessionLogsErrorWhenQueueProcessingThrows(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')
+            ->willThrowException(new RuntimeException('session broken'));
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::exactly(2))->method('error');
+
+        $service = new FlashMessageService($logger);
+
+        self::assertSame([], $service->collectFromSession());
+    }
+
+    #[Test]
+    public function collectFromSessionSkipsNonArraySessionData(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('getSessionData')->willReturn(null);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new FlashMessageService($this->createMock(LoggerInterface::class));
+
+        self::assertSame([], $service->collectFromSession());
+    }
+}

--- a/Tests/Unit/Service/Ui/IconServiceTest.php
+++ b/Tests/Unit/Service/Ui/IconServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Imaging\{Icon, IconFactory, IconSize};
+use Xima\XimaTypo3FrontendEdit\Service\Ui\IconService;
+
+/**
+ * IconServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(IconService::class)]
+final class IconServiceTest extends TestCase
+{
+    #[Test]
+    public function getIconReturnsIconFromFactory(): void
+    {
+        $icon = $this->createMock(Icon::class);
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->expects(self::once())
+            ->method('getIcon')
+            ->with('actions-open', IconSize::SMALL)
+            ->willReturn($icon);
+
+        $service = new IconService($iconFactory);
+
+        self::assertSame($icon, $service->getIcon('actions-open'));
+    }
+
+    #[Test]
+    public function getIconCachesResultAndCallsFactoryOnce(): void
+    {
+        $icon = $this->createMock(Icon::class);
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->expects(self::once())
+            ->method('getIcon')
+            ->willReturn($icon);
+
+        $service = new IconService($iconFactory);
+
+        $first = $service->getIcon('actions-open');
+        $second = $service->getIcon('actions-open');
+
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function getIconRequestsSeparateIconsForDifferentIdentifiers(): void
+    {
+        $iconOpen = $this->createMock(Icon::class);
+        $iconClose = $this->createMock(Icon::class);
+        $iconFactory = $this->createMock(IconFactory::class);
+        $iconFactory->expects(self::exactly(2))
+            ->method('getIcon')
+            ->willReturnMap([
+                ['actions-open', IconSize::SMALL, null, null, $iconOpen],
+                ['actions-close', IconSize::SMALL, null, null, $iconClose],
+            ]);
+
+        $service = new IconService($iconFactory);
+
+        self::assertSame($iconOpen, $service->getIcon('actions-open'));
+        self::assertSame($iconClose, $service->getIcon('actions-close'));
+    }
+}

--- a/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
+++ b/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
 use TYPO3\CMS\Core\Http\Uri;
-use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Package\{PackageInterface, PackageManager};
 use TYPO3\CMS\Core\Settings\SettingsInterface;
 use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
 use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
@@ -31,6 +31,8 @@ use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{BackendSettingsService, ResourceRendererService, UrlBuilderService};
+
+use function dirname;
 
 /**
  * ResourceRendererServiceTest.
@@ -47,9 +49,16 @@ final class ResourceRendererServiceTest extends TestCase
         $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
         GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
 
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getPackagePath')->willReturn(dirname(__DIR__, 4).'/');
+
         $packageManager = $this->createMock(PackageManager::class);
         $packageManager->method('resolvePackagePath')
             ->willReturnCallback(static fn (string $path): string => '/var/www/html/public/'.ltrim(str_replace('EXT:', 'typo3conf/ext/', $path), '/'));
+        $packageManager->method('isPackageActive')->willReturn(true);
+        $packageManager->method('getPackage')->willReturn($package);
+        $packageManager->method('getActivePackages')->willReturn([]);
+        GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
         ExtensionManagementUtility::setPackageManager($packageManager);
 
         Environment::initialize(

--- a/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
+++ b/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Settings\SettingsInterface;
+use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
+use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
+use TYPO3\CMS\Core\View\{ViewFactoryInterface, ViewInterface};
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
+use Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator;
+use Xima\XimaTypo3FrontendEdit\Service\Ui\{BackendSettingsService, ResourceRendererService, UrlBuilderService};
+
+/**
+ * ResourceRendererServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ResourceRendererService::class)]
+final class ResourceRendererServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $uriBuilder = $this->createMock(UriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
+        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
+
+        $packageManager = $this->createMock(PackageManager::class);
+        $packageManager->method('resolvePackagePath')
+            ->willReturnCallback(static fn (string $path): string => '/var/www/html/public/'.ltrim(str_replace('EXT:', 'typo3conf/ext/', $path), '/'));
+        ExtensionManagementUtility::setPackageManager($packageManager);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function renderReturnsRenderedTemplate(): void
+    {
+        $view = $this->createMock(ViewInterface::class);
+        $view->method('render')->willReturn('<rendered/>');
+        $viewFactory = $this->createMock(ViewFactoryInterface::class);
+        $viewFactory->method('create')->willReturn($view);
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $viewFactory);
+
+        $service = $this->createService(false);
+
+        $result = $service->render($this->createRequest([]));
+
+        self::assertSame('<rendered/>', $result);
+    }
+
+    #[Test]
+    public function renderWithContextualEditingEnabledAddsBackendStubs(): void
+    {
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(true);
+
+        $service->render($this->createRequest(['frontendEdit.enableContextualEditing' => true]));
+
+        self::assertArrayHasKey('backend_stubs', $captured);
+        self::assertArrayHasKey('iframe_edit', $captured);
+        self::assertArrayHasKey('contextual_edit', $captured);
+    }
+
+    #[Test]
+    public function renderAddsCoreResources(): void
+    {
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(false);
+
+        $service->render($this->createRequest([]));
+
+        self::assertArrayHasKey('floating_ui', $captured);
+        self::assertArrayHasKey('settings_config', $captured);
+        self::assertArrayHasKey('toolbar_config', $captured);
+        self::assertArrayHasKey('sticky_toolbar_config', $captured);
+        self::assertArrayHasKey('sticky_toolbar', $captured);
+    }
+
+    #[Test]
+    public function renderAddsDebugConfigWhenDebugModeEnabled(): void
+    {
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(false, debugMode: true);
+
+        $service->render($this->createRequest([]));
+
+        self::assertArrayHasKey('debug_config', $captured);
+    }
+
+    #[Test]
+    public function renderOmitsStickyToolbarWhenDisabled(): void
+    {
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(false);
+
+        $service->render($this->createRequest(['frontendEdit.showStickyToolbar' => false]));
+
+        self::assertArrayNotHasKey('sticky_toolbar', $captured);
+        self::assertArrayNotHasKey('sticky_toolbar_config', $captured);
+    }
+
+    #[Test]
+    public function renderAddsFlashMessagesConfigWhenProvided(): void
+    {
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(false);
+
+        $flashMessages = [
+            ['title' => 'Saved', 'message' => 'Done', 'severity' => 'OK'],
+        ];
+        $service->render($this->createRequest([]), $flashMessages);
+
+        self::assertArrayHasKey('flash_messages_config', $captured);
+    }
+
+    #[Test]
+    public function renderMarksToolbarDisabledWhenFrontendEditDisabled(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = ['frontendEditDisabled' => true];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        GeneralUtility::addInstance(ViewFactoryInterface::class, $this->createViewFactoryCapturingResources($captured));
+
+        $service = $this->createService(false);
+
+        $service->render($this->createRequest([]));
+
+        self::assertStringContainsString('data-disabled="true"', $captured['toolbar_config']);
+    }
+
+    /**
+     * @param array<string, string>|null $captured
+     */
+    private function createViewFactoryCapturingResources(?array &$captured): ViewFactoryInterface
+    {
+        $view = $this->createMock(ViewInterface::class);
+        $view->method('assignMultiple')->willReturnCallback(
+            static function (array $values) use (&$captured, &$view): ViewInterface {
+                $captured = $values['resources'] ?? [];
+
+                return $view;
+            },
+        );
+        $view->method('render')->willReturn('<rendered/>');
+
+        $viewFactory = $this->createMock(ViewFactoryInterface::class);
+        $viewFactory->method('create')->willReturn($view);
+
+        return $viewFactory;
+    }
+
+    private function createService(bool $contextualEditing, bool $debugMode = false): ResourceRendererService
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['frontendDebugMode' => $debugMode]);
+
+        $settingsService = new SettingsService($extensionConfiguration);
+        $backendUserService = new BackendUserService();
+        $urlBuilderService = new UrlBuilderService();
+        $pageMenuGenerator = (new ReflectionClass(PageMenuGenerator::class))->newInstanceWithoutConstructor();
+        $backendSettingsService = new BackendSettingsService();
+
+        return new ResourceRendererService(
+            $settingsService,
+            $backendUserService,
+            $urlBuilderService,
+            $pageMenuGenerator,
+            $backendSettingsService,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function createRequest(array $settings): ServerRequestInterface
+    {
+        $settingsInterface = $this->createMock(SettingsInterface::class);
+        $settingsInterface->method('has')->willReturn(false);
+        $settingsInterface->method('getIdentifiers')->willReturn([]);
+        $siteSettings = new SiteSettings($settingsInterface, [], $settings);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($siteSettings);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnCallback(
+            static fn (string $name): mixed => 'site' === $name ? $site : null,
+        );
+        $request->method('getUri')->willReturn(new Uri('https://example.com/page'));
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Utility/Compatibility/BackendUserUtilityTest.php
+++ b/Tests/Unit/Utility/Compatibility/BackendUserUtilityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Utility\Compatibility;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\BackendUserUtility;
+
+/**
+ * BackendUserUtilityTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(BackendUserUtility::class)]
+final class BackendUserUtilityTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
+    #[Test]
+    public function hasRecordEditAccessDelegatesToLegacyMethodOnVersion13(): void
+    {
+        $this->registerVersion(13);
+
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->method('recordEditAccessInternals')
+            ->with('tt_content', ['uid' => 1])
+            ->willReturn(true);
+
+        self::assertTrue(BackendUserUtility::hasRecordEditAccess($backendUser, 'tt_content', ['uid' => 1]));
+    }
+
+    #[Test]
+    public function hasRecordEditAccessReturnsFalseWhenLegacyMethodDenies(): void
+    {
+        $this->registerVersion(13);
+
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->method('recordEditAccessInternals')->willReturn(false);
+
+        self::assertFalse(BackendUserUtility::hasRecordEditAccess($backendUser, 'tt_content', ['uid' => 2]));
+    }
+
+    private function registerVersion(int $majorVersion): void
+    {
+        $versionMock = $this->createMock(Typo3Version::class);
+        $versionMock->method('getMajorVersion')->willReturn($majorVersion);
+        GeneralUtility::addInstance(Typo3Version::class, $versionMock);
+    }
+}

--- a/Tests/Unit/Utility/Compatibility/ButtonFactoryUtilityTest.php
+++ b/Tests/Unit/Utility/Compatibility/ButtonFactoryUtilityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Utility\Compatibility;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Template\Components\ButtonBar;
+use TYPO3\CMS\Backend\Template\Components\Buttons\InputButton;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\ButtonFactoryUtility;
+
+/**
+ * ButtonFactoryUtilityTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ButtonFactoryUtility::class)]
+final class ButtonFactoryUtilityTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
+    #[Test]
+    public function createInputButtonUsesButtonBarOnVersion13(): void
+    {
+        $this->registerVersion(13);
+
+        $inputButton = new InputButton();
+        $buttonBar = $this->createMock(ButtonBar::class);
+        $buttonBar->expects(self::once())
+            ->method('makeInputButton')
+            ->willReturn($inputButton);
+
+        self::assertSame($inputButton, ButtonFactoryUtility::createInputButton($buttonBar));
+    }
+
+    private function registerVersion(int $majorVersion): void
+    {
+        $versionMock = $this->createMock(Typo3Version::class);
+        $versionMock->method('getMajorVersion')->willReturn($majorVersion);
+        GeneralUtility::addInstance(Typo3Version::class, $versionMock);
+    }
+}

--- a/Tests/Unit/Utility/Compatibility/VersionUtilityTest.php
+++ b/Tests/Unit/Utility/Compatibility/VersionUtilityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Utility\Compatibility;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3FrontendEdit\Utility\Compatibility\VersionUtility;
+
+/**
+ * VersionUtilityTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(VersionUtility::class)]
+final class VersionUtilityTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
+    #[Test]
+    public function is14OrHigherReturnsTrueForVersion14(): void
+    {
+        $this->registerVersion(14);
+
+        self::assertTrue(VersionUtility::is14OrHigher());
+    }
+
+    #[Test]
+    public function is14OrHigherReturnsTrueForVersionAbove14(): void
+    {
+        $this->registerVersion(15);
+
+        self::assertTrue(VersionUtility::is14OrHigher());
+    }
+
+    #[Test]
+    public function is14OrHigherReturnsFalseForVersion13(): void
+    {
+        $this->registerVersion(13);
+
+        self::assertFalse(VersionUtility::is14OrHigher());
+    }
+
+    private function registerVersion(int $majorVersion): void
+    {
+        $versionMock = $this->createMock(Typo3Version::class);
+        $versionMock->method('getMajorVersion')->willReturn($majorVersion);
+        GeneralUtility::addInstance(Typo3Version::class, $versionMock);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,13 @@
 		"typo3fluid/fluid": "^4.2 || ^5.0"
 	},
 	"require-dev": {
+		"composer/class-map-generator": "^1.7.3",
 		"eliashaeussler/version-bumper": "^4.0.3",
 		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
 		"typo3/cms-base-distribution": "^13.4 || ^14.0",
 		"typo3/cms-lowlevel": "^13.4 || ^14.0",
-		"typo3/testing-framework": "^8.2 || ^9.0"
+		"typo3/testing-framework": "^8.0 || ^9.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,11 @@
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^4.0.3",
+		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
 		"typo3/cms-base-distribution": "^13.4 || ^14.0",
-		"typo3/cms-lowlevel": "^13.4 || ^14.0"
+		"typo3/cms-lowlevel": "^13.4 || ^14.0",
+		"typo3/testing-framework": "^8.2 || ^9.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -82,7 +84,20 @@
 		"docs:build": "docker compose run --rm docs",
 		"docs:cleanup": "rm -rf .Build/docs",
 		"docs:open": "open .Build/docs/Index.html",
-		"test": "@test:coverage --no-coverage",
-		"test:coverage": "phpunit -c phpunit.xml"
+		"test": [
+			"@test:unit",
+			"@test:functional"
+		],
+		"test:coverage": [
+			"@putenv XDEBUG_MODE=coverage",
+			"@test:coverage:clean",
+			"phpunit -c phpunit.xml",
+			"phpunit -c phpunit.functional.xml",
+			"@test:coverage:merge"
+		],
+		"test:coverage:clean": "rm -rf .Build/coverage/cov && mkdir -p .Build/coverage/cov",
+		"test:coverage:merge": "phpcov merge --clover .Build/coverage/clover.xml --html .Build/coverage/html --text php://stdout .Build/coverage/cov",
+		"test:functional": "phpunit -c phpunit.functional.xml --no-coverage",
+		"test:unit": "phpunit -c phpunit.xml --no-coverage"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7412877413f733cfa4e347f94cbcdb7a",
+    "content-hash": "2b4a99509d4f4097e345ba7603a00892",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -121,6 +121,228 @@
             "time": "2021-02-26T10:19:33+00:00"
         },
         {
+            "name": "composer/class-map-generator",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2.1 || ^3.1",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpunit/phpunit": "^8",
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T09:17:07+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
             "name": "dasprid/enum",
             "version": "1.0.7",
             "source": {
@@ -169,83 +391,6 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.10.28",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6.4 || ^7",
-                "vimeo/psalm": "^4.30 || ^5.14"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
-            },
-            "abandoned": true,
-            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -400,97 +545,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
-        },
-        {
-            "name": "doctrine/event-manager",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
-                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "conflict": {
-                "doctrine/common": "<2.9"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^14",
-                "phpdocumentor/guides-cli": "^1.4",
-                "phpstan/phpstan": "^2.1.32",
-                "phpunit/phpunit": "^10.5.58"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
-            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
-            "keywords": [
-                "event",
-                "event dispatcher",
-                "event manager",
-                "event system",
-                "events"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-01-29T07:11:08+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -749,16 +803,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.3",
+            "version": "7.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3"
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
                 "shasum": ""
             },
             "require": {
@@ -777,7 +831,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5.1",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -857,7 +911,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
             },
             "funding": [
                 {
@@ -873,7 +927,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:29:02+00:00"
+            "time": "2026-06-29T20:14:18+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1779,16 +1833,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673"
+                "reference": "9adfcb2a7fc3924473b09f5a0b058dcc2cc7be9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/4c09e18a92cce126cc0d1155825279fca8cd0673",
-                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/9adfcb2a7fc3924473b09f5a0b058dcc2cc7be9a",
+                "reference": "9adfcb2a7fc3924473b09f5a0b058dcc2cc7be9a",
                 "shasum": ""
             },
             "require": {
@@ -1859,7 +1913,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.13"
+                "source": "https://github.com/symfony/cache/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1879,20 +1933,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T08:43:14+00:00"
+            "time": "2026-06-17T14:44:48+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "225e8a254166bd3442e370c6f50145465db63831"
+                "reference": "9789738bc19af1106dc54d6afba9a0b467516cf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/225e8a254166bd3442e370c6f50145465db63831",
-                "reference": "225e8a254166bd3442e370c6f50145465db63831",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/9789738bc19af1106dc54d6afba9a0b467516cf2",
+                "reference": "9789738bc19af1106dc54d6afba9a0b467516cf2",
                 "shasum": ""
             },
             "require": {
@@ -1939,7 +1993,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -1959,7 +2013,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T15:33:14+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/clock",
@@ -2041,16 +2095,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.10",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
-                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
                 "shasum": ""
             },
             "require": {
@@ -2096,7 +2150,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.10"
+                "source": "https://github.com/symfony/config/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2116,20 +2170,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-03T14:20:49+00:00"
+            "time": "2026-06-09T07:51:57+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
-                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -2194,7 +2248,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.13"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2214,20 +2268,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T08:56:14+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2"
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f299e20ce983be6c0744952533c6dfeaaa1448e2",
-                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
                 "shasum": ""
             },
             "require": {
@@ -2278,7 +2332,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.13"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2298,20 +2352,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T14:07:29+00:00"
+            "time": "2026-06-24T07:41:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -2349,7 +2403,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2369,20 +2423,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/doctrine-messenger",
-            "version": "v7.4.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-messenger.git",
-                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3"
+                "reference": "c29901ea81dff6557ae3c78c0bad1d559500c2d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
-                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
+                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/c29901ea81dff6557ae3c78c0bad1d559500c2d8",
+                "reference": "c29901ea81dff6557ae3c78c0bad1d559500c2d8",
                 "shasum": ""
             },
             "require": {
@@ -2425,7 +2479,7 @@
             "description": "Symfony Doctrine Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.6"
+                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2445,20 +2499,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T09:40:04+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.9",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/51fe3d170227be8d1772214b82ae506e15ed78ff",
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff",
                 "shasum": ""
             },
             "require": {
@@ -2510,7 +2564,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2530,20 +2584,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-06-06T11:10:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -2590,7 +2644,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2610,20 +2664,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/expression-language",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "87ff95687748f4af65e4d5a6e917d448ec52aa83"
+                "reference": "bd5763f92959201816ecc31defdf352d2ea473be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/87ff95687748f4af65e4d5a6e917d448ec52aa83",
-                "reference": "87ff95687748f4af65e4d5a6e917d448ec52aa83",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/bd5763f92959201816ecc31defdf352d2ea473be",
+                "reference": "bd5763f92959201816ecc31defdf352d2ea473be",
                 "shasum": ""
             },
             "require": {
@@ -2658,7 +2712,7 @@
             "description": "Provides an engine that can compile and evaluate expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/expression-language/tree/v7.4.8"
+                "source": "https://github.com/symfony/expression-language/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2678,7 +2732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2752,16 +2806,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -2796,7 +2850,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2816,20 +2870,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
-                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -2878,7 +2932,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2898,20 +2952,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T11:20:33+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.12",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
-                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +3016,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2982,20 +3036,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-06-13T08:51:35+00:00"
         },
         {
             "name": "symfony/messenger",
-            "version": "v7.4.12",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "906387986caecc10b2ad2e85f715d834e5133a04"
+                "reference": "1ebe448527c77d9efaf2d3205b23707ebaaa28c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/906387986caecc10b2ad2e85f715d834e5133a04",
-                "reference": "906387986caecc10b2ad2e85f715d834e5133a04",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/1ebe448527c77d9efaf2d3205b23707ebaaa28c4",
+                "reference": "1ebe448527c77d9efaf2d3205b23707ebaaa28c4",
                 "shasum": ""
             },
             "require": {
@@ -3056,7 +3110,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v7.4.12"
+                "source": "https://github.com/symfony/messenger/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3076,7 +3130,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T07:02:47+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "symfony/mime",
@@ -3974,16 +4028,16 @@
         },
         {
             "name": "symfony/rate-limiter",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/rate-limiter.git",
-                "reference": "8b162768544e5a8895c52161d63c999aca91f4a9"
+                "reference": "5c0af3fdc93e6115d9b806a6ea73e7de040e711d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/8b162768544e5a8895c52161d63c999aca91f4a9",
-                "reference": "8b162768544e5a8895c52161d63c999aca91f4a9",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/5c0af3fdc93e6115d9b806a6ea73e7de040e711d",
+                "reference": "5c0af3fdc93e6115d9b806a6ea73e7de040e711d",
                 "shasum": ""
             },
             "require": {
@@ -4024,7 +4078,7 @@
                 "rate-limiter"
             ],
             "support": {
-                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.13"
+                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4044,7 +4098,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T16:05:06+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "symfony/routing",
@@ -4133,16 +4187,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -4196,7 +4250,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4216,7 +4270,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
@@ -4310,6 +4364,188 @@
             "time": "2026-05-23T15:23:29+00:00"
         },
         {
+            "name": "symfony/translation",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
+                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
+            },
+            "conflict": {
+                "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-06T09:33:19+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v7.4.9",
             "source": {
@@ -4389,16 +4625,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.9",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701"
+                "reference": "0118811b1d59f323bf131250b3fb919febfece28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/22e03a49c95ef054a43601cd159b222bfab1c701",
-                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0118811b1d59f323bf131250b3fb919febfece28",
+                "reference": "0118811b1d59f323bf131250b3fb919febfece28",
                 "shasum": ""
             },
             "require": {
@@ -4446,7 +4682,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.9"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4466,20 +4702,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-06-27T08:41:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
                 "shasum": ""
             },
             "require": {
@@ -4522,7 +4758,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4542,39 +4778,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "typo3/class-alias-loader",
-            "version": "v1.2.2",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/class-alias-loader.git",
-                "reference": "9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2"
+                "reference": "c44de30ec91e134e28d4e886bc642bacaf4f407f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/class-alias-loader/zipball/9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2",
-                "reference": "9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2",
+                "url": "https://api.github.com/repos/TYPO3/class-alias-loader/zipball/c44de30ec91e134e28d4e886bc642bacaf4f407f",
+                "reference": "c44de30ec91e134e28d4e886bc642bacaf4f407f",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0",
-                "php": ">=7.1"
+                "php": ">=8.2"
             },
             "replace": {
                 "helhum/class-alias-loader": "*"
             },
             "require-dev": {
                 "composer/composer": "^2.0@dev",
+                "friendsofphp/php-cs-fixer": "^3.95",
                 "mikey179/vfsstream": "~1.4.0@dev",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpunit/phpunit": "^11"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "TYPO3\\ClassAliasLoader\\Plugin",
                 "branch-alias": {
-                    "dev-main": "1.1.x-dev"
+                    "dev-main": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4602,29 +4839,29 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/class-alias-loader/issues",
-                "source": "https://github.com/TYPO3/class-alias-loader/tree/v1.2.2"
+                "source": "https://github.com/TYPO3/class-alias-loader/tree/v2.0.1"
             },
-            "time": "2026-04-17T09:41:06+00:00"
+            "time": "2026-04-17T13:11:31+00:00"
         },
         {
             "name": "typo3/cms-backend",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/backend.git",
-                "reference": "ce09675ab6f002014f1203c3cd5277ef64845335"
+                "reference": "f842410118ea059292dc697e3c085e5b12ea41f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/ce09675ab6f002014f1203c3cd5277ef64845335",
-                "reference": "ce09675ab6f002014f1203c3cd5277ef64845335",
+                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/f842410118ea059292dc697e3c085e5b12ea41f0",
+                "reference": "f842410118ea059292dc697e3c085e5b12ea41f0",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "ext-libxml": "*",
                 "psr/event-dispatcher": "^1.0",
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4635,12 +4872,13 @@
                 "typo3/cms-cshmanual": "self.version",
                 "typo3/cms-func-wizards": "self.version",
                 "typo3/cms-recordlist": "self.version",
+                "typo3/cms-setup": "self.version",
                 "typo3/cms-t3editor": "self.version",
                 "typo3/cms-wizard-crpages": "self.version",
                 "typo3/cms-wizard-sortpages": "self.version"
             },
             "suggest": {
-                "typo3/cms-install": "To generate url to install tool in environment toolbar"
+                "typo3/cms-install": "Displays a link to the Environment module in the System Information toolbar."
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -4654,7 +4892,7 @@
                     "extension-key": "backend"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -4664,7 +4902,8 @@
             },
             "autoload": {
                 "psr-4": {
-                    "TYPO3\\CMS\\Backend\\": "Classes/"
+                    "TYPO3\\CMS\\Backend\\": "Classes/",
+                    "TYPO3\\CMS\\Setup\\Event\\": "DeprecatedClasses/Setup/Event/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4679,14 +4918,23 @@
                 }
             ],
             "description": "TYPO3 CMS backend",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-cli",
@@ -4795,25 +5043,25 @@
         },
         {
             "name": "typo3/cms-core",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/core.git",
-                "reference": "e4258da9b06eec87c9194a66a8d9fb3fcaa230b3"
+                "reference": "e59ef7a3348e439bf103140e01614f1bc403d373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/e4258da9b06eec87c9194a66a8d9fb3fcaa230b3",
-                "reference": "e4258da9b06eec87c9194a66a8d9fb3fcaa230b3",
+                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/e59ef7a3348e439bf103140e01614f1bc403d373",
+                "reference": "e59ef7a3348e439bf103140e01614f1bc403d373",
                 "shasum": ""
             },
             "require": {
-                "bacon/bacon-qr-code": "^3.0",
+                "bacon/bacon-qr-code": "^3.1.1",
                 "christian-riesen/base32": "^1.6",
                 "composer-runtime-api": "^2.1",
-                "doctrine/annotations": "^2.0.2",
+                "composer/class-map-generator": "^1.7.2",
+                "composer/semver": "^3.4",
                 "doctrine/dbal": "~4.4.3",
-                "doctrine/event-manager": "^2.0.1",
                 "doctrine/lexer": "^3.0.1",
                 "egulias/email-validator": "^4.0",
                 "enshrined/svg-sanitize": "~0.22",
@@ -4825,12 +5073,13 @@
                 "ext-pcre": "*",
                 "ext-pdo": "*",
                 "ext-session": "*",
+                "ext-sodium": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "firebase/php-jwt": "^6.10.2 || ^7.0.2",
+                "firebase/php-jwt": "^6.10.2 || ^7.0.5",
                 "guzzlehttp/guzzle": "^7.9.2",
-                "guzzlehttp/psr7": "^2.7.0",
-                "lolli42/finediff": "^1.1.1",
+                "guzzlehttp/psr7": "^2.9.0",
+                "lolli42/finediff": "^1.1.2",
                 "masterminds/html5": "^2.10.0",
                 "php": "^8.2",
                 "psr/container": "^2.0",
@@ -4841,30 +5090,31 @@
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
                 "psr/log": "^3.0.1",
-                "symfony/config": "^7.4",
-                "symfony/console": "^7.4",
-                "symfony/dependency-injection": "^7.4",
-                "symfony/doctrine-messenger": "^7.4",
-                "symfony/event-dispatcher-contracts": "^3.1",
-                "symfony/expression-language": "^7.4",
-                "symfony/filesystem": "^7.4",
-                "symfony/finder": "^7.4",
+                "symfony/config": "^7.4.8",
+                "symfony/console": "^7.4.8",
+                "symfony/dependency-injection": "^7.4.8",
+                "symfony/doctrine-messenger": "^7.4.6",
+                "symfony/event-dispatcher-contracts": "^3.6.0",
+                "symfony/expression-language": "^7.4.8",
+                "symfony/filesystem": "^7.4.8",
+                "symfony/finder": "^7.4.8",
                 "symfony/http-foundation": "^7.4.13",
                 "symfony/mailer": "^7.4.12",
-                "symfony/messenger": "^7.4",
+                "symfony/messenger": "^7.4.8",
                 "symfony/mime": "^7.4.12",
-                "symfony/options-resolver": "^7.4",
-                "symfony/polyfill-php83": "^1.31",
-                "symfony/process": "^7.4",
-                "symfony/rate-limiter": "^7.4",
+                "symfony/options-resolver": "^7.4.8",
+                "symfony/polyfill-php83": "^1.36.0",
+                "symfony/process": "^7.4.8",
+                "symfony/rate-limiter": "^7.4.8",
                 "symfony/routing": "^7.4.13",
-                "symfony/uid": "^7.4",
+                "symfony/translation": "^7.4.8",
+                "symfony/uid": "^7.4.8",
                 "symfony/yaml": "^7.4.12",
-                "typo3/class-alias-loader": "^1.2",
-                "typo3/cms-cli": "^3.1.1",
+                "typo3/class-alias-loader": "^2.0.1",
+                "typo3/cms-cli": "^3.1.3",
                 "typo3/cms-composer-installers": "^5.0.2",
                 "typo3/html-sanitizer": "^2.3.2",
-                "typo3fluid/fluid": "^4.6.1"
+                "typo3fluid/fluid": "^5.3.1"
             },
             "conflict": {
                 "hoa/core": "*",
@@ -4887,7 +5137,7 @@
                 "ext-mysqli": "",
                 "ext-openssl": "OpenSSL is required for sending SMTP mails over an encrypted channel endpoint",
                 "ext-zip": "",
-                "ext-zlib": "TYPO3 uses zlib for amongst others output compression and un/packing t3x extension files"
+                "ext-zlib": "TYPO3 uses zlib for resource compression and un/packing t3x extension files"
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -4901,7 +5151,7 @@
                     "extension-key": "core"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -4915,7 +5165,10 @@
                 ],
                 "psr-4": {
                     "TYPO3\\CMS\\Core\\": "Classes/"
-                }
+                },
+                "classmap": [
+                    "DeprecatedClasses/ext-install/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4929,14 +5182,23 @@
                 }
             ],
             "description": "TYPO3 CMS Core",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/html-sanitizer",
@@ -4991,16 +5253,16 @@
         },
         {
             "name": "typo3fluid/fluid",
-            "version": "4.6.1",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/Fluid.git",
-                "reference": "7dc645eba0cb1ea4d2418252e00db4a4733e9b06"
+                "reference": "28c42c75b171aef196ddbe151b0d1146c290249d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/7dc645eba0cb1ea4d2418252e00db4a4733e9b06",
-                "reference": "7dc645eba0cb1ea4d2418252e00db4a4733e9b06",
+                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/28c42c75b171aef196ddbe151b0d1146c290249d",
+                "reference": "28c42c75b171aef196ddbe151b0d1146c290249d",
                 "shasum": ""
             },
             "require": {
@@ -5011,11 +5273,12 @@
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "friendsofphp/php-cs-fixer": "^3.94.2",
+                "infection/infection": "^0.32.6",
                 "phpstan/phpstan": "^2.1.40",
                 "phpstan/phpstan-phpunit": "^2.0.16",
                 "phpunit/phpunit": "^11.5.55 || ^12.5.14 || ^13.0.5",
                 "psr/container": "^2.0.2",
-                "t3docs/fluid-documentation-generator": "^4.4.1"
+                "t3docs/fluid-documentation-generator": "^4.4.2"
             },
             "suggest": {
                 "ext-json": "PHP JSON is needed when using JSONVariableProvider: A relatively rare use case",
@@ -5027,7 +5290,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.x-dev"
+                    "dev-main": "5.x-dev"
                 }
             },
             "autoload": {
@@ -5046,167 +5309,22 @@
                 "issues": "https://github.com/TYPO3/Fluid/issues",
                 "source": "https://github.com/TYPO3/Fluid"
             },
-            "time": "2026-04-16T17:21:26+00:00"
+            "time": "2026-04-16T17:09:54+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "composer/class-map-generator",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
-                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
-                "shasum": ""
-            },
-            "require": {
-                "composer/pcre": "^2.1 || ^3.1",
-                "php": "^7.2 || ^8.0",
-                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
-                "phpstan/phpstan-phpunit": "^1 || ^2",
-                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
-                "phpunit/phpunit": "^8",
-                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\ClassMapGenerator\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "https://seld.be"
-                }
-            ],
-            "description": "Utilities to scan PHP code and generate class maps.",
-            "keywords": [
-                "classmap"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-05-05T09:17:07+00:00"
-        },
-        {
-            "name": "composer/pcre",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
-                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<2.2.2"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^2",
-                "phpstan/phpstan-deprecation-rules": "^2",
-                "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^9"
-            },
-            "type": "library",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
             "name": "cuyz/valinor",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CuyZ/Valinor.git",
-                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34"
+                "reference": "afbe7352692d5925a76edd53d5998161334056d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/3b0afa3a287ed7f3a69aab223726cf1139454c34",
-                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34",
+                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/afbe7352692d5925a76edd53d5998161334056d4",
+                "reference": "afbe7352692d5925a76edd53d5998161334056d4",
                 "shasum": ""
             },
             "require": {
@@ -5262,7 +5380,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CuyZ/Valinor/issues",
-                "source": "https://github.com/CuyZ/Valinor/tree/2.4.0"
+                "source": "https://github.com/CuyZ/Valinor/tree/2.5.0"
             },
             "funding": [
                 {
@@ -5270,7 +5388,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-23T17:38:05+00:00"
+            "time": "2026-06-28T21:53:40+00:00"
         },
         {
             "name": "cypresslab/gitelephant",
@@ -5822,16 +5940,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.7",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -5839,8 +5957,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -5850,7 +5968,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -5880,44 +5999,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-03-18T20:47:46+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -5938,9 +6057,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2025-11-21T15:09:14+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -7876,6 +7995,110 @@
             "time": "2026-04-22T15:21:55+00:00"
         },
         {
+            "name": "symfony/validator",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "306d904336166d001751759351d40d5e82312596"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/306d904336166d001751759351d40d5e82312596",
+                "reference": "306d904336166d001751759351d40d5e82312596",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php83": "^1.27",
+                "symfony/translation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/lexer": "<1.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<7.0",
+                "symfony/expression-language": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/intl": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/var-exporter": "<6.4.25|>=7.0,<7.3.3",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
+                "symfony/type-info": "^7.1.8",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-27T06:16:12+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -7927,44 +8150,43 @@
         },
         {
             "name": "typo3/cms-base-distribution",
-            "version": "v13.4.1",
+            "version": "v14.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution.git",
-                "reference": "881fa7d50bd5795c184fea0abc59cc27cbb7fbca"
+                "reference": "af03f3d0de6d50b81848a64851cb331b5d8a8135"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/TYPO3.CMS.BaseDistribution/zipball/881fa7d50bd5795c184fea0abc59cc27cbb7fbca",
-                "reference": "881fa7d50bd5795c184fea0abc59cc27cbb7fbca",
+                "url": "https://api.github.com/repos/TYPO3/TYPO3.CMS.BaseDistribution/zipball/af03f3d0de6d50b81848a64851cb331b5d8a8135",
+                "reference": "af03f3d0de6d50b81848a64851cb331b5d8a8135",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-backend": "^13.4",
-                "typo3/cms-belog": "^13.4",
-                "typo3/cms-beuser": "^13.4",
-                "typo3/cms-core": "^13.4",
-                "typo3/cms-dashboard": "^13.4",
-                "typo3/cms-extbase": "^13.4",
-                "typo3/cms-extensionmanager": "^13.4",
-                "typo3/cms-felogin": "^13.4",
-                "typo3/cms-filelist": "^13.4",
-                "typo3/cms-fluid": "^13.4",
-                "typo3/cms-fluid-styled-content": "^13.4",
-                "typo3/cms-form": "^13.4",
-                "typo3/cms-frontend": "^13.4",
-                "typo3/cms-impexp": "^13.4",
-                "typo3/cms-info": "^13.4",
-                "typo3/cms-install": "^13.4",
-                "typo3/cms-reactions": "^13.4",
-                "typo3/cms-recycler": "^13.4",
-                "typo3/cms-rte-ckeditor": "^13.4",
-                "typo3/cms-seo": "^13.4",
-                "typo3/cms-setup": "^13.4",
-                "typo3/cms-sys-note": "^13.4",
-                "typo3/cms-tstemplate": "^13.4",
-                "typo3/cms-viewpage": "^13.4",
-                "typo3/cms-webhooks": "^13.4"
+                "typo3/cms-backend": "^14.3",
+                "typo3/cms-belog": "^14.3",
+                "typo3/cms-beuser": "^14.3",
+                "typo3/cms-core": "^14.3",
+                "typo3/cms-dashboard": "^14.3",
+                "typo3/cms-extbase": "^14.3",
+                "typo3/cms-felogin": "^14.3",
+                "typo3/cms-filelist": "^14.3",
+                "typo3/cms-fluid": "^14.3",
+                "typo3/cms-fluid-styled-content": "^14.3",
+                "typo3/cms-form": "^14.3",
+                "typo3/cms-frontend": "^14.3",
+                "typo3/cms-impexp": "^14.3",
+                "typo3/cms-info": "^14.3",
+                "typo3/cms-install": "^14.3",
+                "typo3/cms-reactions": "^14.3",
+                "typo3/cms-recycler": "^14.3",
+                "typo3/cms-rte-ckeditor": "^14.3",
+                "typo3/cms-seo": "^14.3",
+                "typo3/cms-setup": "^14.3",
+                "typo3/cms-sys-note": "^14.3",
+                "typo3/cms-tstemplate": "^14.3",
+                "typo3/cms-viewpage": "^14.3",
+                "typo3/cms-webhooks": "^14.3"
             },
             "type": "project",
             "notification-url": "https://packagist.org/downloads/",
@@ -7974,26 +8196,26 @@
             "description": "TYPO3 CMS Base Distribution",
             "support": {
                 "issues": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/issues",
-                "source": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/tree/v13.4.1"
+                "source": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/tree/v14.3.0"
             },
-            "time": "2024-11-21T17:50:31+00:00"
+            "time": "2026-04-21T20:02:41+00:00"
         },
         {
             "name": "typo3/cms-belog",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/belog.git",
-                "reference": "283972b74c1038e6f4aa677e9dfe820c2e28913c"
+                "reference": "e5f33784c536e43929104e378d872cafbb5c3afd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/283972b74c1038e6f4aa677e9dfe820c2e28913c",
-                "reference": "283972b74c1038e6f4aa677e9dfe820c2e28913c",
+                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/e5f33784c536e43929104e378d872cafbb5c3afd",
+                "reference": "e5f33784c536e43929104e378d872cafbb5c3afd",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8007,7 +8229,7 @@
                     "extension-key": "belog"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8027,31 +8249,40 @@
                 }
             ],
             "description": "TYPO3 CMS Log - View logs from the sys_log table in the TYPO3 backend modules System>Log",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-beuser",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/beuser.git",
-                "reference": "6d6342a213d3c00090b18a0d6e89af81f6359972"
+                "reference": "124498b0bcf090e1cde666f9f6f80d34322bdd1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/6d6342a213d3c00090b18a0d6e89af81f6359972",
-                "reference": "6d6342a213d3c00090b18a0d6e89af81f6359972",
+                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/124498b0bcf090e1cde666f9f6f80d34322bdd1e",
+                "reference": "124498b0bcf090e1cde666f9f6f80d34322bdd1e",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8065,7 +8296,7 @@
                     "extension-key": "beuser"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8084,36 +8315,45 @@
                     "role": "Developer"
                 }
             ],
-            "description": "TYPO3 CMS Backend User - TYPO3 backend module System>Backend Users for managing backend users and groups.",
-            "homepage": "https://typo3.org",
+            "description": "TYPO3 CMS Backend User - TYPO3 backend module Administration > Users for managing backend users and groups.",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-dashboard",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/dashboard.git",
-                "reference": "9aa050d581524b5aed1e01a27296531cd9a9c77a"
+                "reference": "0dfdb48e21dfd7e48785b775aa0265c981ca43b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/dashboard/zipball/9aa050d581524b5aed1e01a27296531cd9a9c77a",
-                "reference": "9aa050d581524b5aed1e01a27296531cd9a9c77a",
+                "url": "https://api.github.com/repos/TYPO3-CMS/dashboard/zipball/0dfdb48e21dfd7e48785b775aa0265c981ca43b1",
+                "reference": "0dfdb48e21dfd7e48785b775aa0265c981ca43b1",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-backend": "13.4.32",
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-extbase": "13.4.32",
-                "typo3/cms-fluid": "13.4.32",
-                "typo3/cms-frontend": "13.4.32"
+                "typo3/cms-backend": "14.3.4",
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-extbase": "14.3.4",
+                "typo3/cms-fluid": "14.3.4",
+                "typo3/cms-frontend": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8128,7 +8368,7 @@
                     "extension-key": "dashboard"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8148,37 +8388,48 @@
                 }
             ],
             "description": "TYPO3 CMS Dashboard - TYPO3 backend module used to configure and create backend widgets.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-extbase",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/extbase.git",
-                "reference": "73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a"
+                "reference": "3d41793cdb2dcae4a3490f859af6a999e5cc5627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a",
-                "reference": "73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/3d41793cdb2dcae4a3490f859af6a999e5cc5627",
+                "reference": "3d41793cdb2dcae4a3490f859af6a999e5cc5627",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5 || ^2.0",
-                "phpdocumentor/reflection-docblock": "^5.6.5",
-                "phpdocumentor/type-resolver": "^1.8.2",
-                "symfony/dependency-injection": "^7.4",
-                "symfony/property-access": "^7.4",
-                "symfony/property-info": "^7.4",
-                "typo3/cms-core": "13.4.32"
+                "phpdocumentor/reflection-docblock": "^6.0.3",
+                "phpdocumentor/type-resolver": "^2.0.0",
+                "phpstan/phpdoc-parser": "^2.1",
+                "symfony/dependency-injection": "^7.4.8",
+                "symfony/property-access": "^7.4.8",
+                "symfony/property-info": "^7.4.8",
+                "symfony/validator": "^7.4.8",
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8198,7 +8449,12 @@
                     "extension-key": "extbase"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
+                },
+                "typo3/class-alias-loader": {
+                    "class-alias-maps": [
+                        "Migrations/Code/ClassAliasMap.php"
+                    ]
                 }
             },
             "autoload": {
@@ -8218,97 +8474,40 @@
                 }
             ],
             "description": "TYPO3 CMS Extbase - Extension framework to create TYPO3 frontend plugins and TYPO3 backend modules.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
-        },
-        {
-            "name": "typo3/cms-extensionmanager",
-            "version": "v13.4.32",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TYPO3-CMS/extensionmanager.git",
-                "reference": "539bc227ed99ddc37cdb53b48978ef8573675465"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extensionmanager/zipball/539bc227ed99ddc37cdb53b48978ef8573675465",
-                "reference": "539bc227ed99ddc37cdb53b48978ef8573675465",
-                "shasum": ""
-            },
-            "require": {
-                "ext-libxml": "*",
-                "typo3/cms-core": "13.4.32"
-            },
-            "conflict": {
-                "typo3/cms": "*"
-            },
-            "type": "typo3-cms-framework",
-            "extra": {
-                "typo3/cms": {
-                    "Package": {
-                        "protected": true,
-                        "partOfFactoryDefault": true,
-                        "partOfMinimalUsableSystem": true
-                    },
-                    "extension-key": "extensionmanager"
-                },
-                "branch-alias": {
-                    "dev-main": "13.4.x-dev"
-                },
-                "typo3/class-alias-loader": {
-                    "class-alias-maps": [
-                        "Migrations/Code/ClassAliasMap.php"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TYPO3\\CMS\\Extensionmanager\\": "Classes/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "TYPO3 Core Team",
-                    "email": "typo3cms@typo3.org",
-                    "role": "Developer"
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
                 }
             ],
-            "description": "TYPO3 CMS Extension Manager - Backend module (Admin Tools>Extensions) for viewing and managing extensions.",
-            "homepage": "https://typo3.org",
-            "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
-            },
-            "time": "2026-06-16T08:43:58+00:00"
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-felogin",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/felogin.git",
-                "reference": "2c63d98a8cc675b9dda27e7df32b3a0966646b2a"
+                "reference": "d45a4987e58186b3806829ca0e715b148ea6b721"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/2c63d98a8cc675b9dda27e7df32b3a0966646b2a",
-                "reference": "2c63d98a8cc675b9dda27e7df32b3a0966646b2a",
+                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/d45a4987e58186b3806829ca0e715b148ea6b721",
+                "reference": "d45a4987e58186b3806829ca0e715b148ea6b721",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8322,7 +8521,7 @@
                     "extension-key": "felogin"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8342,31 +8541,40 @@
                 }
             ],
             "description": "TYPO3 CMS Frontend Login - A template-based plugin to log in website users in the TYPO3 frontend.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org/c/typo3/cms-felogin/main/en-us",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-filelist",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/filelist.git",
-                "reference": "efe6ca773a51c9a87148b4a68ed2d2678f3a96e9"
+                "reference": "8bc262bbd3577a5535317941e141b0975803a4ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/efe6ca773a51c9a87148b4a68ed2d2678f3a96e9",
-                "reference": "efe6ca773a51c9a87148b4a68ed2d2678f3a96e9",
+                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/8bc262bbd3577a5535317941e141b0975803a4ca",
+                "reference": "8bc262bbd3577a5535317941e141b0975803a4ca",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8382,7 +8590,7 @@
                     "extension-key": "filelist"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8401,35 +8609,45 @@
                     "role": "Developer"
                 }
             ],
-            "description": "TYPO3 CMS Filelist - TYPO3 backend module (File>Filelist) used for managing files.",
-            "homepage": "https://typo3.org",
+            "description": "TYPO3 CMS Filelist - TYPO3 backend module 'Media' used for managing files.",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-fluid",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid.git",
-                "reference": "18a1e6cbda8869390d6eb2c113057958dd4e76f6"
+                "reference": "8f50a943ac2a22532379591c97b570119c8e4bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/18a1e6cbda8869390d6eb2c113057958dd4e76f6",
-                "reference": "18a1e6cbda8869390d6eb2c113057958dd4e76f6",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/8f50a943ac2a22532379591c97b570119c8e4bae",
+                "reference": "8f50a943ac2a22532379591c97b570119c8e4bae",
                 "shasum": ""
             },
             "require": {
-                "symfony/dependency-injection": "^7.4",
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-extbase": "13.4.32",
-                "typo3fluid/fluid": "^4.6.1"
+                "symfony/dependency-injection": "^7.4.8",
+                "symfony/finder": "^7.4.8",
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-extbase": "14.3.4",
+                "typo3fluid/fluid": "^5.3.1"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8446,7 +8664,7 @@
                     "extension-key": "fluid"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8466,33 +8684,42 @@
                 }
             ],
             "description": "TYPO3 CMS Fluid Integration - Integration of the Fluid templating engine into TYPO3.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-fluid-styled-content",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid_styled_content.git",
-                "reference": "152a61bba7057569d8f2a11bb3c354ed28a7f4eb"
+                "reference": "b08e119753ab90e15f015135cdfd65d47bbdbbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/152a61bba7057569d8f2a11bb3c354ed28a7f4eb",
-                "reference": "152a61bba7057569d8f2a11bb3c354ed28a7f4eb",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/b08e119753ab90e15f015135cdfd65d47bbdbbf6",
+                "reference": "b08e119753ab90e15f015135cdfd65d47bbdbbf6",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-fluid": "13.4.32",
-                "typo3/cms-frontend": "13.4.32"
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-fluid": "14.3.4",
+                "typo3/cms-frontend": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8506,7 +8733,7 @@
                     "extension-key": "fluid_styled_content"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8526,34 +8753,43 @@
                 }
             ],
             "description": "TYPO3 CMS Fluid Styled Content - Fluid templates for TYPO3 content elements.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-form",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/form.git",
-                "reference": "0ebf16d6f6005983b9d51b6d9336260d6db4440b"
+                "reference": "3307aae5867a885cd239226c9dda2791ad711f56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/0ebf16d6f6005983b9d51b6d9336260d6db4440b",
-                "reference": "0ebf16d6f6005983b9d51b6d9336260d6db4440b",
+                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/3307aae5867a885cd239226c9dda2791ad711f56",
+                "reference": "3307aae5867a885cd239226c9dda2791ad711f56",
                 "shasum": ""
             },
             "require": {
                 "psr/http-message": "^1.1 || ^2.0",
-                "symfony/expression-language": "^7.4",
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-frontend": "13.4.32"
+                "symfony/expression-language": "^7.4.8",
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-frontend": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8572,7 +8808,7 @@
                     "extension-key": "form"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8592,32 +8828,41 @@
                 }
             ],
             "description": "TYPO3 CMS Form - Flexible TYPO3 frontend form framework that comes with a backend editor interface.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org/c/typo3/cms-form/main/en-us",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/c/typo3/cms-form/main/en-us/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-frontend",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/frontend.git",
-                "reference": "2a1b1c5e711a0474c77417035253a051a3ab75e4"
+                "reference": "bd865d76c5b63a5c0b1f0325b32292e975ad7c38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/2a1b1c5e711a0474c77417035253a051a3ab75e4",
-                "reference": "2a1b1c5e711a0474c77417035253a051a3ab75e4",
+                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/bd865d76c5b63a5c0b1f0325b32292e975ad7c38",
+                "reference": "bd865d76c5b63a5c0b1f0325b32292e975ad7c38",
                 "shasum": ""
             },
             "require": {
                 "ext-libxml": "*",
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8630,14 +8875,13 @@
                 "typo3/cms": {
                     "Package": {
                         "protected": true,
-                        "serviceProvider": "TYPO3\\CMS\\Frontend\\ServiceProvider",
                         "partOfFactoryDefault": true,
                         "partOfMinimalUsableSystem": true
                     },
                     "extension-key": "frontend"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -8662,31 +8906,40 @@
                 }
             ],
             "description": "TYPO3 CMS Frontend",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-impexp",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/impexp.git",
-                "reference": "2a7add7ad4960d873955644a4dc53cab0a38813d"
+                "reference": "b7644c24e3cb118a91be1eafa8810eb33cd94ddf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/2a7add7ad4960d873955644a4dc53cab0a38813d",
-                "reference": "2a7add7ad4960d873955644a4dc53cab0a38813d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/b7644c24e3cb118a91be1eafa8810eb33cd94ddf",
+                "reference": "b7644c24e3cb118a91be1eafa8810eb33cd94ddf",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8700,7 +8953,7 @@
                     "extension-key": "impexp"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8720,31 +8973,40 @@
                 }
             ],
             "description": "TYPO3 CMS Import/Export - Tool for importing and exporting records using XML or the custom T3D format.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-info",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/info.git",
-                "reference": "7d2e6a8f776032fa2179b01243f769f7ff7d5f00"
+                "reference": "b530430877339b2a16c30ba7b78b8c88454dd7a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/7d2e6a8f776032fa2179b01243f769f7ff7d5f00",
-                "reference": "7d2e6a8f776032fa2179b01243f769f7ff7d5f00",
+                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/b530430877339b2a16c30ba7b78b8c88454dd7a1",
+                "reference": "b530430877339b2a16c30ba7b78b8c88454dd7a1",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8761,7 +9023,7 @@
                     "extension-key": "info"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8781,38 +9043,47 @@
                 }
             ],
             "description": "TYPO3 CMS Info - TYPO3 backend module for displaying information, such as a pagetree overview and localization information.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-install",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/install.git",
-                "reference": "be094bb8134114263bc0e6cb7e4f45a526ac3315"
+                "reference": "a4c5bd2e9a598d5d45975312ae097df2a33ef05d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/be094bb8134114263bc0e6cb7e4f45a526ac3315",
-                "reference": "be094bb8134114263bc0e6cb7e4f45a526ac3315",
+                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/a4c5bd2e9a598d5d45975312ae097df2a33ef05d",
+                "reference": "a4c5bd2e9a598d5d45975312ae097df2a33ef05d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "~4.4.3",
                 "guzzlehttp/promises": "^2.0.3",
                 "nikic/php-parser": "^5.4.0",
-                "symfony/finder": "^7.4",
+                "symfony/finder": "^7.4.8",
                 "symfony/http-foundation": "^7.4.13",
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-extbase": "13.4.32",
-                "typo3/cms-fluid": "13.4.32"
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-extbase": "14.3.4",
+                "typo3/cms-fluid": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8829,7 +9100,7 @@
                     "extension-key": "install"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8849,31 +9120,40 @@
                 }
             ],
             "description": "TYPO3 CMS Install Tool - The Install Tool is used for installation, upgrade, system administration and setup tasks.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-lowlevel",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/lowlevel.git",
-                "reference": "cfe15b177df1706bf2528ffc4bc5c6d788378a99"
+                "reference": "f408674f4060c1eddf4378b1840ac08c6a829242"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/lowlevel/zipball/cfe15b177df1706bf2528ffc4bc5c6d788378a99",
-                "reference": "cfe15b177df1706bf2528ffc4bc5c6d788378a99",
+                "url": "https://api.github.com/repos/TYPO3-CMS/lowlevel/zipball/f408674f4060c1eddf4378b1840ac08c6a829242",
+                "reference": "f408674f4060c1eddf4378b1840ac08c6a829242",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8887,7 +9167,7 @@
                     "extension-key": "lowlevel"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8907,31 +9187,40 @@
                 }
             ],
             "description": "TYPO3 CMS Lowlevel - Technical analysis of the system. This includes raw database search, checking relations, counting pages and records etc.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-reactions",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/reactions.git",
-                "reference": "183bd114fb04cfed852c2a768f319af52c4d0a8d"
+                "reference": "700233067b941381d551fa8a0662c92977ba9ceb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/reactions/zipball/183bd114fb04cfed852c2a768f319af52c4d0a8d",
-                "reference": "183bd114fb04cfed852c2a768f319af52c4d0a8d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/reactions/zipball/700233067b941381d551fa8a0662c92977ba9ceb",
+                "reference": "700233067b941381d551fa8a0662c92977ba9ceb",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8945,7 +9234,7 @@
                     "extension-key": "reactions"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -8965,31 +9254,40 @@
                 }
             ],
             "description": "TYPO3 CMS Reactions - Handle incoming Webhooks for TYPO3",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/c/typo3/cms-reactions/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-recycler",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/recycler.git",
-                "reference": "8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb"
+                "reference": "e34ad4cf0561f2e441248c52243457adef3a9bac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/recycler/zipball/8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb",
-                "reference": "8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb",
+                "url": "https://api.github.com/repos/TYPO3-CMS/recycler/zipball/e34ad4cf0561f2e441248c52243457adef3a9bac",
+                "reference": "e34ad4cf0561f2e441248c52243457adef3a9bac",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9006,7 +9304,7 @@
                     "extension-key": "recycler"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9026,37 +9324,43 @@
                 }
             ],
             "description": "TYPO3 CMS Recycler - Restore deleted records or remove them from the database permanently.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-rte-ckeditor",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/rte_ckeditor.git",
-                "reference": "63c0c4b9904c06030ed352e7ea6203aa04175925"
+                "reference": "1e649567cec0c67a3acef5fc2a680f861c6ed146"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/63c0c4b9904c06030ed352e7ea6203aa04175925",
-                "reference": "63c0c4b9904c06030ed352e7ea6203aa04175925",
+                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/1e649567cec0c67a3acef5fc2a680f861c6ed146",
+                "reference": "1e649567cec0c67a3acef5fc2a680f861c6ed146",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
-            },
-            "suggest": {
-                "typo3/cms-setup": "*"
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -9067,7 +9371,7 @@
                     "extension-key": "rte_ckeditor"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9087,33 +9391,42 @@
                 }
             ],
             "description": "TYPO3 CMS RTE CKEditor - Integration of CKEditor as a Rich Text Editor for the TYPO3 backend.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-seo",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/seo.git",
-                "reference": "3523bd5070ec00708edb05ae6060bcb32a7cd886"
+                "reference": "ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/3523bd5070ec00708edb05ae6060bcb32a7cd886",
-                "reference": "3523bd5070ec00708edb05ae6060bcb32a7cd886",
+                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc",
+                "reference": "ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32",
-                "typo3/cms-extbase": "13.4.32",
-                "typo3/cms-frontend": "13.4.32"
+                "typo3/cms-core": "14.3.4",
+                "typo3/cms-extbase": "14.3.4",
+                "typo3/cms-frontend": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9130,7 +9443,7 @@
                     "extension-key": "seo"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9150,89 +9463,40 @@
                 }
             ],
             "description": "TYPO3 CMS SEO - SEO features including specific fields for SEO purposes, rendering of HTML meta tags and sitemaps.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org/c/typo3/cms-seo/main/en-us",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/c/typo3/cms-seo/main/en-us/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
-        },
-        {
-            "name": "typo3/cms-setup",
-            "version": "v13.4.32",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TYPO3-CMS/setup.git",
-                "reference": "efc0c8cb65da16912e069ad4e4766330537a37fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/setup/zipball/efc0c8cb65da16912e069ad4e4766330537a37fe",
-                "reference": "efc0c8cb65da16912e069ad4e4766330537a37fe",
-                "shasum": ""
-            },
-            "require": {
-                "typo3/cms-core": "13.4.32"
-            },
-            "conflict": {
-                "typo3/cms": "*"
-            },
-            "type": "typo3-cms-framework",
-            "extra": {
-                "typo3/cms": {
-                    "Package": {
-                        "partOfFactoryDefault": true
-                    },
-                    "extension-key": "setup"
-                },
-                "branch-alias": {
-                    "dev-main": "13.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TYPO3\\CMS\\Setup\\": "Classes/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "TYPO3 Core Team",
-                    "email": "typo3cms@typo3.org",
-                    "role": "Developer"
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
                 }
             ],
-            "description": "TYPO3 CMS Setup - Allows users to edit a limited set of options for their user profile, including preferred language, their name and email address.",
-            "homepage": "https://typo3.org",
-            "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
-            },
-            "time": "2026-06-16T08:43:58+00:00"
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-sys-note",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/sys_note.git",
-                "reference": "808b58843e29023afdb12078af41d9d9eea1aa2d"
+                "reference": "14543f7367fb92adbacc96a889ff602fe559a979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/808b58843e29023afdb12078af41d9d9eea1aa2d",
-                "reference": "808b58843e29023afdb12078af41d9d9eea1aa2d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/14543f7367fb92adbacc96a889ff602fe559a979",
+                "reference": "14543f7367fb92adbacc96a889ff602fe559a979",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9249,7 +9513,7 @@
                     "extension-key": "sys_note"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9269,31 +9533,40 @@
                 }
             ],
             "description": "TYPO3 CMS System Notes - Records with messages which can be placed on any page and contain instructions or other information related to a page or section.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-tstemplate",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/tstemplate.git",
-                "reference": "dba0d4e57bd5cf1dce5b530565a2a4a2ff250971"
+                "reference": "caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/dba0d4e57bd5cf1dce5b530565a2a4a2ff250971",
-                "reference": "dba0d4e57bd5cf1dce5b530565a2a4a2ff250971",
+                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4",
+                "reference": "caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9307,7 +9580,7 @@
                     "extension-key": "tstemplate"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9327,31 +9600,40 @@
                 }
             ],
             "description": "TYPO3 CMS TypoScript - TYPO3 backend module for the management of TypoScript records for the CMS frontend.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-viewpage",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/viewpage.git",
-                "reference": "4f5fe9641fe698acf07ee54dfb1b67a3ec80514f"
+                "reference": "519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/4f5fe9641fe698acf07ee54dfb1b67a3ec80514f",
-                "reference": "4f5fe9641fe698acf07ee54dfb1b67a3ec80514f",
+                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee",
+                "reference": "519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.32"
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9365,7 +9647,7 @@
                     "extension-key": "viewpage"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9385,32 +9667,41 @@
                 }
             ],
             "description": "TYPO3 CMS Viewpage - Use the (Web>View) backend module to view a frontend page inside the TYPO3 backend.",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "chat": "https://typo3.community/meet/slack/",
+                "docs": "https://docs.typo3.org/",
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/cms-webhooks",
-            "version": "v13.4.32",
+            "version": "v14.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/webhooks.git",
-                "reference": "3e60c977f912822178dcc8fa4f97809947924868"
+                "reference": "e72dac3ec0378c4f5094987ffdc08ba07f68cb41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/webhooks/zipball/3e60c977f912822178dcc8fa4f97809947924868",
-                "reference": "3e60c977f912822178dcc8fa4f97809947924868",
+                "url": "https://api.github.com/repos/TYPO3-CMS/webhooks/zipball/e72dac3ec0378c4f5094987ffdc08ba07f68cb41",
+                "reference": "e72dac3ec0378c4f5094987ffdc08ba07f68cb41",
                 "shasum": ""
             },
             "require": {
-                "symfony/uid": "^7.4",
-                "typo3/cms-core": "13.4.32"
+                "symfony/uid": "^7.4.8",
+                "typo3/cms-core": "14.3.4"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9424,7 +9715,7 @@
                     "extension-key": "webhooks"
                 },
                 "branch-alias": {
-                    "dev-main": "13.4.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -9444,14 +9735,23 @@
                 }
             ],
             "description": "TYPO3 CMS Webhooks - Handle outgoing Webhooks for TYPO3",
-            "homepage": "https://typo3.org",
+            "homepage": "https://typo3.community/",
             "support": {
-                "chat": "https://typo3.org/help",
+                "chat": "https://typo3.community/meet/slack/",
                 "docs": "https://docs.typo3.org/c/typo3/cms-webhooks/main/en-us/",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
+                "forum": "https://talk.typo3.org/",
+                "issues": "https://forge.typo3.org/issues/",
+                "rss": "https://news.typo3.com/rss/",
+                "security": "https://typo3.org/security/",
+                "source": "https://github.com/TYPO3/typo3/"
             },
-            "time": "2026-06-16T08:43:58+00:00"
+            "funding": [
+                {
+                    "url": "https://typo3.org/membership",
+                    "type": "membership"
+                }
+            ],
+            "time": "2026-06-16T08:52:34+00:00"
         },
         {
             "name": "typo3/testing-framework",

--- a/composer.lock
+++ b/composer.lock
@@ -121,228 +121,6 @@
             "time": "2021-02-26T10:19:33+00:00"
         },
         {
-            "name": "composer/class-map-generator",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
-                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
-                "shasum": ""
-            },
-            "require": {
-                "composer/pcre": "^2.1 || ^3.1",
-                "php": "^7.2 || ^8.0",
-                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
-                "phpstan/phpstan-phpunit": "^1 || ^2",
-                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
-                "phpunit/phpunit": "^8",
-                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\ClassMapGenerator\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "https://seld.be"
-                }
-            ],
-            "description": "Utilities to scan PHP code and generate class maps.",
-            "keywords": [
-                "classmap"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-05-05T09:17:07+00:00"
-        },
-        {
-            "name": "composer/pcre",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
-                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<2.2.2"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^2",
-                "phpstan/phpstan-deprecation-rules": "^2",
-                "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^9"
-            },
-            "type": "library",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
-        },
-        {
             "name": "dasprid/enum",
             "version": "1.0.7",
             "source": {
@@ -391,6 +169,83 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "abandoned": true,
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -545,6 +400,97 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-29T07:11:08+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -4364,188 +4310,6 @@
             "time": "2026-05-23T15:23:29+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v7.4.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
-                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5.3|^3.3"
-            },
-            "conflict": {
-                "nikic/php-parser": "<5.0",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/yaml": "<6.4"
-            },
-            "provide": {
-                "symfony/translation-implementation": "2.3|3.0"
-            },
-            "require-dev": {
-                "nikic/php-parser": "^5.0",
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
-                "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\Translation\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools to internationalize your application",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.4.14"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-06T09:33:19+00:00"
-        },
-        {
-            "name": "symfony/translation-contracts",
-            "version": "v3.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
-                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Translation\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to translation",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-05T06:23:12+00:00"
-        },
-        {
             "name": "symfony/uid",
             "version": "v7.4.9",
             "source": {
@@ -4782,36 +4546,35 @@
         },
         {
             "name": "typo3/class-alias-loader",
-            "version": "v2.0.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/class-alias-loader.git",
-                "reference": "c44de30ec91e134e28d4e886bc642bacaf4f407f"
+                "reference": "9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/class-alias-loader/zipball/c44de30ec91e134e28d4e886bc642bacaf4f407f",
-                "reference": "c44de30ec91e134e28d4e886bc642bacaf4f407f",
+                "url": "https://api.github.com/repos/TYPO3/class-alias-loader/zipball/9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2",
+                "reference": "9e385e64ddf8a1ad354a4d62d4d0f90bce4dcbc2",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0",
-                "php": ">=8.2"
+                "php": ">=7.1"
             },
             "replace": {
                 "helhum/class-alias-loader": "*"
             },
             "require-dev": {
                 "composer/composer": "^2.0@dev",
-                "friendsofphp/php-cs-fixer": "^3.95",
                 "mikey179/vfsstream": "~1.4.0@dev",
-                "phpunit/phpunit": "^11"
+                "phpunit/phpunit": "^8 || ^9"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "TYPO3\\ClassAliasLoader\\Plugin",
                 "branch-alias": {
-                    "dev-main": "2.0.x-dev"
+                    "dev-main": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -4839,29 +4602,29 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/class-alias-loader/issues",
-                "source": "https://github.com/TYPO3/class-alias-loader/tree/v2.0.1"
+                "source": "https://github.com/TYPO3/class-alias-loader/tree/v1.2.2"
             },
-            "time": "2026-04-17T13:11:31+00:00"
+            "time": "2026-04-17T09:41:06+00:00"
         },
         {
             "name": "typo3/cms-backend",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/backend.git",
-                "reference": "f842410118ea059292dc697e3c085e5b12ea41f0"
+                "reference": "ce09675ab6f002014f1203c3cd5277ef64845335"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/f842410118ea059292dc697e3c085e5b12ea41f0",
-                "reference": "f842410118ea059292dc697e3c085e5b12ea41f0",
+                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/ce09675ab6f002014f1203c3cd5277ef64845335",
+                "reference": "ce09675ab6f002014f1203c3cd5277ef64845335",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "ext-libxml": "*",
                 "psr/event-dispatcher": "^1.0",
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4872,13 +4635,12 @@
                 "typo3/cms-cshmanual": "self.version",
                 "typo3/cms-func-wizards": "self.version",
                 "typo3/cms-recordlist": "self.version",
-                "typo3/cms-setup": "self.version",
                 "typo3/cms-t3editor": "self.version",
                 "typo3/cms-wizard-crpages": "self.version",
                 "typo3/cms-wizard-sortpages": "self.version"
             },
             "suggest": {
-                "typo3/cms-install": "Displays a link to the Environment module in the System Information toolbar."
+                "typo3/cms-install": "To generate url to install tool in environment toolbar"
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -4892,7 +4654,7 @@
                     "extension-key": "backend"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -4902,8 +4664,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "TYPO3\\CMS\\Backend\\": "Classes/",
-                    "TYPO3\\CMS\\Setup\\Event\\": "DeprecatedClasses/Setup/Event/"
+                    "TYPO3\\CMS\\Backend\\": "Classes/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4918,23 +4679,14 @@
                 }
             ],
             "description": "TYPO3 CMS backend",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-cli",
@@ -5043,25 +4795,25 @@
         },
         {
             "name": "typo3/cms-core",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/core.git",
-                "reference": "e59ef7a3348e439bf103140e01614f1bc403d373"
+                "reference": "e4258da9b06eec87c9194a66a8d9fb3fcaa230b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/e59ef7a3348e439bf103140e01614f1bc403d373",
-                "reference": "e59ef7a3348e439bf103140e01614f1bc403d373",
+                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/e4258da9b06eec87c9194a66a8d9fb3fcaa230b3",
+                "reference": "e4258da9b06eec87c9194a66a8d9fb3fcaa230b3",
                 "shasum": ""
             },
             "require": {
-                "bacon/bacon-qr-code": "^3.1.1",
+                "bacon/bacon-qr-code": "^3.0",
                 "christian-riesen/base32": "^1.6",
                 "composer-runtime-api": "^2.1",
-                "composer/class-map-generator": "^1.7.2",
-                "composer/semver": "^3.4",
+                "doctrine/annotations": "^2.0.2",
                 "doctrine/dbal": "~4.4.3",
+                "doctrine/event-manager": "^2.0.1",
                 "doctrine/lexer": "^3.0.1",
                 "egulias/email-validator": "^4.0",
                 "enshrined/svg-sanitize": "~0.22",
@@ -5073,13 +4825,12 @@
                 "ext-pcre": "*",
                 "ext-pdo": "*",
                 "ext-session": "*",
-                "ext-sodium": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "firebase/php-jwt": "^6.10.2 || ^7.0.5",
+                "firebase/php-jwt": "^6.10.2 || ^7.0.2",
                 "guzzlehttp/guzzle": "^7.9.2",
-                "guzzlehttp/psr7": "^2.9.0",
-                "lolli42/finediff": "^1.1.2",
+                "guzzlehttp/psr7": "^2.7.0",
+                "lolli42/finediff": "^1.1.1",
                 "masterminds/html5": "^2.10.0",
                 "php": "^8.2",
                 "psr/container": "^2.0",
@@ -5090,31 +4841,30 @@
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
                 "psr/log": "^3.0.1",
-                "symfony/config": "^7.4.8",
-                "symfony/console": "^7.4.8",
-                "symfony/dependency-injection": "^7.4.8",
-                "symfony/doctrine-messenger": "^7.4.6",
-                "symfony/event-dispatcher-contracts": "^3.6.0",
-                "symfony/expression-language": "^7.4.8",
-                "symfony/filesystem": "^7.4.8",
-                "symfony/finder": "^7.4.8",
+                "symfony/config": "^7.4",
+                "symfony/console": "^7.4",
+                "symfony/dependency-injection": "^7.4",
+                "symfony/doctrine-messenger": "^7.4",
+                "symfony/event-dispatcher-contracts": "^3.1",
+                "symfony/expression-language": "^7.4",
+                "symfony/filesystem": "^7.4",
+                "symfony/finder": "^7.4",
                 "symfony/http-foundation": "^7.4.13",
                 "symfony/mailer": "^7.4.12",
-                "symfony/messenger": "^7.4.8",
+                "symfony/messenger": "^7.4",
                 "symfony/mime": "^7.4.12",
-                "symfony/options-resolver": "^7.4.8",
-                "symfony/polyfill-php83": "^1.36.0",
-                "symfony/process": "^7.4.8",
-                "symfony/rate-limiter": "^7.4.8",
+                "symfony/options-resolver": "^7.4",
+                "symfony/polyfill-php83": "^1.31",
+                "symfony/process": "^7.4",
+                "symfony/rate-limiter": "^7.4",
                 "symfony/routing": "^7.4.13",
-                "symfony/translation": "^7.4.8",
-                "symfony/uid": "^7.4.8",
+                "symfony/uid": "^7.4",
                 "symfony/yaml": "^7.4.12",
-                "typo3/class-alias-loader": "^2.0.1",
-                "typo3/cms-cli": "^3.1.3",
+                "typo3/class-alias-loader": "^1.2",
+                "typo3/cms-cli": "^3.1.1",
                 "typo3/cms-composer-installers": "^5.0.2",
                 "typo3/html-sanitizer": "^2.3.2",
-                "typo3fluid/fluid": "^5.3.1"
+                "typo3fluid/fluid": "^4.6.1"
             },
             "conflict": {
                 "hoa/core": "*",
@@ -5137,7 +4887,7 @@
                 "ext-mysqli": "",
                 "ext-openssl": "OpenSSL is required for sending SMTP mails over an encrypted channel endpoint",
                 "ext-zip": "",
-                "ext-zlib": "TYPO3 uses zlib for resource compression and un/packing t3x extension files"
+                "ext-zlib": "TYPO3 uses zlib for amongst others output compression and un/packing t3x extension files"
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -5151,7 +4901,7 @@
                     "extension-key": "core"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -5165,10 +4915,7 @@
                 ],
                 "psr-4": {
                     "TYPO3\\CMS\\Core\\": "Classes/"
-                },
-                "classmap": [
-                    "DeprecatedClasses/ext-install/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5182,23 +4929,14 @@
                 }
             ],
             "description": "TYPO3 CMS Core",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/html-sanitizer",
@@ -5253,16 +4991,16 @@
         },
         {
             "name": "typo3fluid/fluid",
-            "version": "5.3.1",
+            "version": "4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/Fluid.git",
-                "reference": "28c42c75b171aef196ddbe151b0d1146c290249d"
+                "reference": "7dc645eba0cb1ea4d2418252e00db4a4733e9b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/28c42c75b171aef196ddbe151b0d1146c290249d",
-                "reference": "28c42c75b171aef196ddbe151b0d1146c290249d",
+                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/7dc645eba0cb1ea4d2418252e00db4a4733e9b06",
+                "reference": "7dc645eba0cb1ea4d2418252e00db4a4733e9b06",
                 "shasum": ""
             },
             "require": {
@@ -5273,12 +5011,11 @@
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "friendsofphp/php-cs-fixer": "^3.94.2",
-                "infection/infection": "^0.32.6",
                 "phpstan/phpstan": "^2.1.40",
                 "phpstan/phpstan-phpunit": "^2.0.16",
                 "phpunit/phpunit": "^11.5.55 || ^12.5.14 || ^13.0.5",
                 "psr/container": "^2.0.2",
-                "t3docs/fluid-documentation-generator": "^4.4.2"
+                "t3docs/fluid-documentation-generator": "^4.4.1"
             },
             "suggest": {
                 "ext-json": "PHP JSON is needed when using JSONVariableProvider: A relatively rare use case",
@@ -5290,7 +5027,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -5309,10 +5046,155 @@
                 "issues": "https://github.com/TYPO3/Fluid/issues",
                 "source": "https://github.com/TYPO3/Fluid"
             },
-            "time": "2026-04-16T17:09:54+00:00"
+            "time": "2026-04-16T17:21:26+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "composer/class-map-generator",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2.1 || ^3.1",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpunit/phpunit": "^8",
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T09:17:07+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
+        },
         {
             "name": "cuyz/valinor",
             "version": "2.5.0",
@@ -5940,16 +5822,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.3",
+            "version": "5.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
                 "shasum": ""
             },
             "require": {
@@ -5957,8 +5839,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -5968,8 +5850,7 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26",
-                "shipmonk/dead-code-detector": "^0.5.1"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -5999,44 +5880,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
             },
-            "time": "2026-03-18T20:49:53+00:00"
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "2.0.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^4"
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev",
-                    "dev-2.x": "2.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
@@ -6057,9 +5938,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
-            "time": "2026-01-06T21:53:42+00:00"
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -7995,110 +7876,6 @@
             "time": "2026-04-22T15:21:55+00:00"
         },
         {
-            "name": "symfony/validator",
-            "version": "v7.4.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/validator.git",
-                "reference": "306d904336166d001751759351d40d5e82312596"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/306d904336166d001751759351d40d5e82312596",
-                "reference": "306d904336166d001751759351d40d5e82312596",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php83": "^1.27",
-                "symfony/translation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "doctrine/lexer": "<1.1",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/doctrine-bridge": "<7.0",
-                "symfony/expression-language": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/intl": "<6.4",
-                "symfony/property-info": "<6.4",
-                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
-                "symfony/var-exporter": "<6.4.25|>=7.0,<7.3.3",
-                "symfony/yaml": "<6.4"
-            },
-            "require-dev": {
-                "egulias/email-validator": "^2.1.10|^3|^4",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
-                "symfony/type-info": "^7.1.8",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Validator\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/",
-                    "/Resources/bin/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools to validate values",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/validator/tree/v7.4.14"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-27T06:16:12+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -8150,43 +7927,44 @@
         },
         {
             "name": "typo3/cms-base-distribution",
-            "version": "v14.3.0",
+            "version": "v13.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution.git",
-                "reference": "af03f3d0de6d50b81848a64851cb331b5d8a8135"
+                "reference": "881fa7d50bd5795c184fea0abc59cc27cbb7fbca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/TYPO3.CMS.BaseDistribution/zipball/af03f3d0de6d50b81848a64851cb331b5d8a8135",
-                "reference": "af03f3d0de6d50b81848a64851cb331b5d8a8135",
+                "url": "https://api.github.com/repos/TYPO3/TYPO3.CMS.BaseDistribution/zipball/881fa7d50bd5795c184fea0abc59cc27cbb7fbca",
+                "reference": "881fa7d50bd5795c184fea0abc59cc27cbb7fbca",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-backend": "^14.3",
-                "typo3/cms-belog": "^14.3",
-                "typo3/cms-beuser": "^14.3",
-                "typo3/cms-core": "^14.3",
-                "typo3/cms-dashboard": "^14.3",
-                "typo3/cms-extbase": "^14.3",
-                "typo3/cms-felogin": "^14.3",
-                "typo3/cms-filelist": "^14.3",
-                "typo3/cms-fluid": "^14.3",
-                "typo3/cms-fluid-styled-content": "^14.3",
-                "typo3/cms-form": "^14.3",
-                "typo3/cms-frontend": "^14.3",
-                "typo3/cms-impexp": "^14.3",
-                "typo3/cms-info": "^14.3",
-                "typo3/cms-install": "^14.3",
-                "typo3/cms-reactions": "^14.3",
-                "typo3/cms-recycler": "^14.3",
-                "typo3/cms-rte-ckeditor": "^14.3",
-                "typo3/cms-seo": "^14.3",
-                "typo3/cms-setup": "^14.3",
-                "typo3/cms-sys-note": "^14.3",
-                "typo3/cms-tstemplate": "^14.3",
-                "typo3/cms-viewpage": "^14.3",
-                "typo3/cms-webhooks": "^14.3"
+                "typo3/cms-backend": "^13.4",
+                "typo3/cms-belog": "^13.4",
+                "typo3/cms-beuser": "^13.4",
+                "typo3/cms-core": "^13.4",
+                "typo3/cms-dashboard": "^13.4",
+                "typo3/cms-extbase": "^13.4",
+                "typo3/cms-extensionmanager": "^13.4",
+                "typo3/cms-felogin": "^13.4",
+                "typo3/cms-filelist": "^13.4",
+                "typo3/cms-fluid": "^13.4",
+                "typo3/cms-fluid-styled-content": "^13.4",
+                "typo3/cms-form": "^13.4",
+                "typo3/cms-frontend": "^13.4",
+                "typo3/cms-impexp": "^13.4",
+                "typo3/cms-info": "^13.4",
+                "typo3/cms-install": "^13.4",
+                "typo3/cms-reactions": "^13.4",
+                "typo3/cms-recycler": "^13.4",
+                "typo3/cms-rte-ckeditor": "^13.4",
+                "typo3/cms-seo": "^13.4",
+                "typo3/cms-setup": "^13.4",
+                "typo3/cms-sys-note": "^13.4",
+                "typo3/cms-tstemplate": "^13.4",
+                "typo3/cms-viewpage": "^13.4",
+                "typo3/cms-webhooks": "^13.4"
             },
             "type": "project",
             "notification-url": "https://packagist.org/downloads/",
@@ -8196,26 +7974,26 @@
             "description": "TYPO3 CMS Base Distribution",
             "support": {
                 "issues": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/issues",
-                "source": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/tree/v14.3.0"
+                "source": "https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/tree/v13.4.1"
             },
-            "time": "2026-04-21T20:02:41+00:00"
+            "time": "2024-11-21T17:50:31+00:00"
         },
         {
             "name": "typo3/cms-belog",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/belog.git",
-                "reference": "e5f33784c536e43929104e378d872cafbb5c3afd"
+                "reference": "283972b74c1038e6f4aa677e9dfe820c2e28913c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/e5f33784c536e43929104e378d872cafbb5c3afd",
-                "reference": "e5f33784c536e43929104e378d872cafbb5c3afd",
+                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/283972b74c1038e6f4aa677e9dfe820c2e28913c",
+                "reference": "283972b74c1038e6f4aa677e9dfe820c2e28913c",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8229,7 +8007,7 @@
                     "extension-key": "belog"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8249,40 +8027,31 @@
                 }
             ],
             "description": "TYPO3 CMS Log - View logs from the sys_log table in the TYPO3 backend modules System>Log",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-beuser",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/beuser.git",
-                "reference": "124498b0bcf090e1cde666f9f6f80d34322bdd1e"
+                "reference": "6d6342a213d3c00090b18a0d6e89af81f6359972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/124498b0bcf090e1cde666f9f6f80d34322bdd1e",
-                "reference": "124498b0bcf090e1cde666f9f6f80d34322bdd1e",
+                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/6d6342a213d3c00090b18a0d6e89af81f6359972",
+                "reference": "6d6342a213d3c00090b18a0d6e89af81f6359972",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8296,7 +8065,7 @@
                     "extension-key": "beuser"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8315,45 +8084,36 @@
                     "role": "Developer"
                 }
             ],
-            "description": "TYPO3 CMS Backend User - TYPO3 backend module Administration > Users for managing backend users and groups.",
-            "homepage": "https://typo3.community/",
+            "description": "TYPO3 CMS Backend User - TYPO3 backend module System>Backend Users for managing backend users and groups.",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-dashboard",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/dashboard.git",
-                "reference": "0dfdb48e21dfd7e48785b775aa0265c981ca43b1"
+                "reference": "9aa050d581524b5aed1e01a27296531cd9a9c77a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/dashboard/zipball/0dfdb48e21dfd7e48785b775aa0265c981ca43b1",
-                "reference": "0dfdb48e21dfd7e48785b775aa0265c981ca43b1",
+                "url": "https://api.github.com/repos/TYPO3-CMS/dashboard/zipball/9aa050d581524b5aed1e01a27296531cd9a9c77a",
+                "reference": "9aa050d581524b5aed1e01a27296531cd9a9c77a",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-backend": "14.3.4",
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-extbase": "14.3.4",
-                "typo3/cms-fluid": "14.3.4",
-                "typo3/cms-frontend": "14.3.4"
+                "typo3/cms-backend": "13.4.32",
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-extbase": "13.4.32",
+                "typo3/cms-fluid": "13.4.32",
+                "typo3/cms-frontend": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8368,7 +8128,7 @@
                     "extension-key": "dashboard"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8388,48 +8148,37 @@
                 }
             ],
             "description": "TYPO3 CMS Dashboard - TYPO3 backend module used to configure and create backend widgets.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-extbase",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/extbase.git",
-                "reference": "3d41793cdb2dcae4a3490f859af6a999e5cc5627"
+                "reference": "73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/3d41793cdb2dcae4a3490f859af6a999e5cc5627",
-                "reference": "3d41793cdb2dcae4a3490f859af6a999e5cc5627",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a",
+                "reference": "73d1dcbced793c2ebdbc5454201bbbb3f5dbd23a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5 || ^2.0",
-                "phpdocumentor/reflection-docblock": "^6.0.3",
-                "phpdocumentor/type-resolver": "^2.0.0",
-                "phpstan/phpdoc-parser": "^2.1",
-                "symfony/dependency-injection": "^7.4.8",
-                "symfony/property-access": "^7.4.8",
-                "symfony/property-info": "^7.4.8",
-                "symfony/validator": "^7.4.8",
-                "typo3/cms-core": "14.3.4"
+                "phpdocumentor/reflection-docblock": "^5.6.5",
+                "phpdocumentor/type-resolver": "^1.8.2",
+                "symfony/dependency-injection": "^7.4",
+                "symfony/property-access": "^7.4",
+                "symfony/property-info": "^7.4",
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8449,12 +8198,7 @@
                     "extension-key": "extbase"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
-                },
-                "typo3/class-alias-loader": {
-                    "class-alias-maps": [
-                        "Migrations/Code/ClassAliasMap.php"
-                    ]
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8474,40 +8218,97 @@
                 }
             ],
             "description": "TYPO3 CMS Extbase - Extension framework to create TYPO3 frontend plugins and TYPO3 backend modules.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
-            "name": "typo3/cms-felogin",
-            "version": "v14.3.4",
+            "name": "typo3/cms-extensionmanager",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
-                "url": "https://github.com/TYPO3-CMS/felogin.git",
-                "reference": "d45a4987e58186b3806829ca0e715b148ea6b721"
+                "url": "https://github.com/TYPO3-CMS/extensionmanager.git",
+                "reference": "539bc227ed99ddc37cdb53b48978ef8573675465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/d45a4987e58186b3806829ca0e715b148ea6b721",
-                "reference": "d45a4987e58186b3806829ca0e715b148ea6b721",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extensionmanager/zipball/539bc227ed99ddc37cdb53b48978ef8573675465",
+                "reference": "539bc227ed99ddc37cdb53b48978ef8573675465",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "ext-libxml": "*",
+                "typo3/cms-core": "13.4.32"
+            },
+            "conflict": {
+                "typo3/cms": "*"
+            },
+            "type": "typo3-cms-framework",
+            "extra": {
+                "typo3/cms": {
+                    "Package": {
+                        "protected": true,
+                        "partOfFactoryDefault": true,
+                        "partOfMinimalUsableSystem": true
+                    },
+                    "extension-key": "extensionmanager"
+                },
+                "branch-alias": {
+                    "dev-main": "13.4.x-dev"
+                },
+                "typo3/class-alias-loader": {
+                    "class-alias-maps": [
+                        "Migrations/Code/ClassAliasMap.php"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\CMS\\Extensionmanager\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "TYPO3 Core Team",
+                    "email": "typo3cms@typo3.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "TYPO3 CMS Extension Manager - Backend module (Admin Tools>Extensions) for viewing and managing extensions.",
+            "homepage": "https://typo3.org",
+            "support": {
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
+            },
+            "time": "2026-06-16T08:43:58+00:00"
+        },
+        {
+            "name": "typo3/cms-felogin",
+            "version": "v13.4.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3-CMS/felogin.git",
+                "reference": "2c63d98a8cc675b9dda27e7df32b3a0966646b2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/2c63d98a8cc675b9dda27e7df32b3a0966646b2a",
+                "reference": "2c63d98a8cc675b9dda27e7df32b3a0966646b2a",
+                "shasum": ""
+            },
+            "require": {
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8521,7 +8322,7 @@
                     "extension-key": "felogin"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8541,40 +8342,31 @@
                 }
             ],
             "description": "TYPO3 CMS Frontend Login - A template-based plugin to log in website users in the TYPO3 frontend.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org/c/typo3/cms-felogin/main/en-us",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-filelist",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/filelist.git",
-                "reference": "8bc262bbd3577a5535317941e141b0975803a4ca"
+                "reference": "efe6ca773a51c9a87148b4a68ed2d2678f3a96e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/8bc262bbd3577a5535317941e141b0975803a4ca",
-                "reference": "8bc262bbd3577a5535317941e141b0975803a4ca",
+                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/efe6ca773a51c9a87148b4a68ed2d2678f3a96e9",
+                "reference": "efe6ca773a51c9a87148b4a68ed2d2678f3a96e9",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8590,7 +8382,7 @@
                     "extension-key": "filelist"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8609,45 +8401,35 @@
                     "role": "Developer"
                 }
             ],
-            "description": "TYPO3 CMS Filelist - TYPO3 backend module 'Media' used for managing files.",
-            "homepage": "https://typo3.community/",
+            "description": "TYPO3 CMS Filelist - TYPO3 backend module (File>Filelist) used for managing files.",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-fluid",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid.git",
-                "reference": "8f50a943ac2a22532379591c97b570119c8e4bae"
+                "reference": "18a1e6cbda8869390d6eb2c113057958dd4e76f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/8f50a943ac2a22532379591c97b570119c8e4bae",
-                "reference": "8f50a943ac2a22532379591c97b570119c8e4bae",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/18a1e6cbda8869390d6eb2c113057958dd4e76f6",
+                "reference": "18a1e6cbda8869390d6eb2c113057958dd4e76f6",
                 "shasum": ""
             },
             "require": {
-                "symfony/dependency-injection": "^7.4.8",
-                "symfony/finder": "^7.4.8",
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-extbase": "14.3.4",
-                "typo3fluid/fluid": "^5.3.1"
+                "symfony/dependency-injection": "^7.4",
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-extbase": "13.4.32",
+                "typo3fluid/fluid": "^4.6.1"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8664,7 +8446,7 @@
                     "extension-key": "fluid"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8684,42 +8466,33 @@
                 }
             ],
             "description": "TYPO3 CMS Fluid Integration - Integration of the Fluid templating engine into TYPO3.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-fluid-styled-content",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid_styled_content.git",
-                "reference": "b08e119753ab90e15f015135cdfd65d47bbdbbf6"
+                "reference": "152a61bba7057569d8f2a11bb3c354ed28a7f4eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/b08e119753ab90e15f015135cdfd65d47bbdbbf6",
-                "reference": "b08e119753ab90e15f015135cdfd65d47bbdbbf6",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/152a61bba7057569d8f2a11bb3c354ed28a7f4eb",
+                "reference": "152a61bba7057569d8f2a11bb3c354ed28a7f4eb",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-fluid": "14.3.4",
-                "typo3/cms-frontend": "14.3.4"
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-fluid": "13.4.32",
+                "typo3/cms-frontend": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8733,7 +8506,7 @@
                     "extension-key": "fluid_styled_content"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8753,43 +8526,34 @@
                 }
             ],
             "description": "TYPO3 CMS Fluid Styled Content - Fluid templates for TYPO3 content elements.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-form",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/form.git",
-                "reference": "3307aae5867a885cd239226c9dda2791ad711f56"
+                "reference": "0ebf16d6f6005983b9d51b6d9336260d6db4440b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/3307aae5867a885cd239226c9dda2791ad711f56",
-                "reference": "3307aae5867a885cd239226c9dda2791ad711f56",
+                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/0ebf16d6f6005983b9d51b6d9336260d6db4440b",
+                "reference": "0ebf16d6f6005983b9d51b6d9336260d6db4440b",
                 "shasum": ""
             },
             "require": {
                 "psr/http-message": "^1.1 || ^2.0",
-                "symfony/expression-language": "^7.4.8",
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-frontend": "14.3.4"
+                "symfony/expression-language": "^7.4",
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-frontend": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8808,7 +8572,7 @@
                     "extension-key": "form"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8828,41 +8592,32 @@
                 }
             ],
             "description": "TYPO3 CMS Form - Flexible TYPO3 frontend form framework that comes with a backend editor interface.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/c/typo3/cms-form/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org/c/typo3/cms-form/main/en-us",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-frontend",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/frontend.git",
-                "reference": "bd865d76c5b63a5c0b1f0325b32292e975ad7c38"
+                "reference": "2a1b1c5e711a0474c77417035253a051a3ab75e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/bd865d76c5b63a5c0b1f0325b32292e975ad7c38",
-                "reference": "bd865d76c5b63a5c0b1f0325b32292e975ad7c38",
+                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/2a1b1c5e711a0474c77417035253a051a3ab75e4",
+                "reference": "2a1b1c5e711a0474c77417035253a051a3ab75e4",
                 "shasum": ""
             },
             "require": {
                 "ext-libxml": "*",
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8875,13 +8630,14 @@
                 "typo3/cms": {
                     "Package": {
                         "protected": true,
+                        "serviceProvider": "TYPO3\\CMS\\Frontend\\ServiceProvider",
                         "partOfFactoryDefault": true,
                         "partOfMinimalUsableSystem": true
                     },
                     "extension-key": "frontend"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 },
                 "typo3/class-alias-loader": {
                     "class-alias-maps": [
@@ -8906,40 +8662,31 @@
                 }
             ],
             "description": "TYPO3 CMS Frontend",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-impexp",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/impexp.git",
-                "reference": "b7644c24e3cb118a91be1eafa8810eb33cd94ddf"
+                "reference": "2a7add7ad4960d873955644a4dc53cab0a38813d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/b7644c24e3cb118a91be1eafa8810eb33cd94ddf",
-                "reference": "b7644c24e3cb118a91be1eafa8810eb33cd94ddf",
+                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/2a7add7ad4960d873955644a4dc53cab0a38813d",
+                "reference": "2a7add7ad4960d873955644a4dc53cab0a38813d",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -8953,7 +8700,7 @@
                     "extension-key": "impexp"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -8973,40 +8720,31 @@
                 }
             ],
             "description": "TYPO3 CMS Import/Export - Tool for importing and exporting records using XML or the custom T3D format.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-info",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/info.git",
-                "reference": "b530430877339b2a16c30ba7b78b8c88454dd7a1"
+                "reference": "7d2e6a8f776032fa2179b01243f769f7ff7d5f00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/b530430877339b2a16c30ba7b78b8c88454dd7a1",
-                "reference": "b530430877339b2a16c30ba7b78b8c88454dd7a1",
+                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/7d2e6a8f776032fa2179b01243f769f7ff7d5f00",
+                "reference": "7d2e6a8f776032fa2179b01243f769f7ff7d5f00",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9023,7 +8761,7 @@
                     "extension-key": "info"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9043,47 +8781,38 @@
                 }
             ],
             "description": "TYPO3 CMS Info - TYPO3 backend module for displaying information, such as a pagetree overview and localization information.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-install",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/install.git",
-                "reference": "a4c5bd2e9a598d5d45975312ae097df2a33ef05d"
+                "reference": "be094bb8134114263bc0e6cb7e4f45a526ac3315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/a4c5bd2e9a598d5d45975312ae097df2a33ef05d",
-                "reference": "a4c5bd2e9a598d5d45975312ae097df2a33ef05d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/be094bb8134114263bc0e6cb7e4f45a526ac3315",
+                "reference": "be094bb8134114263bc0e6cb7e4f45a526ac3315",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "~4.4.3",
                 "guzzlehttp/promises": "^2.0.3",
                 "nikic/php-parser": "^5.4.0",
-                "symfony/finder": "^7.4.8",
+                "symfony/finder": "^7.4",
                 "symfony/http-foundation": "^7.4.13",
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-extbase": "14.3.4",
-                "typo3/cms-fluid": "14.3.4"
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-extbase": "13.4.32",
+                "typo3/cms-fluid": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9100,7 +8829,7 @@
                     "extension-key": "install"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9120,40 +8849,31 @@
                 }
             ],
             "description": "TYPO3 CMS Install Tool - The Install Tool is used for installation, upgrade, system administration and setup tasks.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-lowlevel",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/lowlevel.git",
-                "reference": "f408674f4060c1eddf4378b1840ac08c6a829242"
+                "reference": "cfe15b177df1706bf2528ffc4bc5c6d788378a99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/lowlevel/zipball/f408674f4060c1eddf4378b1840ac08c6a829242",
-                "reference": "f408674f4060c1eddf4378b1840ac08c6a829242",
+                "url": "https://api.github.com/repos/TYPO3-CMS/lowlevel/zipball/cfe15b177df1706bf2528ffc4bc5c6d788378a99",
+                "reference": "cfe15b177df1706bf2528ffc4bc5c6d788378a99",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9167,7 +8887,7 @@
                     "extension-key": "lowlevel"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9187,40 +8907,31 @@
                 }
             ],
             "description": "TYPO3 CMS Lowlevel - Technical analysis of the system. This includes raw database search, checking relations, counting pages and records etc.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-reactions",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/reactions.git",
-                "reference": "700233067b941381d551fa8a0662c92977ba9ceb"
+                "reference": "183bd114fb04cfed852c2a768f319af52c4d0a8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/reactions/zipball/700233067b941381d551fa8a0662c92977ba9ceb",
-                "reference": "700233067b941381d551fa8a0662c92977ba9ceb",
+                "url": "https://api.github.com/repos/TYPO3-CMS/reactions/zipball/183bd114fb04cfed852c2a768f319af52c4d0a8d",
+                "reference": "183bd114fb04cfed852c2a768f319af52c4d0a8d",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9234,7 +8945,7 @@
                     "extension-key": "reactions"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9254,40 +8965,31 @@
                 }
             ],
             "description": "TYPO3 CMS Reactions - Handle incoming Webhooks for TYPO3",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/c/typo3/cms-reactions/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-recycler",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/recycler.git",
-                "reference": "e34ad4cf0561f2e441248c52243457adef3a9bac"
+                "reference": "8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/recycler/zipball/e34ad4cf0561f2e441248c52243457adef3a9bac",
-                "reference": "e34ad4cf0561f2e441248c52243457adef3a9bac",
+                "url": "https://api.github.com/repos/TYPO3-CMS/recycler/zipball/8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb",
+                "reference": "8bcbf0b9e0ff540d66e3a3bc6849c1072f116ebb",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9304,7 +9006,7 @@
                     "extension-key": "recycler"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9324,43 +9026,37 @@
                 }
             ],
             "description": "TYPO3 CMS Recycler - Restore deleted records or remove them from the database permanently.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-rte-ckeditor",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/rte_ckeditor.git",
-                "reference": "1e649567cec0c67a3acef5fc2a680f861c6ed146"
+                "reference": "63c0c4b9904c06030ed352e7ea6203aa04175925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/1e649567cec0c67a3acef5fc2a680f861c6ed146",
-                "reference": "1e649567cec0c67a3acef5fc2a680f861c6ed146",
+                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/63c0c4b9904c06030ed352e7ea6203aa04175925",
+                "reference": "63c0c4b9904c06030ed352e7ea6203aa04175925",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
+            },
+            "suggest": {
+                "typo3/cms-setup": "*"
             },
             "type": "typo3-cms-framework",
             "extra": {
@@ -9371,7 +9067,7 @@
                     "extension-key": "rte_ckeditor"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9391,42 +9087,33 @@
                 }
             ],
             "description": "TYPO3 CMS RTE CKEditor - Integration of CKEditor as a Rich Text Editor for the TYPO3 backend.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-seo",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/seo.git",
-                "reference": "ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc"
+                "reference": "3523bd5070ec00708edb05ae6060bcb32a7cd886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc",
-                "reference": "ed5e9f465e1379adfcff0abedbfe1d68b96f6bdc",
+                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/3523bd5070ec00708edb05ae6060bcb32a7cd886",
+                "reference": "3523bd5070ec00708edb05ae6060bcb32a7cd886",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4",
-                "typo3/cms-extbase": "14.3.4",
-                "typo3/cms-frontend": "14.3.4"
+                "typo3/cms-core": "13.4.32",
+                "typo3/cms-extbase": "13.4.32",
+                "typo3/cms-frontend": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9443,7 +9130,7 @@
                     "extension-key": "seo"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9463,40 +9150,89 @@
                 }
             ],
             "description": "TYPO3 CMS SEO - SEO features including specific fields for SEO purposes, rendering of HTML meta tags and sitemaps.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/c/typo3/cms-seo/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org/c/typo3/cms-seo/main/en-us",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
-            "name": "typo3/cms-sys-note",
-            "version": "v14.3.4",
+            "name": "typo3/cms-setup",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
-                "url": "https://github.com/TYPO3-CMS/sys_note.git",
-                "reference": "14543f7367fb92adbacc96a889ff602fe559a979"
+                "url": "https://github.com/TYPO3-CMS/setup.git",
+                "reference": "efc0c8cb65da16912e069ad4e4766330537a37fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/14543f7367fb92adbacc96a889ff602fe559a979",
-                "reference": "14543f7367fb92adbacc96a889ff602fe559a979",
+                "url": "https://api.github.com/repos/TYPO3-CMS/setup/zipball/efc0c8cb65da16912e069ad4e4766330537a37fe",
+                "reference": "efc0c8cb65da16912e069ad4e4766330537a37fe",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
+            },
+            "conflict": {
+                "typo3/cms": "*"
+            },
+            "type": "typo3-cms-framework",
+            "extra": {
+                "typo3/cms": {
+                    "Package": {
+                        "partOfFactoryDefault": true
+                    },
+                    "extension-key": "setup"
+                },
+                "branch-alias": {
+                    "dev-main": "13.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\CMS\\Setup\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "TYPO3 Core Team",
+                    "email": "typo3cms@typo3.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "TYPO3 CMS Setup - Allows users to edit a limited set of options for their user profile, including preferred language, their name and email address.",
+            "homepage": "https://typo3.org",
+            "support": {
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
+            },
+            "time": "2026-06-16T08:43:58+00:00"
+        },
+        {
+            "name": "typo3/cms-sys-note",
+            "version": "v13.4.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3-CMS/sys_note.git",
+                "reference": "808b58843e29023afdb12078af41d9d9eea1aa2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/808b58843e29023afdb12078af41d9d9eea1aa2d",
+                "reference": "808b58843e29023afdb12078af41d9d9eea1aa2d",
+                "shasum": ""
+            },
+            "require": {
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9513,7 +9249,7 @@
                     "extension-key": "sys_note"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9533,40 +9269,31 @@
                 }
             ],
             "description": "TYPO3 CMS System Notes - Records with messages which can be placed on any page and contain instructions or other information related to a page or section.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-tstemplate",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/tstemplate.git",
-                "reference": "caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4"
+                "reference": "dba0d4e57bd5cf1dce5b530565a2a4a2ff250971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4",
-                "reference": "caa2a8e1a373a8ae5b8cba0ea8e8944bffce83f4",
+                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/dba0d4e57bd5cf1dce5b530565a2a4a2ff250971",
+                "reference": "dba0d4e57bd5cf1dce5b530565a2a4a2ff250971",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9580,7 +9307,7 @@
                     "extension-key": "tstemplate"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9600,40 +9327,31 @@
                 }
             ],
             "description": "TYPO3 CMS TypoScript - TYPO3 backend module for the management of TypoScript records for the CMS frontend.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-viewpage",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/viewpage.git",
-                "reference": "519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee"
+                "reference": "4f5fe9641fe698acf07ee54dfb1b67a3ec80514f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee",
-                "reference": "519ebbb6b6da69b13bd2a7a3651c0ae1e8ece3ee",
+                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/4f5fe9641fe698acf07ee54dfb1b67a3ec80514f",
+                "reference": "4f5fe9641fe698acf07ee54dfb1b67a3ec80514f",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "14.3.4"
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9647,7 +9365,7 @@
                     "extension-key": "viewpage"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9667,41 +9385,32 @@
                 }
             ],
             "description": "TYPO3 CMS Viewpage - Use the (Web>View) backend module to view a frontend page inside the TYPO3 backend.",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
-                "docs": "https://docs.typo3.org/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/cms-webhooks",
-            "version": "v14.3.4",
+            "version": "v13.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/webhooks.git",
-                "reference": "e72dac3ec0378c4f5094987ffdc08ba07f68cb41"
+                "reference": "3e60c977f912822178dcc8fa4f97809947924868"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/webhooks/zipball/e72dac3ec0378c4f5094987ffdc08ba07f68cb41",
-                "reference": "e72dac3ec0378c4f5094987ffdc08ba07f68cb41",
+                "url": "https://api.github.com/repos/TYPO3-CMS/webhooks/zipball/3e60c977f912822178dcc8fa4f97809947924868",
+                "reference": "3e60c977f912822178dcc8fa4f97809947924868",
                 "shasum": ""
             },
             "require": {
-                "symfony/uid": "^7.4.8",
-                "typo3/cms-core": "14.3.4"
+                "symfony/uid": "^7.4",
+                "typo3/cms-core": "13.4.32"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -9715,7 +9424,7 @@
                     "extension-key": "webhooks"
                 },
                 "branch-alias": {
-                    "dev-main": "14.3.x-dev"
+                    "dev-main": "13.4.x-dev"
                 }
             },
             "autoload": {
@@ -9735,23 +9444,14 @@
                 }
             ],
             "description": "TYPO3 CMS Webhooks - Handle outgoing Webhooks for TYPO3",
-            "homepage": "https://typo3.community/",
+            "homepage": "https://typo3.org",
             "support": {
-                "chat": "https://typo3.community/meet/slack/",
+                "chat": "https://typo3.org/help",
                 "docs": "https://docs.typo3.org/c/typo3/cms-webhooks/main/en-us/",
-                "forum": "https://talk.typo3.org/",
-                "issues": "https://forge.typo3.org/issues/",
-                "rss": "https://news.typo3.com/rss/",
-                "security": "https://typo3.org/security/",
-                "source": "https://github.com/TYPO3/typo3/"
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
             },
-            "funding": [
-                {
-                    "url": "https://typo3.org/membership",
-                    "type": "membership"
-                }
-            ],
-            "time": "2026-06-16T08:52:34+00:00"
+            "time": "2026-06-16T08:43:58+00:00"
         },
         {
             "name": "typo3/testing-framework",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14ea5c6c3ab3daa766532f809644fe5f",
+    "content-hash": "7412877413f733cfa4e347f94cbcdb7a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5051,6 +5051,151 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/class-map-generator",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2.1 || ^3.1",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpunit/phpunit": "^8",
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T09:17:07+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
+        },
+        {
             "name": "cuyz/valinor",
             "version": "2.4.0",
             "source": {
@@ -6265,6 +6410,68 @@
                 }
             ],
             "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpcov",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcov.git",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.8",
+                "phpunit/php-file-iterator": "^5.1",
+                "phpunit/phpunit": "^11.5.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/version": "^5.0.2"
+            },
+            "bin": [
+                "phpcov"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "CLI frontend for php-code-coverage",
+            "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpcov/issues",
+                "source": "https://github.com/sebastianbergmann/phpcov/tree/10.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T09:43:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -9245,6 +9452,84 @@
                 "source": "https://github.com/typo3/typo3"
             },
             "time": "2026-06-16T08:43:58+00:00"
+        },
+        {
+            "name": "typo3/testing-framework",
+            "version": "9.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3/testing-framework.git",
+                "reference": "bc918e46acc8d10c3e883b90f39b7fcdc339ab65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3/testing-framework/zipball/bc918e46acc8d10c3e883b90f39b7fcdc339ab65",
+                "reference": "bc918e46acc8d10c3e883b90f39b7fcdc339ab65",
+                "shasum": ""
+            },
+            "require": {
+                "composer/class-map-generator": "^1.3.4",
+                "guzzlehttp/psr7": "^2.5.0",
+                "php": "^8.2",
+                "phpunit/phpunit": "^11.2.5 || ^12.1.2 || ^13.0.2",
+                "psr/container": "^2.0",
+                "typo3/cms-backend": "13.*.*@dev || 14.*.*@dev",
+                "typo3/cms-core": "13.*.*@dev || 14.*.*@dev",
+                "typo3/cms-extbase": "13.*.*@dev || 14.*.*@dev",
+                "typo3/cms-fluid": "13.*.*@dev || 14.*.*@dev",
+                "typo3/cms-frontend": "13.*.*@dev || 14.*.*@dev"
+            },
+            "replace": {
+                "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "phpstan/phpstan": "^2.1.42",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "typo3/cms-workspaces": "13.*.*@dev || 14.*.*@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\JsonResponse\\": "Resources/Core/Functional/Extensions/json_response/Classes/",
+                    "TYPO3\\PrivateContainer\\": "Resources/Core/Functional/Extensions/private_container/Classes/",
+                    "TYPO3\\TestingFramework\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "TYPO3 CMS Core Team",
+                    "homepage": "https://forge.typo3.org/projects/typo3cms-core",
+                    "role": "Developer"
+                },
+                {
+                    "name": "The TYPO3 Community",
+                    "homepage": "https://typo3.org/community/",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "The TYPO3 testing framework provides base classes for unit, functional and acceptance testing.",
+            "homepage": "https://typo3.org/",
+            "keywords": [
+                "testing",
+                "tests",
+                "typo3"
+            ],
+            "support": {
+                "general": "https://typo3.org/support/",
+                "issues": "https://github.com/TYPO3/testing-framework/issues",
+                "source": "https://github.com/TYPO3/testing-framework/tree/9.5.0"
+            },
+            "time": "2026-03-25T21:37:25+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpunit.functional.xml
+++ b/phpunit.functional.xml
@@ -4,28 +4,23 @@
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnSkippedTests="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
          colors="true"
 >
     <php>
         <env name="COLUMNS" value="300" />
+        <env name="typo3DatabaseDriver" value="pdo_sqlite" />
     </php>
     <testsuites>
-        <testsuite name="Tests">
-            <directory>Tests/Unit</directory>
+        <testsuite name="Functional">
+            <directory>Tests/Functional</directory>
         </testsuite>
     </testsuites>
     <coverage>
         <report>
-            <php outputFile=".Build/coverage/cov/unit.cov"/>
-            <clover outputFile=".Build/coverage/clover.xml"/>
-            <html outputDirectory=".Build/coverage/html"/>
-            <text outputFile="php://stdout" showOnlySummary="true"/>
+            <php outputFile=".Build/coverage/cov/functional.cov"/>
         </report>
     </coverage>
-    <logging>
-        <junit outputFile=".Build/coverage/junit.xml"/>
-    </logging>
     <source>
         <include>
             <directory>Classes</directory>


### PR DESCRIPTION
## Summary

- Add a TYPO3 testing-framework **functional test suite** (SQLite) alongside the existing unit suite, raising merged line coverage from **33% to 92%**
- Cover previously untested classes: repository, controller, middleware, services, event listeners, compatibility utilities, and abstract bases
- Fix a latent bug in `ContentElementRepository::getTranslatedRecord()` uncovered while testing translations
- Wire a `phpcov`-based merged-coverage pipeline via composer scripts

## Changes

### Fix
- `Classes/Repository/ContentElementRepository.php` — resolve the translation-parent column from TCA `transOrigPointerField` instead of hardcoding `l10n_parent`; previously any lookup against `tt_content` (real column `l18n_parent`) would fail

### Test infrastructure
- `composer.json` / `composer.lock` — add `typo3/testing-framework` and `phpunit/phpcov` (dev); add `test`, `test:unit`, `test:functional`, `test:coverage` (+ `:clean`/`:merge`) scripts
- `phpunit.xml` / `phpunit.functional.xml` — emit per-suite `.cov` files for phpcov merging; functional suite runs on `pdo_sqlite` (no DB service needed)

### Tests
- `Tests/Functional/` — new functional tests for `ContentElementRepository` (CSV fixtures), `AjaxController`, `ToolRendererMiddleware`, plus a smoke test
- `Tests/Unit/` — new unit tests for `SettingsService`, `ResourceRendererService`, `BackendSettingsService`, `FlashMessageService`, `IconService`, `ContentElementFilter`, `AdditionalDataHandler`, the compatibility utilities, event listeners, and abstract menu bases; deepened `ContentElementMenuGenerator` (24%→84%) and `PageMenuGenerator` (13%→97%) tests

## Test plan

- `composer test` — 273 unit + 38 functional tests green (PHP 8.2)
- `composer test:coverage` — merged line coverage 92.68% (1266/1366)
- PHPStan level 8 and PHP CS Fixer clean