### PR TITLE
perf: narrow content-element DOM scan to ids starting with c

### DIFF
--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1067,8 +1067,12 @@
       const allUids = new Set();
 
       // Scan DOM for all content elements by id="c{uid}" pattern
-      // This enables editing content from other pages (onepager scenarios)
-      document.querySelectorAll('[id]').forEach(element => {
+      // This enables editing content from other pages (onepager scenarios).
+      // Narrow the candidate set to ids starting with "c" (the regex below still
+      // validates the exact "c{digits}" shape) instead of scanning every [id].
+      // The attribute selector reads the real attribute, so it stays safe against
+      // the id clobbering that Dom.id() guards against.
+      document.querySelectorAll('[id^="c"]').forEach(element => {
         const match = Dom.id(element).match(/^c(\d+)$/);
         if (match) {
           const uid = parseInt(match[1], 10);


### PR DESCRIPTION
## Summary

- `collectDataItems()` scanned every element on the page with an id (`querySelectorAll('[id]')`) and regex-tested each for the `c{uid}` content-element pattern. Narrow the candidate set to `[id^="c"]`; the `^c(\d+)$` regex still validates the exact shape, so results are identical while the browser filters far fewer nodes on large pages.

## Changes

- `Resources/Public/JavaScript/frontend_edit.js` — use the `[id^="c"]` prefix selector for the content-element DOM scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content detection by limiting scans to relevant content elements.
  * Reduced unnecessary processing when collecting content data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->