### PR TITLE
chore: ignore version-specific AccessCheckResult in dependency analysis

### DIFF
--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -26,6 +26,11 @@ $configuration
     ->addPathsToExclude([
         $rootPath.'/Tests/CGL',
     ])
+    // AccessCheckResult only exists in TYPO3 v14.2+. The unit test doubles reference
+    // it behind method_exists() guards, so it is legitimately unavailable on v13.
+    ->ignoreUnknownClasses([
+        'TYPO3\CMS\Core\Authentication\AccessCheckResult',
+    ])
 ;
 
 return $configuration;


### PR DESCRIPTION
## Summary

- \`composer-dependency-analyser\` reported \`TYPO3\CMS\Core\Authentication\AccessCheckResult\` as an unknown class. That class only exists in TYPO3 v14.2+, while the test doubles reference it behind \`method_exists()\` guards, so it is legitimately unavailable when the CGL tooling resolves against TYPO3 v13.
- Add it to \`ignoreUnknownClasses()\` so \`ddev cgl analyze\` passes on all supported TYPO3 versions without masking real issues.

## Changes

- \`Tests/CGL/composer-dependency-analyser.php\` — ignore the version-specific \`AccessCheckResult\` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dependency analysis rules to account for a newer TYPO3 core class that may not exist on older versions, reducing false positives in test checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->