### PR TITLE
refactor: shorten content element dropdown labels

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -9,7 +9,7 @@
 			</trans-unit>
 			<trans-unit id="edit_content_element">
 				<source />
-				<target>Inhaltselement bearbeiten</target>
+				<target>Element bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="edit_plugin">
 				<source />
@@ -37,7 +37,7 @@
 			</trans-unit>
 			<trans-unit id="new_content_after">
 				<source />
-				<target>Neues Inhaltselement danach</target>
+				<target>Neues Element (danach)</target>
 			</trans-unit>
 			<trans-unit id="div_info">
 				<source />

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -7,7 +7,7 @@
 				<source>Edit menu</source>
 			</trans-unit>
 			<trans-unit id="edit_content_element">
-				<source>Edit content element</source>
+				<source>Edit element</source>
 			</trans-unit>
 			<trans-unit id="edit_plugin">
 				<source>Edit plugin</source>
@@ -28,7 +28,7 @@
 				<source>Move</source>
 			</trans-unit>
 			<trans-unit id="new_content_after">
-				<source>New content after</source>
+				<source>New element (after)</source>
 			</trans-unit>
 			<trans-unit id="div_info">
 				<source>Info</source>


### PR DESCRIPTION
## Summary

- Shorten the "Edit content element" dropdown label to "Edit element"
- Shorten the "New content after" dropdown label to "New element (after)"
- Update matching German translations

## Changes

- `Resources/Private/Language/locallang.xlf` - shortened `edit_content_element` and `new_content_after` source labels
- `Resources/Private/Language/de.locallang.xlf` - shortened matching German target labels