### PR TITLE
fix: guard toggle endpoint against cross-site request forgery

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -25,6 +25,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementMenuGenerator;
 
+use function in_array;
 use function is_array;
 use function is_scalar;
 
@@ -49,8 +50,12 @@ readonly class AjaxController
      *
      * Uses the backend user's uc (user configuration) to persist the state.
      */
-    public function toggleAction(): JsonResponse
+    public function toggleAction(ServerRequestInterface $request): JsonResponse
     {
+        if (!$this->isSameOriginWriteRequest($request)) {
+            return new JsonResponse(['success' => false, 'error' => 'Invalid request'], 403);
+        }
+
         if (!$this->backendUserService->isFrontendEditAllowed()) {
             return new JsonResponse(['success' => false, 'error' => 'Frontend edit is not allowed'], 403);
         }
@@ -143,6 +148,24 @@ readonly class AjaxController
     protected function getBackendUser(): ?BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'] ?? null;
+    }
+
+    /**
+     * Guard state-changing requests against cross-site request forgery.
+     *
+     * Requires POST and, when the browser provides Fetch Metadata, a same-origin
+     * context. Browsers that omit Sec-Fetch-Site (legacy) fall back to POST-only.
+     */
+    private function isSameOriginWriteRequest(ServerRequestInterface $request): bool
+    {
+        if ('POST' !== $request->getMethod()) {
+            return false;
+        }
+
+        $fetchSite = $request->getHeaderLine('Sec-Fetch-Site');
+
+        return '' === $fetchSite
+            || in_array($fetchSite, ['same-origin', 'same-site', 'none'], true);
     }
 
     private function validateContentType(ServerRequestInterface $request): void

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -56,7 +56,30 @@ final class AjaxControllerTest extends FunctionalTestCase
     {
         unset($GLOBALS['BE_USER']);
 
-        $response = $this->subject->toggleAction();
+        $response = $this->subject->toggleAction($this->createToggleRequest());
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->decode($response)['success']);
+    }
+
+    #[Test]
+    public function toggleActionRejectsNonPostRequest(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->toggleAction($this->createToggleRequest(method: 'GET'));
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->decode($response)['success']);
+    }
+
+    #[Test]
+    public function toggleActionRejectsCrossSiteRequest(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $request = $this->createToggleRequest()->withHeader('Sec-Fetch-Site', 'cross-site');
+        $response = $this->subject->toggleAction($request);
 
         self::assertSame(403, $response->getStatusCode());
         self::assertFalse($this->decode($response)['success']);
@@ -67,7 +90,7 @@ final class AjaxControllerTest extends FunctionalTestCase
     {
         $this->setUpBackendUser(1);
 
-        $response = $this->subject->toggleAction();
+        $response = $this->subject->toggleAction($this->createToggleRequest());
 
         $payload = $this->decode($response);
 
@@ -82,7 +105,7 @@ final class AjaxControllerTest extends FunctionalTestCase
         $backendUser = $this->setUpBackendUser(1);
         $backendUser->uc[Configuration::UC_KEY_DISABLED] = true;
 
-        $payload = $this->decode($this->subject->toggleAction());
+        $payload = $this->decode($this->subject->toggleAction($this->createToggleRequest()));
 
         self::assertTrue($payload['success']);
         self::assertFalse($payload['disabled']);
@@ -93,7 +116,7 @@ final class AjaxControllerTest extends FunctionalTestCase
     {
         $backendUser = $this->setUpBackendUser(1);
 
-        $this->subject->toggleAction();
+        $this->subject->toggleAction($this->createToggleRequest());
 
         self::assertTrue((bool) $backendUser->uc[Configuration::UC_KEY_DISABLED]);
     }
@@ -200,6 +223,12 @@ final class AjaxControllerTest extends FunctionalTestCase
     {
         return (new ServerRequest('https://example.com/', 'GET'))
             ->withQueryParams($queryParams);
+    }
+
+    private function createToggleRequest(string $method = 'POST'): ServerRequestInterface
+    {
+        return (new ServerRequest('https://example.com/', $method))
+            ->withHeader('Sec-Fetch-Site', 'same-origin');
     }
 
     private function stream(string $content): Stream


### PR DESCRIPTION
## Summary

- Add a CSRF guard to the state-changing \`frontendEdit_toggle\` endpoint: it now requires a \`POST\` method and, when the browser sends Fetch Metadata, a same-origin context (\`Sec-Fetch-Site\`). Legacy clients without the header fall back to POST-only.
- The endpoint previously accepted any method from any origin as long as a valid backend session existed, allowing a visited page to flip an editor's frontend-edit state.
- No frontend change required — the sticky toolbar already calls the endpoint via \`POST\` with \`credentials: 'same-origin'\`.

## Changes

- \`Classes/Controller/AjaxController.php\` — \`toggleAction\` now receives the request and validates method + Fetch Metadata via \`isSameOriginWriteRequest()\`.
- \`Tests/Functional/Controller/AjaxControllerTest.php\` — pass a POST/same-origin request to existing toggle tests; add rejection tests for non-POST and cross-site requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for state-changing requests by rejecting invalid or cross-site toggle attempts with a 403 response.
  * Added safer handling for toggle actions, ensuring only approved request methods and origins are accepted.
  * Updated toggle behavior checks to continue returning the expected success and state responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->