### PR TITLE
fix: re-check edit access on resolved translated record

### DIFF
--- a/Classes/Service/Menu/AdditionalDataHandler.php
+++ b/Classes/Service/Menu/AdditionalDataHandler.php
@@ -173,11 +173,17 @@ final readonly class AdditionalDataHandler
                 $languageUid,
             );
 
-            if (is_array($translatedRecord)) {
-                return $translatedRecord['uid'];
+            if (!is_array($translatedRecord)) {
+                return null;
             }
 
-            return null;
+            // The access check above applied to the parent record; re-check it on the
+            // resolved translation before its uid is turned into an edit link.
+            if (!$this->backendUserService->hasRecordEditAccess($dataEntry['table'], $translatedRecord)) {
+                return null;
+            }
+
+            return $translatedRecord['uid'];
         }
 
         return $recordUid;

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -299,6 +299,45 @@ final class AdditionalDataHandlerTest extends TestCase
     }
 
     #[Test]
+    public function handleDataSkipsTranslatedRecordWhenAccessDenied(): void
+    {
+        // Access is granted for the parent (uid 5) but denied for the translation (uid 99).
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        if (method_exists(BackendUserAuthentication::class, 'checkRecordEditAccess')) {
+            $backendUser->method('checkRecordEditAccess')->willReturnCallback(
+                static fn (string $table, array $record): \TYPO3\CMS\Core\Authentication\AccessCheckResult => new \TYPO3\CMS\Core\Authentication\AccessCheckResult(99 !== ($record['uid'] ?? 0)),
+            );
+        }
+        $backendUser->method('recordEditAccessInternals')->willReturnCallback(
+            static fn (string $table, array $record): bool => 99 !== ($record['uid'] ?? 0),
+        );
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $this->registerRecordLookup(['uid' => 5, 'sys_language_uid' => 0]);
+
+        $repository = new ContentElementRepository(
+            $this->createConnectionPoolReturning(['uid' => 99, 'sys_language_uid' => 1]),
+        );
+
+        $handler = new AdditionalDataHandler(
+            new BackendUserService(),
+            new UrlBuilderService(),
+            new IconService($this->createIconFactory()),
+            $repository,
+        );
+        $button = $this->createButton();
+
+        $entries = [
+            ['label' => 'Record', 'table' => 'pages', 'uid' => 5, 'url' => null, 'icon' => null],
+        ];
+
+        $handler->handleData($button, $entries, ['icon' => 'content-text'], 1, '#anchor');
+
+        self::assertArrayNotHasKey('data_0', $button->getChildren());
+    }
+
+    #[Test]
     public function handleDataSkipsWhenTranslationMissing(): void
     {
         $this->registerBackendUserWithAccess();


### PR DESCRIPTION
> Stacked on #199 (`security/validate-additional-data-url`) because it touches the same `resolveRecordUid()`. Review/merge #199 first; the base will retarget to `main` automatically once #199 merges.

## Summary

- When an additional-data entry resolves to a translated record, edit access was only checked on the parent record, but the edit URL was built for the translation. Re-check `hasRecordEditAccess()` on the resolved translation before turning its uid into an edit link.

## Changes

- `Classes/Service/Menu/AdditionalDataHandler.php` — re-check access on the translated record in `resolveRecordUid()`.
- `Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php` — test that a translation is skipped when access is granted on the parent but denied on the translation.