### PR TITLE
fix: edit menus for translated content in connected language mode

### DIFF
--- a/Classes/Repository/ContentElementRepository.php
+++ b/Classes/Repository/ContentElementRepository.php
@@ -81,6 +81,11 @@ final readonly class ContentElementRepository
      * is rendered on a single page. Permission checks are performed per-element
      * in the ContentElementFilter layer.
      *
+     * In connected/overlay language mode the given UIDs are the default-language
+     * (L0) uids taken from the DOM anchors; translations are resolved via
+     * l18n_parent and the matching variant is selected in resolveLanguageVariants()
+     * (translation wins over L0). Free mode and the default language are unaffected.
+     *
      * @param array<int> $uids Array of content element UIDs
      *
      * @return array<int, array<string, mixed>> Array of content element records
@@ -99,16 +104,22 @@ final readonly class ContentElementRepository
         }
 
         try {
-            $queryBuilder = $this->buildContentQuery($languageUid, $includeMultilingualContent);
+            if (!$includeMultilingualContent) {
+                $queryBuilder = $this->buildContentQuery($languageUid, false);
+                $queryBuilder->andWhere(
+                    $queryBuilder->expr()->in(
+                        'uid',
+                        $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY),
+                    ),
+                );
 
-            $queryBuilder->andWhere(
-                $queryBuilder->expr()->in(
-                    'uid',
-                    $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY),
-                ),
-            );
+                return $queryBuilder->executeQuery()->fetchAllAssociative();
+            }
 
-            return $queryBuilder->executeQuery()->fetchAllAssociative();
+            $queryBuilder = $this->buildContentQueryByUids($uids, $languageUid);
+            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+            return $this->resolveLanguageVariants($rows);
         } catch (\Doctrine\DBAL\Exception $exception) {
             throw new Exception('Failed to fetch content elements by UIDs: '.$exception->getMessage(), 1640000011, $exception);
         }
@@ -298,6 +309,104 @@ final readonly class ContentElementRepository
         }
 
         return $queryBuilder;
