### PR TITLE
perf: reorder middleware gates and inject before last body tag

### DIFF
--- a/Classes/Middleware/ToolRendererMiddleware.php
+++ b/Classes/Middleware/ToolRendererMiddleware.php
@@ -24,6 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{FlashMessageService, ResourceRendererService};
 
 use function is_array;
+use function strlen;
 
 /**
  * ToolRendererMiddleware.
@@ -49,10 +50,8 @@ class ToolRendererMiddleware implements MiddlewareInterface
     {
         $response = $handler->handle($request);
 
-        if (!$this->settingsService->isEnabled($request)) {
-            return $response;
-        }
-
+        // Cheapest gate first: bail out immediately for anonymous frontend traffic
+        // before resolving any site settings.
         $backendUser = $GLOBALS['BE_USER'] ?? null;
         if (
             !$backendUser instanceof BackendUserAuthentication
@@ -66,6 +65,11 @@ class ToolRendererMiddleware implements MiddlewareInterface
             return $response;
         }
 
+        // Resolving the site settings is the most expensive check, so it runs last.
+        if (!$this->settingsService->isEnabled($request)) {
+            return $response;
+        }
+
         // Collect flash messages from backend session before rendering (if enabled).
         //
         // The iframe modal editor appends ?tx_ximatypo3frontendedit_iframe=1 to the
@@ -76,14 +80,22 @@ class ToolRendererMiddleware implements MiddlewareInterface
             ? $this->flashMessageService->collectFromSession()
             : [];
 
-        $body = $response->getBody();
-        $body->rewind();
-        $contents = $response->getBody()->getContents();
-        $content = str_ireplace(
-            '</body>',
-            $this->resourceRendererService->render(request: $request, flashMessages: $flashMessages).'</body>',
-            $contents,
-        );
+        $responseBody = $response->getBody();
+        $responseBody->rewind();
+        $contents = $responseBody->getContents();
+
+        // Inject the asset bundle right before the last closing body tag. Using the
+        // last occurrence (instead of str_ireplace, which rewrites every match and
+        // scans the whole document case-insensitively) keeps a stray "</body>" in
+        // page content from receiving a second, misplaced injection.
+        $position = strripos($contents, '</body>');
+        if (false === $position) {
+            return $response;
+        }
+
+        $injection = $this->resourceRendererService->render(request: $request, flashMessages: $flashMessages);
+        $content = substr_replace($contents, $injection.'</body>', $position, strlen('</body>'));
+
         $body = new Stream('php://temp', 'rw');
         $body->write($content);
 

--- a/Tests/Functional/Middleware/ToolRendererMiddlewareTest.php
+++ b/Tests/Functional/Middleware/ToolRendererMiddlewareTest.php
@@ -109,6 +109,43 @@ final class ToolRendererMiddlewareTest extends FunctionalTestCase
         self::assertStringEndsWith('</body></html>', $body);
     }
 
+    #[Test]
+    public function processInjectsOnlyBeforeLastBodyClosingTag(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $html = '<html><body><code>&lt;/body&gt;</code><pre></body></pre><h1>Page</h1></body></html>';
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: true),
+            $this->createHandler($html),
+        );
+
+        $body = $this->readBody($response);
+
+        // Earlier "</body>" occurrences inside page content must stay untouched;
+        // only the final closing tag receives the injection.
+        self::assertStringContainsString('<code>&lt;/body&gt;</code>', $body);
+        self::assertStringContainsString('<pre></body></pre>', $body);
+        self::assertNotSame($html, $body);
+        self::assertStringEndsWith('</body></html>', $body);
+    }
+
+    #[Test]
+    public function processReturnsUnchangedResponseWhenNoBodyClosingTag(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $html = '<html><h1>Page without closing body</h1></html>';
+
+        $response = $this->subject->process(
+            $this->createRequest(enabled: true),
+            $this->createHandler($html),
+        );
+
+        self::assertSame($html, $this->readBody($response));
+    }
+
     private function createRequest(bool $enabled): ServerRequestInterface
     {
         $site = new Site('test', 1, [
@@ -126,12 +163,14 @@ final class ToolRendererMiddlewareTest extends FunctionalTestCase
             ->withAttribute('site', $site);
     }
 
-    private function createHandler(): RequestHandlerInterface
+    private function createHandler(?string $html = null): RequestHandlerInterface
     {
-        return new class implements RequestHandlerInterface {
+        return new class($html ?? ToolRendererMiddlewareTest::HTML) implements RequestHandlerInterface {
+            public function __construct(private readonly string $html) {}
+
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
-                return new HtmlResponse(ToolRendererMiddlewareTest::HTML);
+                return new HtmlResponse($this->html);
             }
         };
     }


### PR DESCRIPTION
## Summary

- Reorder the frontend middleware gates so the cheap backend-user check runs before the more expensive site-settings resolution — anonymous frontend requests now bail out without resolving any settings.
- Replace the full-document \`str_ireplace('</body>', …)\` with a single last-occurrence \`substr_replace\`, avoiding the case-folding scan/copy of the whole HTML body and preventing a stray \`</body>\` in page content from receiving a second, misplaced injection.
- Return the response unchanged when no closing body tag exists.

## Changes

- \`Classes/Middleware/ToolRendererMiddleware.php\` — gate reordering and last-occurrence injection.
- \`Tests/Functional/Middleware/ToolRendererMiddlewareTest.php\` — regression tests for last-occurrence injection and the no-\`</body>\` case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance for some anonymous frontend requests by skipping expensive checks earlier.
  * Made HTML injection more reliable by adding content only before the final closing `</body>` tag.
  * Left pages unchanged when no valid closing `</body>` tag is present.

* **Tests**
  * Expanded coverage for pages with multiple `</body>`-like sequences.
  * Added verification for cases where no closing `</body>` tag exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->