### PR TITLE
perf: reduce edit-information overhead in EmptyColumnService

### DIFF
--- a/Classes/Service/Content/EmptyColumnService.php
+++ b/Classes/Service/Content/EmptyColumnService.php
@@ -74,13 +74,14 @@ final readonly class EmptyColumnService
     private function findPageColumnTargets(int $pid, int $languageUid, string $returnUrl): array
     {
         $result = [];
+        $counts = $this->countPageColumnContent($pid, $languageUid);
 
         foreach ($this->resolvePageColumns($pid) as $column) {
             $colPos = $column['colPos'];
             try {
                 $result[] = [
                     'colPos' => $colPos,
-                    'isEmpty' => $this->isPageColumnEmpty($pid, $colPos, $languageUid),
+                    'isEmpty' => 0 === ($counts[$colPos] ?? 0),
                     'name' => $column['name'],
                     'newContentUrl' => $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl),
                 ];
@@ -102,6 +103,12 @@ final readonly class EmptyColumnService
             return [];
         }
 
+        $counts = $this->countContainerColumnContent(
+            array_keys($containerMarkers),
+            array_values(array_unique(array_merge(...array_values($containerMarkers)))),
+            $languageUid,
+        );
+
         $result = [];
 
         foreach ($containerMarkers as $containerUid => $colPositions) {
@@ -112,7 +119,7 @@ final readonly class EmptyColumnService
                 try {
                     $result[] = [
                         'colPos' => $colPos,
-                        'isEmpty' => $this->isContainerColumnEmpty($containerUid, $colPos, $languageUid),
+                        'isEmpty' => 0 === ($counts[$containerUid][$colPos] ?? 0),
                         'containerUid' => $containerUid,
                         'newContentUrl' => $this->urlBuilderService->buildNewContentWizardUrl($pid, $colPos, $languageUid, $returnUrl, containerUid: $containerUid),
                     ];
@@ -180,13 +187,18 @@ final readonly class EmptyColumnService
         return $columns;
     }
 
-    private function isPageColumnEmpty(int $pid, int $colPos, int $languageUid): bool
+    /**
+     * Count visible content elements per column of a page in a single grouped
+     * query, so column emptiness can be resolved without one COUNT query per column.
+     *
+     * @return array<int, int> colPos => number of visible content elements
+     */
+    private function countPageColumnContent(int $pid, int $languageUid): array
     {
         $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
 
         $conditions = [
             $qb->expr()->eq('pid', $qb->createNamedParameter($pid, Connection::PARAM_INT)),
-            $qb->expr()->eq('colPos', $qb->createNamedParameter($colPos, Connection::PARAM_INT)),
             $qb->expr()->in('sys_language_uid', [
                 $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
                 $qb->createNamedParameter(-1, Connection::PARAM_INT),
@@ -199,19 +211,48 @@ final readonly class EmptyColumnService
             $conditions[] = $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter(0, Connection::PARAM_INT));
         }
 
-        return 0 === (int) $qb->count('uid')->from('tt_content')->where(...$conditions)->executeQuery()->fetchOne();
+        $rows = $qb
+            ->select('colPos')
+            ->addSelectLiteral($qb->expr()->count('uid', 'cnt'))
+            ->from('tt_content')
+            ->where(...$conditions)
+            ->groupBy('colPos')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['colPos']] = (int) $row['cnt'];
+        }
+
+        return $counts;
     }
 
-    private function isContainerColumnEmpty(int $containerUid, int $colPos, int $languageUid): bool
+    /**
+     * Count visible content elements per (container, column) in a single grouped
+     * query, so container column emptiness can be resolved without one COUNT query
+     * per column.
+     *
+     * @param int[] $containerUids
+     * @param int[] $colPositions
+     *
+     * @return array<int, array<int, int>> containerUid => (colPos => count)
+     */
+    private function countContainerColumnContent(array $containerUids, array $colPositions, int $languageUid): array
     {
+        if ([] === $containerUids || [] === $colPositions) {
+            return [];
+        }
+
         $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
 
-        return 0 === (int) $qb
-            ->count('uid')
+        $rows = $qb
+            ->select('tx_container_parent', 'colPos')
+            ->addSelectLiteral($qb->expr()->count('uid', 'cnt'))
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter($containerUid, Connection::PARAM_INT)),
-                $qb->expr()->eq('colPos', $qb->createNamedParameter($colPos, Connection::PARAM_INT)),
+                $qb->expr()->in('tx_container_parent', $qb->createNamedParameter($containerUids, Connection::PARAM_INT_ARRAY)),
+                $qb->expr()->in('colPos', $qb->createNamedParameter($colPositions, Connection::PARAM_INT_ARRAY)),
                 $qb->expr()->in('sys_language_uid', [
                     $qb->createNamedParameter($languageUid, Connection::PARAM_INT),
                     $qb->createNamedParameter(-1, Connection::PARAM_INT),
@@ -219,8 +260,16 @@ final readonly class EmptyColumnService
                 $qb->expr()->eq('deleted', $qb->createNamedParameter(0, Connection::PARAM_INT)),
                 $qb->expr()->eq('hidden', $qb->createNamedParameter(0, Connection::PARAM_INT)),
             )
+            ->groupBy('tx_container_parent', 'colPos')
             ->executeQuery()
-            ->fetchOne();
+            ->fetchAllAssociative();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['tx_container_parent']][(int) $row['colPos']] = (int) $row['cnt'];
+        }
+
+        return $counts;
     }
 
     /**
@@ -244,15 +293,10 @@ final readonly class EmptyColumnService
 
     private function detectContainerField(): bool
     {
-        try {
-            return $this->connectionPool
-                ->getConnectionForTable('tt_content')
-                ->createSchemaManager()
-                ->introspectTableByUnquotedName('tt_content')
-                ->hasColumn('tx_container_parent');
-        } catch (Throwable) {
-            return false;
-        }
+        // EXT:container registers tx_container_parent in the TCA, which is already
+        // loaded in memory — cheaper than introspecting the database schema on every
+        // request just to learn whether the column exists.
+        return isset($GLOBALS['TCA']['tt_content']['columns']['tx_container_parent']);
     }
 
     private function translateLabel(string $label): string

--- a/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
+++ b/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
@@ -17,13 +17,15 @@ use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder};
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+
+use function is_array;
 
 /**
  * EmptyColumnServiceTest.
@@ -52,25 +54,20 @@ final class EmptyColumnServiceTest extends TestCase
         $this->urlBuilderService = new UrlBuilderService();
         $this->languageServiceFactory = $this->createMock(LanguageServiceFactory::class);
 
-        // Mock schema manager to simulate missing tx_container_parent field
-        $connection = $this->createMock(Connection::class);
-        $schemaManager = $this->createMock(\Doctrine\DBAL\Schema\AbstractSchemaManager::class);
-        $table = $this->createMock(\Doctrine\DBAL\Schema\Table::class);
-        $table->method('hasColumn')->willReturn(false);
-        $schemaManager->method('introspectTableByUnquotedName')->willReturn($table);
-        $connection->method('createSchemaManager')->willReturn($schemaManager);
-        $this->connectionPool->method('getConnectionForTable')->willReturn($connection);
+        // Default: EXT:container not installed (tx_container_parent absent from TCA)
+        unset($GLOBALS['TCA']['tt_content']);
     }
 
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
+        unset($GLOBALS['TCA']['tt_content']);
     }
 
     #[Test]
     public function getColumnTargetsMarksFilledColumnsAsNotEmpty(): void
     {
-        $this->mockQueryBuilderWithCount(3);
+        $this->mockGroupedCount($this->connectionPool, 3);
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -88,7 +85,7 @@ final class EmptyColumnServiceTest extends TestCase
     #[Test]
     public function getColumnTargetsMarksEmptyColumnsAsEmpty(): void
     {
-        $this->mockQueryBuilderWithCount(0);
+        $this->mockGroupedCount($this->connectionPool, 0);
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -105,7 +102,7 @@ final class EmptyColumnServiceTest extends TestCase
     #[Test]
     public function getColumnTargetsOmitsFilledColumnsWhenInsertButtonsEnabled(): void
     {
-        $this->mockQueryBuilderWithCount(3);
+        $this->mockGroupedCount($this->connectionPool, 3);
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -122,7 +119,7 @@ final class EmptyColumnServiceTest extends TestCase
     #[Test]
     public function getColumnTargetsKeepsEmptyColumnsWhenInsertButtonsEnabled(): void
     {
-        $this->mockQueryBuilderWithCount(0);
+        $this->mockGroupedCount($this->connectionPool, 0);
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -140,7 +137,7 @@ final class EmptyColumnServiceTest extends TestCase
     #[Test]
     public function getColumnTargetsIgnoresContainerMarkersWithoutContainerField(): void
     {
-        $this->mockQueryBuilderWithCount(1);
+        $this->mockGroupedCount($this->connectionPool, 1);
 
         $service = new EmptyColumnService(
             $this->connectionPool,
@@ -164,18 +161,11 @@ final class EmptyColumnServiceTest extends TestCase
     #[Test]
     public function getColumnTargetsHandlesContainerMarkersWhenFieldExists(): void
     {
-        // Mock schema manager to simulate tx_container_parent field exists
-        $connectionPool = $this->createMock(ConnectionPool::class);
-        $connection = $this->createMock(Connection::class);
-        $schemaManager = $this->createMock(\Doctrine\DBAL\Schema\AbstractSchemaManager::class);
-        $table = $this->createMock(\Doctrine\DBAL\Schema\Table::class);
-        $table->method('hasColumn')->willReturn(true);
-        $schemaManager->method('introspectTableByUnquotedName')->willReturn($table);
-        $connection->method('createSchemaManager')->willReturn($schemaManager);
-        $connectionPool->method('getConnectionForTable')->willReturn($connection);
+        $this->registerContainerField();
 
-        // All columns empty
-        $this->mockQueryBuilderWithCountForPool($connectionPool, 0);
+        // All columns empty (grouped query returns no rows)
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $this->mockGroupedCount($connectionPool, 0);
 
         $service = new EmptyColumnService(
             $connectionPool,
@@ -200,20 +190,45 @@ final class EmptyColumnServiceTest extends TestCase
     }
 
     #[Test]
+    public function getColumnTargetsMarksFilledContainerColumnAsNotEmpty(): void
+    {
+        $this->registerContainerField();
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        // Container column 200 of container 42 holds one element
+        $this->mockGroupedCountForPool(
+            $connectionPool,
+            [['colPos' => 0, 'tx_container_parent' => 0, 'cnt' => 0]],
+            [['colPos' => 200, 'tx_container_parent' => 42, 'cnt' => 1]],
+        );
+
+        $service = new EmptyColumnService(
+            $connectionPool,
+            $this->urlBuilderService,
+            $this->languageServiceFactory,
+        );
+
+        $requestData = [
+            '_containerMarkers' => [
+                42 => [200],
+            ],
+        ];
+
+        $result = $service->getColumnTargets(1, 0, '/return', $requestData);
+
+        $containerResults = array_values(array_filter($result, static fn (array $r): bool => isset($r['containerUid'])));
+        self::assertNotEmpty($containerResults);
+        self::assertFalse($containerResults[0]['isEmpty']);
+    }
+
+    #[Test]
     public function getColumnTargetsFiltersInvalidContainerMarkers(): void
     {
-        // Mock schema manager with container field
-        $connectionPool = $this->createMock(ConnectionPool::class);
-        $connection = $this->createMock(Connection::class);
-        $schemaManager = $this->createMock(\Doctrine\DBAL\Schema\AbstractSchemaManager::class);
-        $table = $this->createMock(\Doctrine\DBAL\Schema\Table::class);
-        $table->method('hasColumn')->willReturn(true);
-        $schemaManager->method('introspectTableByUnquotedName')->willReturn($table);
-        $connection->method('createSchemaManager')->willReturn($schemaManager);
-        $connectionPool->method('getConnectionForTable')->willReturn($connection);
+        $this->registerContainerField();
 
+        $connectionPool = $this->createMock(ConnectionPool::class);
         // Keep page columns non-empty
-        $this->mockQueryBuilderWithCountForPool($connectionPool, 1);
+        $this->mockGroupedCount($connectionPool, 1);
 
         $service = new EmptyColumnService(
             $connectionPool,
@@ -235,12 +250,24 @@ final class EmptyColumnServiceTest extends TestCase
         self::assertEmpty($containerResults);
     }
 
-    private function mockQueryBuilderWithCount(int $count): void
+    private function registerContainerField(): void
     {
-        $this->mockQueryBuilderWithCountForPool($this->connectionPool, $count);
+        $GLOBALS['TCA']['tt_content']['columns']['tx_container_parent'] = ['config' => ['type' => 'passthrough']];
     }
 
-    private function mockQueryBuilderWithCountForPool(ConnectionPool $connectionPool, int $count): void
+    private function mockGroupedCount(ConnectionPool $connectionPool, int $count): void
+    {
+        $this->mockGroupedCountForPool(
+            $connectionPool,
+            [['colPos' => 0, 'tx_container_parent' => 0, 'cnt' => $count]],
+        );
+    }
+
+    /**
+     * @param list<array<string, int>>      $pageRows      grouped rows for the page-column query
+     * @param list<array<string, int>>|null $containerRows grouped rows for the container-column query
+     */
+    private function mockGroupedCountForPool(ConnectionPool $connectionPool, array $pageRows, ?array $containerRows = null): void
     {
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
@@ -248,13 +275,21 @@ final class EmptyColumnServiceTest extends TestCase
 
         $expressionBuilder->method('eq')->willReturn('');
         $expressionBuilder->method('in')->willReturn('');
+        $expressionBuilder->method('count')->willReturn('COUNT(`uid`) AS `cnt`');
         $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('count')->willReturn($queryBuilder);
+        $queryBuilder->method('select')->willReturn($queryBuilder);
+        $queryBuilder->method('addSelectLiteral')->willReturn($queryBuilder);
         $queryBuilder->method('from')->willReturn($queryBuilder);
         $queryBuilder->method('where')->willReturn($queryBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturnCallback(static fn (mixed $value): string => (string) $value);
+        $queryBuilder->method('groupBy')->willReturn($queryBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturnCallback(static fn (mixed $value): string => is_array($value) ? implode(',', $value) : (string) $value);
         $queryBuilder->method('executeQuery')->willReturn($result);
-        $result->method('fetchOne')->willReturn($count);
+
+        // The page-column query runs first, the container-column query (if any) second.
+        $result->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
+            $pageRows,
+            $containerRows ?? [],
+        );
 
         $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
     }


### PR DESCRIPTION
## Summary

- Detect the EXT:container field (\`tx_container_parent\`) via the in-memory TCA instead of introspecting the database schema on every AJAX request.
- Resolve page-column emptiness with a single grouped COUNT query instead of one COUNT query per column.
- Resolve container-column emptiness with a single grouped COUNT query instead of one COUNT query per container column.

Together these cut the per-request query count for the edit-information endpoint from N (one per column) plus a schema introspection down to two grouped queries, most noticeable on backend layouts and container pages with many columns.

> Note: the originally-considered per-request memoization of site settings was intentionally omitted — \`Site::getSettings()\` already returns a pre-built, cached \`SiteSettings\` object, so re-resolving it is cheap and memoizing would require dropping the \`final readonly\` service convention for no measurable gain.

## Changes

- \`Classes/Service/Content/EmptyColumnService.php\` — TCA-based container detection; grouped \`countPageColumnContent()\` / \`countContainerColumnContent()\` replacing per-column COUNT queries.
- \`Tests/Unit/Service/Content/EmptyColumnServiceTest.php\` — adapt mocks to the grouped queries and TCA detection; add a filled-container-column case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how empty page and container columns are detected, making column visibility more reliable in content layouts.
  * Simplified detection of container-aware fields for more consistent behavior across configurations.

* **Tests**
  * Updated unit coverage to reflect the new grouped-count logic and improve test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->