### PR TITLE
perf: drop redundant mb_convert_encoding on ajax response

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -139,10 +139,10 @@ readonly class AjaxController
             $this->settingsService->isShowInsertButtons($request),
         );
 
-        return new JsonResponse(mb_convert_encoding([
+        return new JsonResponse([
             'contentElements' => $dropdown,
             'columnTargets' => $columnTargets,
-        ], 'UTF-8'));
+        ]);
     }
 
     protected function getBackendUser(): ?BackendUserAuthentication


### PR DESCRIPTION
> Stacked on #198 (`security/harden-toggle-csrf`) because it touches the same `AjaxController`. Review/merge #198 first; the base retargets to `main` automatically once #198 merges.

## Summary

- `editInformationAction` wrapped its entire response payload in `mb_convert_encoding(..., 'UTF-8')` (single-argument target form). TYPO3 content is already UTF-8, so this walked the whole nested menu structure on every request without changing it. Remove it; `JsonResponse` encodes the array directly.

## Changes

- `Classes/Controller/AjaxController.php` — remove the redundant `mb_convert_encoding()` wrapper.