### PR TITLE
docs: add code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Latest Stable Version](https://typo3-badges.dev/badge/xima_typo3_frontend_edit/version/shields.svg)](https://extensions.typo3.org/extension/xima_typo3_frontend_edit)
 [![Supported TYPO3 versions](https://typo3-badges.dev/badge/xima_typo3_frontend_edit/typo3/shields.svg)](https://extensions.typo3.org/extension/xima_typo3_frontend_edit)
 [![Supported PHP Versions](https://img.shields.io/packagist/dependency-v/xima/xima-typo3-frontend-edit/php?logo=php)](https://packagist.org/packages/xima/xima-typo3-frontend-edit)
+[![Coverage](https://img.shields.io/coverallsCoverage/github/xima-media/xima-typo3-frontend-edit?logo=coveralls)](https://coveralls.io/github/xima-media/xima-typo3-frontend-edit)
 [![CGL](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-frontend-edit/cgl.yml?label=cgl&logo=github)](https://github.com/xima-media/xima-typo3-frontend-edit/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-frontend-edit/tests.yml?label=tests&logo=github)](https://github.com/xima-media/xima-typo3-frontend-edit/actions/workflows/tests.yml)
 [![License](https://poser.pugx.org/xima/xima-typo3-frontend-edit/license)](LICENSE.md)


### PR DESCRIPTION
## Summary

- Add a Coveralls code-coverage badge to the README, next to the existing PHP/TYPO3/CGL/Tests badges

## Changes

- `README.md` — add `[![Coverage]](https://coveralls.io/github/xima-media/xima-typo3-frontend-edit)` badge

## Note

The badge renders coverage reported to Coveralls. It will populate once a coverage report is uploaded from CI (same setup as other xima-media extensions, e.g. xima-typo3-content-planner).