### PR TITLE
fix: validate frontend-provided edit urls server-side

### DIFF
--- a/Classes/Service/Menu/AdditionalDataHandler.php
+++ b/Classes/Service/Menu/AdditionalDataHandler.php
@@ -24,6 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
 use Xima\XimaTypo3FrontendEdit\Utility\StringUtility;
 
 use function array_key_exists;
+use function in_array;
 use function is_array;
 
 /**
@@ -88,14 +89,50 @@ final readonly class AdditionalDataHandler
      */
     private function isValidDataEntry(array $dataEntry): bool
     {
-        if (null === $dataEntry['label'] || '' === $dataEntry['label']) {
+        $label = $dataEntry['label'] ?? null;
+        if (null === $label || '' === $label) {
             return false;
         }
 
-        $hasTableAndUid = (null !== $dataEntry['table'] && null !== $dataEntry['uid']);
-        $hasUrl = (null !== $dataEntry['url']);
+        $url = $dataEntry['url'] ?? null;
+        if (null !== $url && !$this->isSafeUrl((string) $url)) {
+            return false;
+        }
+
+        $hasTableAndUid = (null !== ($dataEntry['table'] ?? null) && null !== ($dataEntry['uid'] ?? null));
+        $hasUrl = (null !== $url);
 
         return $hasTableAndUid || $hasUrl;
+    }
+
+    /**
+     * Validate a client-supplied edit URL before it is rendered into a menu link.
+     *
+     * The data attributes originate from the (untrusted) frontend, so an absolute
+     * URL must use http(s); relative URLs are allowed. Script-executing schemes
+     * (javascript:, data:, vbscript:, …) and control-character obfuscation are
+     * rejected server-side rather than relying on the client denylist alone.
+     */
+    private function isSafeUrl(string $url): bool
+    {
+        $url = trim($url);
+        if ('' === $url) {
+            return false;
+        }
+
+        // Control characters may be used to obfuscate a scheme (e.g. "java\tscript:").
+        if (1 === preg_match('/[\x00-\x1F\x7F]/', $url)) {
+            return false;
+        }
+
+        // Relative URLs carry no scheme and are considered safe.
+        if (1 !== preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url)) {
+            return true;
+        }
+
+        $scheme = strtolower((string) parse_url($url, \PHP_URL_SCHEME));
+
+        return in_array($scheme, ['http', 'https'], true);
     }
 
     /**
@@ -105,7 +142,7 @@ final readonly class AdditionalDataHandler
      */
     private function resolveRecordUid(array $dataEntry, int $languageUid): ?int
     {
-        if (null === $dataEntry['table'] || null === $dataEntry['uid']) {
+        if (null === ($dataEntry['table'] ?? null) || null === ($dataEntry['uid'] ?? null)) {
             return null;
         }
 
@@ -178,7 +215,7 @@ final readonly class AdditionalDataHandler
      */
     private function buildDataUrl(array $dataEntry, int $recordUid, int $languageUid, string $returnUrlAnchor): string
     {
-        if (null !== $dataEntry['url']) {
+        if (null !== ($dataEntry['url'] ?? null)) {
             return $dataEntry['url'];
         }
 
@@ -196,7 +233,7 @@ final readonly class AdditionalDataHandler
      */
     private function resolveDataIcon(array $dataEntry, array $contentElementConfig): \TYPO3\CMS\Core\Imaging\Icon
     {
-        if (null !== $dataEntry['icon']) {
+        if (null !== ($dataEntry['icon'] ?? null)) {
             return $this->iconService->getIcon($dataEntry['icon']);
         }
 

--- a/Classes/Service/Menu/AdditionalDataHandler.php
+++ b/Classes/Service/Menu/AdditionalDataHandler.php
@@ -110,8 +110,9 @@ final readonly class AdditionalDataHandler
      *
      * The data attributes originate from the (untrusted) frontend, so an absolute
      * URL must use http(s); relative URLs are allowed. Script-executing schemes
-     * (javascript:, data:, vbscript:, …) and control-character obfuscation are
-     * rejected server-side rather than relying on the client denylist alone.
+     * (javascript:, data:, vbscript:, …), scheme-relative URLs pointing at a
+     * foreign host and control-character obfuscation are rejected server-side
+     * rather than relying on the client denylist alone.
      */
     private function isSafeUrl(string $url): bool
     {
@@ -122,6 +123,13 @@ final readonly class AdditionalDataHandler
 
         // Control characters may be used to obfuscate a scheme (e.g. "java\tscript:").
         if (1 === preg_match('/[\x00-\x1F\x7F]/', $url)) {
+            return false;
+        }
+
+        // Scheme-relative URLs ("//host") carry no scheme but still point at a
+        // foreign host. Browsers normalise backslashes to forward slashes in the
+        // authority, so "\\host" and "/\host" resolve the same way.
+        if (str_starts_with(strtr($url, '\\', '/'), '//')) {
             return false;
         }
 

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -164,6 +164,61 @@ final class AdditionalDataHandlerTest extends TestCase
     }
 
     #[Test]
+    public function handleDataRejectsUnsafeEntryUrl(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Evil', 'table' => null, 'uid' => null, 'url' => 'javascript:alert(1)', 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
+    public function handleDataAcceptsSafeAbsoluteEntryUrl(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'External', 'table' => 'pages', 'uid' => 5, 'url' => 'https://example.com/edit', 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertSame('https://example.com/edit', $button->getChildren()['data_0']->getUrl());
+    }
+
+    #[Test]
+    public function handleDataToleratesEntryWithMissingKeys(): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        // Crafted entry missing the optional url/icon keys must not raise warnings.
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertArrayHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
     public function handleDataSkipsWhenRecordNotFound(): void
     {
         $this->registerBackendUserWithAccess();

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
 use Doctrine\DBAL\Result;
-use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use Generator;
+use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -172,13 +173,47 @@ final class AdditionalDataHandlerTest extends TestCase
         $handler = $this->createHandler(new BackendUserService());
         $button = $this->createButton();
 
+        // table/uid must be set, otherwise the entry is already dropped by the
+        // record lookup and the url would never be reached.
         $entries = [
-            ['label' => 'Evil', 'table' => null, 'uid' => null, 'url' => 'javascript:alert(1)', 'icon' => null],
+            ['label' => 'Evil', 'table' => 'pages', 'uid' => 5, 'url' => 'javascript:alert(1)', 'icon' => null],
         ];
 
         $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
 
         self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
+    #[DataProvider('schemeRelativeUrlProvider')]
+    public function handleDataRejectsSchemeRelativeEntryUrl(string $url): void
+    {
+        $this->registerBackendUserWithAccess();
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $handler = $this->createHandler(new BackendUserService());
+        $button = $this->createButton();
+
+        // table/uid must be set, otherwise the entry is already dropped by the
+        // record lookup and the url would never be reached.
+        $entries = [
+            ['label' => 'Evil', 'table' => 'pages', 'uid' => 5, 'url' => $url, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 0, '#anchor');
+
+        self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    /**
+     * @return Generator<string, array{string}>
+     */
+    public static function schemeRelativeUrlProvider(): Generator
+    {
+        yield 'protocol relative' => ['//evil.example.com/edit'];
+        yield 'protocol relative with credentials' => ['//user@evil.example.com'];
+        yield 'backslashes normalised by browsers' => ['\\\\evil.example.com/edit'];
+        yield 'mixed slash and backslash' => ['/\\evil.example.com'];
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Validate the client-supplied \`url\` in the additional-data handler server-side before it is rendered into a menu link: absolute URLs must use \`http(s)\`, relative URLs are allowed, and script-executing schemes (\`javascript:\`, \`data:\`, \`vbscript:\`, …) plus control-character obfuscation are rejected. Previously the only defense was the client-side denylist in \`frontend_edit.js\`.
- Harden access to the untrusted data-entry keys (\`label\`, \`table\`, \`uid\`, \`url\`, \`icon\`) with null-coalescing so a crafted entry omitting keys no longer risks PHP warnings.

## Changes

- \`Classes/Service/Menu/AdditionalDataHandler.php\` — add \`isSafeUrl()\`, reject unsafe entry URLs, null-safe key access.
- \`Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php\` — tests for unsafe URL rejection, safe absolute URL acceptance, and entries with missing keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu link handling by validating frontend-provided URLs and rejecting unsafe values (including `javascript:` and scheme-relative forms), while allowing safe relative links and standard `http`/`https` URLs.
  * Prevented issues when optional menu entry fields (such as link URL or icon) are missing, improving reliability of menu rendering.
* **Tests**
  * Added unit coverage to confirm unsafe URLs are blocked and that valid URLs and missing optional fields behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->