### PR TITLE
docs: restructure and trim README features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@
 
 </div>
 
-This TYPO3 extension adds lightweight editing tools to the frontend, allowing backend users to edit, hide, delete, and reorder content elements and pages without leaving the site.
+This TYPO3 extension adds lightweight editing tools to the frontend, allowing backend users to edit, hide, delete, and reorder content elements and pages without leaving the site. It works out of the box with TYPO3's default `fluid_styled_content` templates; custom templates need to expose a content element ID (c-id) — see [How it works](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/HowItWorks/Index.html) for details.
 
 ![Frontend Edit](./Documentation/Images/screenshot.jpg)
-
-> [!IMPORTANT]
-> **Delineation and classification**: This is **not** a further development of the "original" extension [frontend_editing](https://extensions.typo3.org/extension/frontend_editing). It is similar in some ways to the realisation of the [feedit](https://extensions.typo3.org/extension/feedit) extension. This extension is an independent implementation with a different approach. See the [Delineation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Delineation/Index.html) page in the documentation for a detailed comparison with related extensions like [visual_editor](https://github.com/FriendsOfTYPO3/visual_editor) and [content_preview](https://github.com/T3-UX/content_preview).
-
-The extension injects a small JavaScript into the frontend that generates action links to the TYPO3 backend, bridging the gap between frontend preview and backend editing.
 
 > [!NOTE]
 > **Why?** TYPO3 editors often need to switch between the frontend and the backend to find and edit the right content element. This extension eliminates that context switch by providing editing actions directly where the content is displayed — making the editorial workflow faster and more intuitive.
@@ -29,31 +24,28 @@ The extension injects a small JavaScript into the frontend that generates action
 ## ✨ Features
 
 - **Content Element Editing**
-  - **[Edit Menu](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html)** - Quick access to edit, hide, delete, and move content elements
-  - **[Delete Confirmation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html#delete-confirmation)** - Confirmation dialog before deleting records *(new in v2.3)*
-  - **[Inline Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)** *(experimental)* - Edit content directly in the frontend
-  - **New Content Wizard** - Create new content elements via TYPO3's native New Content Element Wizard, hosted in the slide-in iframe modal on both v13 and v14 (requires `frontendEdit.enableContextualEditing`)
+  - [Edit Dropdown Menu](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html) - Quick access to edit, hide, delete, and move content elements, with confirmation before deleting records
+  - [Contextual Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html) - Edit content directly in the frontend (experimental)
+  - New Content Elements - Create new content elements via TYPO3's native New Content Element Wizard, hosted in the slide-in iframe modal on both v13 and v14 (requires `frontendEdit.enableContextualEditing`)
 - **Page Toolbar**
-  - **[Toolbar](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/Toolbar.html)** - Page-level actions and toggle for frontend editing
-  - **Dark/Light Mode** - Automatic or manual color scheme selection
-  - **Configurable Position** - 12 toolbar positions available
-- **Configuration**
-  - **[Site Settings](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/SiteSettings.html)** - Per-site configuration via YAML
-  - **[UserTSconfig](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/UserTSconfig.html)** - Disable frontend editing per user or user group
-- **Developer**
-  - **[PSR-14 Events](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/Events.html)** - Customize menus with custom actions
-  - **ViewHelpers** - [Data attributes](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/DataAttributes.html) for related records, [column target buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html) for new content (empty columns and end-of-column) *(new in v2.3)*
+  - [Toolbar](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/Toolbar.html) - Page-level actions and toggle for frontend editing
+- **Configuration & Customization**
+  - [Site Settings](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/SiteSettings.html) - Per-site configuration via YAML
+  - [UserTSconfig](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/UserTSconfig.html) - Disable frontend editing per user or user group
+  - [PSR-14 Events](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/Events.html) - Customize menus with custom actions
+  - ViewHelpers - [Data attributes](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/DataAttributes.html) for related records, [column target buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html) for new content (empty columns and end-of-column)
 
-### Inline Editing *(experimental)*
+### [Inline Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)
 
 > [!NOTE]
-> New in **v2.2+** — thanks to [Violetta Digital Craft](https://www.violetta.ch/) for supporting this feature.
+> New in **v2.2+** — thanks to [Violetta Digital Craft](https://www.violetta.ch/) for supporting this feature. This feature is still experimental and may change in future releases.
 
 Edit content elements directly in the frontend without navigating to the backend. Enable via Site Settings: `frontendEdit.enableContextualEditing: true`
 
 ![Inline Editing](./Documentation/Images/inline-edit-screencast.gif)
 
-[Documentation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html)
+> [!IMPORTANT]
+> **Delineation and classification**: This is **not** a further development of the "original" extension [frontend_editing](https://extensions.typo3.org/extension/frontend_editing). It is similar in some ways to the realisation of the [feedit](https://extensions.typo3.org/extension/feedit) extension. This extension is an independent implementation with a different approach. See the [Delineation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Delineation/Index.html) page in the documentation for a detailed comparison with related extensions like [visual_editor](https://github.com/FriendsOfTYPO3/visual_editor) and [content_preview](https://github.com/T3-UX/content_preview).
 
 ## 🔥 Installation
 
@@ -89,9 +81,6 @@ Download the zip file from [TYPO3 extension repository (TER)](https://extensions
 
 Please have a look at the
 [official extension documentation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Index.html).
-
-
-![Frontend Edit Screencast](./Documentation/Images/intro.gif)
 
 > [!NOTE]
 > Facing trouble or issues? You may find help in the following sections:


### PR DESCRIPTION
## Summary

- Reorganize the Features section for a clearer, more focused overview of the extension's capabilities
- Add an out-of-the-box compatibility note (fluid_styled_content vs. custom templates) with a link to the "How it works" documentation
- Move the delineation/classification notice to the end of the Features section
- Trim redundant text and images (duplicate JS-injection description, standalone Documentation link, screencast image already shown elsewhere)
- Simplify sub-bullet formatting (drop bold, merge related items) and remove stale "(new in v2.3)" markers

## Changes

- `README.md` - Restructured and trimmed the Features section and surrounding intro/documentation content