+    }
+
+    /**
+     * Build a QueryBuilder for the UID-based fetch path (onepager + language overlay).
+     *
+     * In connected/overlay language mode the DOM anchors (`id="c{uid}"`) carry the
+     * default-language (L0) uids, so the requested $uids are L0 uids. This query
+     * therefore also matches the translations of those L0 uids via l18n_parent and
+     * keeps L0 records (sys_language_uid = 0) so fallback-rendered elements on
+     * translated pages still receive a menu. The actual variant is picked in
+     * resolveLanguageVariants().
+     *
+     * @param array<int> $uids
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function buildContentQueryByUids(
+        array $uids,
+        int $languageUid,
+    ): \Doctrine\DBAL\Query\QueryBuilder {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+
+        $uidsParameter = $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY);
+
+        $queryBuilder
+            ->select('*')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'hidden',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+                $queryBuilder->expr()->eq(
+                    'deleted',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+            );
+
+        if ($languageUid > 0) {
+            // Match the requested uids directly, or the translations of those uids
+            // (connected mode: translation.l18n_parent points to the L0 uid).
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->in('uid', $uidsParameter),
+                    $queryBuilder->expr()->and(
+                        $queryBuilder->expr()->in('l18n_parent', $uidsParameter),
+                        $queryBuilder->expr()->eq(
+                            'sys_language_uid',
+                            $queryBuilder->createNamedParameter($languageUid, Connection::PARAM_INT),
+                        ),
+                    ),
+                ),
+                $queryBuilder->expr()->in(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter([-1, 0, $languageUid], Connection::PARAM_INT_ARRAY),
+                ),
+            );
+        } else {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->in('uid', $uidsParameter),
+                $queryBuilder->expr()->in(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter([-1, 0], Connection::PARAM_INT_ARRAY),
+                ),
+            );
+        }
+
+        return $queryBuilder;
+    }
+
+    /**
+     * Collapse language variants that map to the same DOM anchor.
+     *
+     * The DOM anchor of a record is its l18n_parent (for translations) or its own
+     * uid (for L0 and all-language records). When both an L0 record and its
+     * translation are returned for the same anchor, the translation wins so the
+     * edit URL targets the translation uid (FormEngine cannot switch records via a
+     * language parameter).
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveLanguageVariants(array $rows): array
+    {
+        $byAnchor = [];
+        foreach ($rows as $row) {
+            $languageId = (int) ($row['sys_language_uid'] ?? 0);
+            $parent = (int) ($row['l18n_parent'] ?? 0);
+            $anchorUid = ($languageId > 0 && $parent > 0) ? $parent : (int) $row['uid'];
+
+            $existing = $byAnchor[$anchorUid] ?? null;
+            if (null === $existing || ($languageId > 0 && (int) ($existing['sys_language_uid'] ?? 0) <= 0)) {
+                $byAnchor[$anchorUid] = $row;
+            }
+        }
+
+        return array_values($byAnchor);
     }
 
     /**

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -77,6 +77,13 @@ This TYPO3 extension adds lightweight editing tools to the frontend, allowing ba
         ..  card-footer::   :ref:`View usage guide <usage>`
             :button-style: btn btn-secondary stretched-link
 
+    ..  card::  Languages
+
+        Which language modes are supported and how translated content is resolved.
+
+        ..  card-footer::   :ref:`View language support <languages>`
+            :button-style: btn btn-secondary stretched-link
+
     ..  card::  Developer corner
 
         A quick overview of the possibilities for extending the extension
@@ -114,6 +121,7 @@ This TYPO3 extension adds lightweight editing tools to the frontend, allowing ba
     Installation/Index
     Configuration/Index
     Usage/Index
+    Languages/Index
     DeveloperCorner/Index
     Delineation/Index
     FAQ/Index

--- a/Documentation/Languages/Index.rst
+++ b/Documentation/Languages/Index.rst
@@ -1,0 +1,65 @@
+..  include:: /Includes.rst.txt
+
+..  _languages:
+
+=========
+Languages
+=========
+
+Frontend Edit builds its Edit Menus from the content elements found on the
+rendered page. Because TYPO3 renders translated pages differently depending on
+the configured language mode, this page documents which modes are supported and
+how the extension resolves the correct record to edit.
+
+How translations are resolved
+==============================
+
+The injected script collects the content element ids (``c<uid>``) from the DOM
+and sends them to the backend. In **connected mode** (language overlay) TYPO3
+keeps the *default-language* uid on the overlaid row, so the DOM anchor carries
+the default-language (L0) uid rather than the translation uid.
+
+Frontend Edit therefore resolves translations on the server side via the
+``l18n_parent`` pointer: for every requested L0 uid it also looks up the matching
+translation and, when both exist, the translation wins. This guarantees that the
+edit link targets the **translation uid** — TYPO3 FormEngine cannot switch the
+edited record via a language parameter alone.
+
+Mode support matrix
+===================
+
+..  list-table::
+    :header-rows: 1
+    :widths: 30 15 55
+
+    *   -   Language mode
+        -   Edit menu
+        -   Behavior
+    *   -   Default language (L0)
+        -   ✅
+        -   Elements are matched directly by their uid.
+    *   -   Connected mode / overlay (``fallbackType: strict`` or ``fallback``)
+        -   ✅
+        -   Translations are resolved via ``l18n_parent``; the edit link targets
+            the translation uid.
+    *   -   Fallback-rendered default element
+        -   ✅
+        -   When no translation exists on a translated page, the default-language
+            element still receives a menu (edits the L0 record).
+    *   -   Free mode
+        -   ✅
+        -   Translated elements are standalone records with their own uid and are
+            matched directly.
+    *   -   All languages (``sys_language_uid = -1``)
+        -   ✅
+        -   Matched directly by uid, independent of the active language.
+    *   -   Chained translation (``l10n_source`` ≠ ``l18n_parent``)
+        -   ✅
+        -   Resolved via the canonical ``l18n_parent`` pointer, not
+            ``l10n_source``.
+
+..  note::
+
+    In connected mode the edit link always opens the translated record. Switching
+    the edited language happens automatically through the resolved translation
+    uid, so no manual language switch is required.

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1194,13 +1194,18 @@
 
         let idElement = document.querySelector(`#c${uid}`);
 
-        // Handle translation mapping
-        if (idElement?.tagName.toLowerCase() === 'a' && contentElement.element.l10n_source) {
-          const l10nElement = document.querySelector(`#c${contentElement.element.l10n_source}`);
-          if (l10nElement) {
-            Logger.log(`Translation mapping: c${uid} → c${contentElement.element.l10n_source}`);
-            uid = contentElement.element.l10n_source;
-            idElement = l10nElement;
+        // Handle translation mapping. In connected/overlay mode the DOM anchor
+        // carries the default-language uid (l18n_parent), so the response uid
+        // (the translation uid) has no anchor of its own. Fall back to the L0
+        // anchor even when the primary lookup missed. Prefer l18n_parent (the
+        // canonical connected-mode pointer) over l10n_source (chained translations).
+        const anchorUid = contentElement.element.l18n_parent || contentElement.element.l10n_source;
+        if (anchorUid && (!idElement || idElement.tagName.toLowerCase() === 'a')) {
+          const anchorElement = document.querySelector(`#c${anchorUid}`);
+          if (anchorElement) {
+            Logger.log(`Translation mapping: c${uid} → c${anchorUid}`);
+            uid = anchorUid;
+            idElement = anchorElement;
           }
         }
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1199,8 +1199,9 @@
         // (the translation uid) has no anchor of its own. Fall back to the L0
         // anchor even when the primary lookup missed. Prefer l18n_parent (the
         // canonical connected-mode pointer) over l10n_source (chained translations).
-        const anchorUid = contentElement.element.l18n_parent || contentElement.element.l10n_source;
-        if (anchorUid && (!idElement || idElement.tagName.toLowerCase() === 'a')) {
+        // Coerce to number: DB values may arrive as strings, and "0" is truthy in JS.
+        const anchorUid = Number(contentElement.element.l18n_parent) || Number(contentElement.element.l10n_source);
+        if (anchorUid > 0 && (!idElement || idElement.tagName.toLowerCase() === 'a')) {
           const anchorElement = document.querySelector(`#c${anchorUid}`);
           if (anchorElement) {
             Logger.log(`Translation mapping: c${uid} → c${anchorUid}`);

--- a/Tests/Functional/Repository/ContentElementRepositoryTest.php
+++ b/Tests/Functional/Repository/ContentElementRepositoryTest.php
@@ -109,6 +109,95 @@ final class ContentElementRepositoryTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function fetchContentElementsByUidsResolvesTranslationForConnectedModeAnchor(): void
+    {
+        // Connected mode: the DOM anchor carries the L0 uid (1); the request must
+        // resolve to the translation record (uid 3) so the edit URL targets it.
+        $result = $this->subject->fetchContentElementsByUids([1], 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([3], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsReturnsL0FallbackWhenNoTranslationExists(): void
+    {
+        // Fallback-rendered L0 element on a translated page (uid 2 has no DE
+        // translation) must still receive a record/menu.
+        $result = $this->subject->fetchContentElementsByUids([2], 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([2], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsPrefersTranslationOverDefaultWithoutDuplicates(): void
+    {
+        // uid 1 has a DE translation (3), uid 2 does not. Each anchor must yield
+        // exactly one record: the translation for 1, the L0 fallback for 2.
+        $result = $this->subject->fetchContentElementsByUids([1, 2], 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+        sort($uids);
+
+        self::assertSame([2, 3], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsResolvesChainedTranslationViaParent(): void
+    {
+        // uid 8 (FR) is translated from the DE record (l10n_source = 3) but its
+        // l18n_parent still points to the L0 uid (1). Requesting the L0 anchor for
+        // language 2 must resolve to the chained translation via l18n_parent.
+        $result = $this->subject->fetchContentElementsByUids([1], 2);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([8], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsReturnsAllLanguageRecordForTranslatedRequest(): void
+    {
+        $result = $this->subject->fetchContentElementsByUids([6], 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([6], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsHandlesOnepagerMixedLanguagesAcrossPages(): void
+    {
+        // Mixed onepager: L0 anchor with translation (1 → 3) plus a foreign-page
+        // L0 element without translation (7).
+        $result = $this->subject->fetchContentElementsByUids([1, 7], 1);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+        sort($uids);
+
+        self::assertSame([3, 7], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsReturnsDefaultLanguageRecordUnchanged(): void
+    {
+        $result = $this->subject->fetchContentElementsByUids([1], 0);
+
+        $uids = array_map(static fn (array $row): int => (int) $row['uid'], $result);
+
+        self::assertSame([1], $uids);
+    }
+
+    #[Test]
+    public function fetchContentElementsByUidsExcludesHiddenAndDeletedRecords(): void
+    {
+        self::assertSame([], $this->subject->fetchContentElementsByUids([4, 5], 0));
+    }
+
+    #[Test]
     public function getTranslatedRecordReturnsTranslationRow(): void
     {
         $record = $this->subject->getTranslatedRecord('pages', 2, 1);

--- a/Tests/Functional/Repository/Fixtures/tt_content.csv
+++ b/Tests/Functional/Repository/Fixtures/tt_content.csv
@@ -1,9 +1,10 @@
 "tt_content"
-,"uid","pid","sys_language_uid","l18n_parent","CType","header","hidden","deleted"
-,1,2,0,0,"text","Default EN",0,0
-,2,2,0,0,"textmedia","Second EN",0,0
-,3,2,1,1,"text","Translated DE",0,0
-,4,2,0,0,"text","Hidden",1,0
-,5,2,0,0,"text","Deleted",0,1
-,6,2,-1,0,"text","All languages",0,0
-,7,3,0,0,"text","Other page",0,0
+,"uid","pid","sys_language_uid","l18n_parent","l10n_source","CType","header","hidden","deleted"
+,1,2,0,0,0,"text","Default EN",0,0
+,2,2,0,0,0,"textmedia","Second EN",0,0
+,3,2,1,1,1,"text","Translated DE",0,0
+,4,2,0,0,0,"text","Hidden",1,0
+,5,2,0,0,0,"text","Deleted",0,1
+,6,2,-1,0,0,"text","All languages",0,0
+,7,3,0,0,0,"text","Other page",0,0
+,8,2,2,1,3,"text","Chained FR",0,0


### PR DESCRIPTION
## Summary

- Fix missing edit menus for translated content elements on pages in connected mode / language overlay (`fallbackType: strict` or `fallback`) — resolves #212
- Resolve translations server-side via `l18n_parent` so the edit link targets the translation uid
- Fallback-rendered default-language elements on translated pages now also receive a menu
- Free mode, default language, and `sys_language_uid = -1` elements are unchanged

## Background

In connected/overlay mode TYPO3 keeps the default-language (L0) uid on the overlaid row, so the DOM anchors (`id="c{uid}"`) carry L0 uids. The uid-based fetch path filtered `uid IN (:uids) AND sys_language_uid IN (-1, :lang)`, which excluded both the L0 records (language 0) and the actual translations (uids not in the request) — resulting in no menus. Additionally the JS remap onto the L0 anchor only ran when the translation anchor already existed, which it never does in overlay mode.

## Changes

- `Classes/Repository/ContentElementRepository.php` — new `buildContentQueryByUids()` matches translations of the requested L0 uids via `l18n_parent` and keeps L0 records (`sys_language_uid IN (-1, 0, :lang)`); new `resolveLanguageVariants()` collapses variants per DOM anchor (translation wins over L0). The `includeMultilingualContent = false` path and the pid-based path are unchanged.
- `Resources/Public/JavaScript/frontend_edit.js` — remap uses `l18n_parent ?: l10n_source` and runs even when the primary `#c{uid}` anchor is absent.
- `Tests/Functional/Repository/ContentElementRepositoryTest.php` + `Fixtures/tt_content.csv` — full matrix: connected mode, fallback L0, translation-wins-without-duplicate, chained translation (`l10n_source ≠ l18n_parent`), all-languages, onepager mixed languages, default-language and hidden/deleted regression.
- `Documentation/Languages/Index.rst` (+ `Documentation/Index.rst`) — new "Languages" section with a mode support matrix.

## Verification

- Unit: 275 tests, Functional: 46 tests (incl. 9 new) — all green
- PHPStan: no errors; php-cs-fixer: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved translation handling for connected and overlay language modes.
* **Bug Fixes**
  * Correctly resolves translated content elements and prefers the translated variant over default language (with proper L0 fallback).
  * Fixes DOM-to-content mapping so edit/render targets the correct translated element.
  * Prevents duplicates and properly resolves chained translations; hidden and deleted records are excluded consistently.
* **Documentation**
  * Added new “Languages” documentation describing supported TYPO3 language modes and translation resolution behavior.
* **Tests**
  * Expanded functional coverage for translation selection, connected-mode anchors, fallback, onepager/mixed languages, and chained translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->