### PR TITLE
feat: omit redundant end-of-column add button when insert buttons are enabled

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementMenuGenerator;
 
@@ -40,6 +41,7 @@ readonly class AjaxController
         private ContentElementMenuGenerator $contentElementMenuGenerator,
         private BackendUserService $backendUserService,
         private EmptyColumnService $emptyColumnService,
+        private SettingsService $settingsService,
     ) {}
 
     /**
@@ -124,7 +126,13 @@ readonly class AjaxController
 
         $dropdown = $this->contentElementMenuGenerator->getDropdown($pid, $returnUrl, $languageUid, $request, $data);
 
-        $columnTargets = $this->emptyColumnService->getColumnTargets($pid, $languageUid, $returnUrl, $data);
+        $columnTargets = $this->emptyColumnService->getColumnTargets(
+            $pid,
+            $languageUid,
+            $returnUrl,
+            $data,
+            $this->settingsService->isShowInsertButtons($request),
+        );
 
         return new JsonResponse(mb_convert_encoding([
             'contentElements' => $dropdown,

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -42,19 +42,30 @@ final readonly class EmptyColumnService
     }
 
     /**
-     * @param int          $pid         Page UID
-     * @param int          $languageUid sys_language_uid
-     * @param string       $returnUrl   Frontend URL to return to after editing
-     * @param array<mixed> $requestData Raw request data from the AJAX call
+     * @param int          $pid               Page UID
+     * @param int          $languageUid       sys_language_uid
+     * @param string       $returnUrl         Frontend URL to return to after editing
+     * @param array<mixed> $requestData       Raw request data from the AJAX call
+     * @param bool         $showInsertButtons Whether per-element "insert after" buttons are enabled;
+     *                                         if so, the end-of-column button on filled columns is redundant
      *
      * @return list<array{colPos: int, isEmpty: bool, newContentUrl: string, name?: string, containerUid?: int}>
      */
-    public function getColumnTargets(int $pid, int $languageUid, string $returnUrl, array $requestData = []): array
+    public function getColumnTargets(int $pid, int $languageUid, string $returnUrl, array $requestData = [], bool $showInsertButtons = false): array
     {
-        return [
+        $targets = [
             ...$this->findPageColumnTargets($pid, $languageUid, $returnUrl),
             ...$this->findContainerColumnTargets($pid, $languageUid, $returnUrl, $this->extractContainerMarkers($requestData)),
         ];
+
+        // Filled columns already expose an "insert after" button on their last element,
+        // so the standalone end-of-column button would only duplicate it. Empty columns
+        // have no elements and therefore keep their button.
+        if ($showInsertButtons) {
+            $targets = array_values(array_filter($targets, static fn (array $target): bool => $target['isEmpty']));
+        }
+
+        return $targets;
     }
 
     /**

--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -47,7 +47,7 @@ final readonly class EmptyColumnService
      * @param string       $returnUrl         Frontend URL to return to after editing
      * @param array<mixed> $requestData       Raw request data from the AJAX call
      * @param bool         $showInsertButtons Whether per-element "insert after" buttons are enabled;
-     *                                         if so, the end-of-column button on filled columns is redundant
+     *                                        if so, the end-of-column button on filled columns is redundant
      *
      * @return list<array{colPos: int, isEmpty: bool, newContentUrl: string, name?: string, containerUid?: int}>
      */

--- a/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
+++ b/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
@@ -103,6 +103,41 @@ final class EmptyColumnServiceTest extends TestCase
     }
 
     #[Test]
+    public function getColumnTargetsOmitsFilledColumnsWhenInsertButtonsEnabled(): void
+    {
+        $this->mockQueryBuilderWithCount(3);
+
+        $service = new EmptyColumnService(
+            $this->connectionPool,
+            $this->urlBuilderService,
+            $this->languageServiceFactory,
+        );
+
+        $result = $service->getColumnTargets(1, 0, '/return', [], true);
+
+        // Filled columns are redundant with the per-element "insert after" buttons
+        self::assertEmpty($result);
+    }
+
+    #[Test]
+    public function getColumnTargetsKeepsEmptyColumnsWhenInsertButtonsEnabled(): void
+    {
+        $this->mockQueryBuilderWithCount(0);
+
+        $service = new EmptyColumnService(
+            $this->connectionPool,
+            $this->urlBuilderService,
+            $this->languageServiceFactory,
+        );
+
+        $result = $service->getColumnTargets(1, 0, '/return', [], true);
+
+        // Empty columns have no elements, so they still need their own button
+        self::assertNotEmpty($result);
+        self::assertTrue($result[0]['isEmpty']);
+    }
+
+    #[Test]
     public function getColumnTargetsIgnoresContainerMarkersWithoutContainerField(): void
     {
         $this->mockQueryBuilderWithCount(1);


### PR DESCRIPTION
## Summary

- Filled columns no longer render the standalone end-of-column "+" button when per-element insert buttons are enabled — it duplicated the last element's "insert after" button, which targets the same position.
- Empty columns keep their button in all cases, since they have no elements (and therefore no per-element insert buttons).
- When `frontendEdit.showInsertButtons` is disabled, behavior is unchanged: the end-of-column button remains the only way to append.

The filtering happens server-side, so redundant column targets are never sent to the frontend — no JavaScript changes required.

## Changes

- `Classes/Service/Content/EmptyColumnService.php` — `getColumnTargets()` gains a `$showInsertButtons` parameter; filled column targets are filtered out when it is `true`.
- `Classes/Controller/AjaxController.php` — injects `SettingsService` and passes the resolved `isShowInsertButtons()` value into `getColumnTargets()`.
- `Tests/Unit/Service/Content/EmptyColumnServiceTest.php` — adds coverage for omitting filled columns and keeping empty columns when insert buttons are enabled.