### PR TITLE
feat: container support for frontend drag & drop

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -154,6 +154,8 @@ readonly class AjaxController
      * - targetColPos: destination column (required, non-negative int)
      * - targetUid: neighbour to insert after; 0/omitted = top of column (optional int)
      * - language: current frontend language (must be 0 — translations are out of scope)
+     * - targetContainerUid: EXT:container element the target column belongs to
+     *   (optional; omitted or null means the target is a page column)
      */
     public function moveAction(ServerRequestInterface $request): JsonResponse
     {
@@ -171,31 +173,19 @@ readonly class AjaxController
             return new JsonResponse(['success' => false, 'error' => 'Invalid request data'], 400);
         }
 
-        $uid = filter_var($data['uid'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
-        if (false === $uid) {
-            return new JsonResponse(['success' => false, 'error' => 'Missing or invalid parameter: uid'], 400);
+        $parseResult = $this->parseMovePrameters($data);
+        if ($parseResult['hasError']) {
+            $statusCode = $parseResult['statusCode'] ?? 400;
+
+            return new JsonResponse(['success' => false, 'error' => $parseResult['error']], $statusCode);
         }
 
-        $targetColPos = filter_var($data['targetColPos'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if (false === $targetColPos) {
-            return new JsonResponse(['success' => false, 'error' => 'Missing or invalid parameter: targetColPos'], 400);
-        }
-
-        $language = filter_var($data['language'] ?? 0, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if (false === $language) {
-            return new JsonResponse(['success' => false, 'error' => 'Invalid parameter: language'], 400);
-        }
-        if ($language > 0) {
-            return new JsonResponse(['success' => false, 'error' => 'Translated content cannot be moved via drag & drop'], 422);
-        }
-
-        $targetUidValue = $data['targetUid'] ?? null;
-        $targetUid = null === $targetUidValue ? null : filter_var($targetUidValue, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if (false === $targetUid) {
-            return new JsonResponse(['success' => false, 'error' => 'Invalid parameter: targetUid'], 400);
-        }
-
-        $result = $this->contentMoveService->move($uid, $targetColPos, $targetUid);
+        $result = $this->contentMoveService->move(
+            $parseResult['uid'],
+            $parseResult['targetColPos'],
+            $parseResult['targetUid'],
+            $parseResult['targetContainerUid'],
+        );
 
         return new JsonResponse(
             $result['success']
@@ -275,5 +265,55 @@ readonly class AjaxController
         } catch (JsonException $e) {
             throw new InvalidArgumentException('Invalid JSON format: '.$e->getMessage(), 1640000025, $e);
         }
+    }
+
+    /**
+     * Parse move request parameters.
+     *
+     * @param array<mixed> $data
+     *
+     * @return array{hasError: true, statusCode?: int, error: string}|array{hasError: false, uid: int, targetColPos: int, targetUid: int|null, targetContainerUid: int|null}
+     */
+    private function parseMovePrameters(array $data): array
+    {
+        $uid = filter_var($data['uid'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if (false === $uid) {
+            return ['hasError' => true, 'error' => 'Missing or invalid parameter: uid'];
+        }
+
+        $targetColPos = filter_var($data['targetColPos'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if (false === $targetColPos) {
+            return ['hasError' => true, 'error' => 'Missing or invalid parameter: targetColPos'];
+        }
+
+        $language = filter_var($data['language'] ?? 0, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if (false === $language) {
+            return ['hasError' => true, 'error' => 'Invalid parameter: language'];
+        }
+        if ($language > 0) {
+            return ['hasError' => true, 'statusCode' => 422, 'error' => 'Translated content cannot be moved via drag & drop'];
+        }
+
+        $targetUidValue = $data['targetUid'] ?? null;
+        $targetUid = null === $targetUidValue ? null : filter_var($targetUidValue, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if (false === $targetUid) {
+            return ['hasError' => true, 'error' => 'Invalid parameter: targetUid'];
+        }
+
+        $containerUidValue = $data['targetContainerUid'] ?? null;
+        $targetContainerUid = null === $containerUidValue
+            ? null
+            : filter_var($containerUidValue, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if (false === $targetContainerUid) {
+            return ['hasError' => true, 'error' => 'Invalid parameter: targetContainerUid'];
+        }
+
+        return [
+            'hasError' => false,
+            'uid' => $uid,
+            'targetColPos' => $targetColPos,
+            'targetUid' => $targetUid,
+            'targetContainerUid' => $targetContainerUid,
+        ];
     }
 }

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -276,17 +276,17 @@ readonly class AjaxController
      */
     private function parseMoveParameters(array $data): array
     {
-        $uid = filter_var($data['uid'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $uid = $this->parseInt($data, 'uid', 1);
         if (false === $uid) {
             return ['hasError' => true, 'error' => 'Missing or invalid parameter: uid'];
         }
 
-        $targetColPos = filter_var($data['targetColPos'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        $targetColPos = $this->parseInt($data, 'targetColPos', 0);
         if (false === $targetColPos) {
             return ['hasError' => true, 'error' => 'Missing or invalid parameter: targetColPos'];
         }
 
-        $language = filter_var($data['language'] ?? 0, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        $language = $this->parseInt($data, 'language', 0, 0);
         if (false === $language) {
             return ['hasError' => true, 'error' => 'Invalid parameter: language'];
         }
@@ -294,16 +294,12 @@ readonly class AjaxController
             return ['hasError' => true, 'statusCode' => 422, 'error' => 'Translated content cannot be moved via drag & drop'];
         }
 
-        $targetUidValue = $data['targetUid'] ?? null;
-        $targetUid = null === $targetUidValue ? null : filter_var($targetUidValue, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        $targetUid = $this->parseOptionalInt($data, 'targetUid', 0);
         if (false === $targetUid) {
             return ['hasError' => true, 'error' => 'Invalid parameter: targetUid'];
         }
 
-        $containerUidValue = $data['targetContainerUid'] ?? null;
-        $targetContainerUid = null === $containerUidValue
-            ? null
-            : filter_var($containerUidValue, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $targetContainerUid = $this->parseOptionalInt($data, 'targetContainerUid', 1);
         if (false === $targetContainerUid) {
             return ['hasError' => true, 'error' => 'Invalid parameter: targetContainerUid'];
         }
@@ -315,5 +311,28 @@ readonly class AjaxController
             'targetUid' => $targetUid,
             'targetContainerUid' => $targetContainerUid,
         ];
+    }
+
+    /**
+     * Parse a required integer parameter, substituting $default when absent.
+     *
+     * @param array<mixed> $data
+     */
+    private function parseInt(array $data, string $key, int $min, ?int $default = null): int|false
+    {
+        return filter_var($data[$key] ?? $default, \FILTER_VALIDATE_INT, ['options' => ['min_range' => $min]]);
+    }
+
+    /**
+     * Parse an optional integer parameter: absent or explicit null passes
+     * through as null, present-but-invalid yields false.
+     *
+     * @param array<mixed> $data
+     */
+    private function parseOptionalInt(array $data, string $key, int $min): int|false|null
+    {
+        $value = $data[$key] ?? null;
+
+        return null === $value ? null : filter_var($value, \FILTER_VALIDATE_INT, ['options' => ['min_range' => $min]]);
     }
 }

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -173,7 +173,7 @@ readonly class AjaxController
             return new JsonResponse(['success' => false, 'error' => 'Invalid request data'], 400);
         }
 
-        $parseResult = $this->parseMovePrameters($data);
+        $parseResult = $this->parseMoveParameters($data);
         if ($parseResult['hasError']) {
             $statusCode = $parseResult['statusCode'] ?? 400;
 
@@ -274,7 +274,7 @@ readonly class AjaxController
      *
      * @return array{hasError: true, statusCode?: int, error: string}|array{hasError: false, uid: int, targetColPos: int, targetUid: int|null, targetContainerUid: int|null}
      */
-    private function parseMovePrameters(array $data): array
+    private function parseMoveParameters(array $data): array
     {
         $uid = filter_var($data['uid'] ?? null, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
         if (false === $uid) {

--- a/Classes/Service/Content/ContainerContextResolver.php
+++ b/Classes/Service/Content/ContainerContextResolver.php
@@ -31,8 +31,14 @@ use function sprintf;
  */
 final readonly class ContainerContextResolver
 {
+    /**
+     * $registry is null when EXT:container is not installed — a supported
+     * setup, since the extension only requires it via require-dev. Every
+     * containerUid is then rejected; there are no registered containers to
+     * validate against.
+     */
     public function __construct(
-        private Registry $registry,
+        private ?Registry $registry,
         private ConnectionPool $connectionPool,
     ) {}
 
@@ -59,6 +65,10 @@ final readonly class ContainerContextResolver
             }
 
             return $this->accept($colPos, 0);
+        }
+
+        if (null === $this->registry) {
+            return $this->reject('EXT:container is not installed');
         }
 
         // Rule 5: a container element itself must not be nested via drag & drop.
@@ -137,6 +147,10 @@ final readonly class ContainerContextResolver
      */
     private function allRegisteredContainerColPos(): array
     {
+        if (null === $this->registry) {
+            return [];
+        }
+
         $colPositions = [];
         foreach ($this->registry->getRegisteredCTypes() as $cType) {
             foreach ($this->registry->getAllAvailableColumnsColPos($cType) as $colPos) {

--- a/Classes/Service/Content/ContainerContextResolver.php
+++ b/Classes/Service/Content/ContainerContextResolver.php
@@ -26,7 +26,7 @@ use function sprintf;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-final class ContainerContextResolver
+final readonly class ContainerContextResolver
 {
     public function __construct(
         private Registry $registry,

--- a/Classes/Service/Content/ContainerContextResolver.php
+++ b/Classes/Service/Content/ContainerContextResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Service\Content;
+
+/**
+ * ContainerContextResolver.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class ContainerContextResolver
+{
+    /**
+     * Validate a drop target and resolve it to a column context.
+     *
+     * A null $containerUid means the target is a page column; any other value
+     * must pass all container rules before it is trusted.
+     *
+     * @param array<string, mixed> $movedRecord
+     *
+     * @return array{valid: bool, colPos: int, containerUid: int, error: string|null}
+     */
+    public function resolve(?int $containerUid, int $colPos, array $movedRecord): array
+    {
+        if (null === $containerUid || 0 === $containerUid) {
+            return $this->accept($colPos, 0);
+        }
+
+        return $this->accept($colPos, $containerUid);
+    }
+
+    /**
+     * @return array{valid: bool, colPos: int, containerUid: int, error: string|null}
+     */
+    private function accept(int $colPos, int $containerUid): array
+    {
+        return ['valid' => true, 'colPos' => $colPos, 'containerUid' => $containerUid, 'error' => null];
+    }
+}

--- a/Classes/Service/Content/ContainerContextResolver.php
+++ b/Classes/Service/Content/ContainerContextResolver.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Service\Content;
 
 use B13\Container\Tca\Registry;
+use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 
+use function array_map;
 use function array_unique;
 use function array_values;
 use function in_array;
+use function is_array;
 use function sprintf;
 
 /**
@@ -30,6 +33,7 @@ final readonly class ContainerContextResolver
 {
     public function __construct(
         private Registry $registry,
+        private ConnectionPool $connectionPool,
     ) {}
 
     /**
@@ -44,24 +48,72 @@ final readonly class ContainerContextResolver
      */
     public function resolve(?int $containerUid, int $colPos, array $movedRecord): array
     {
+        $movedCType = (string) ($movedRecord['CType'] ?? '');
+        $pid = (int) ($movedRecord['pid'] ?? 0);
+
         if (null === $containerUid || 0 === $containerUid) {
+            // Rule 6: a container column number without a container would orphan
+            // the record — colPos set, tx_container_parent 0.
+            if (in_array($colPos, $this->allRegisteredContainerColPos(), true)) {
+                return $this->reject(sprintf('column %d is a container column but no container was given', $colPos));
+            }
+
             return $this->accept($colPos, 0);
         }
 
         // Rule 5: a container element itself must not be nested via drag & drop.
-        // Cycles are caught by EXT:container, but nesting is out of scope entirely.
-        $movedCType = (string) ($movedRecord['CType'] ?? '');
         if ($this->registry->isContainerElement($movedCType)) {
             return $this->reject('a container element cannot be dropped into a container');
         }
 
-        // Rule 3 (first stage): the column must belong to some registered
-        // container. Task 3 narrows this to the specific target container.
-        if (!in_array($colPos, $this->allRegisteredContainerColPos(), true)) {
-            return $this->reject(sprintf('column %d is not a registered container column', $colPos));
+        // Rule 1: the container must exist and live on the same page.
+        $container = $this->fetchRecord($containerUid);
+        if (null === $container) {
+            return $this->reject(sprintf('container %d not found', $containerUid));
+        }
+        if ((int) $container['pid'] !== $pid) {
+            return $this->reject(sprintf('container %d is on a different page', $containerUid));
+        }
+
+        // Rule 2: the target must actually be a container element.
+        $containerCType = (string) $container['CType'];
+        if (!$this->registry->isContainerElement($containerCType)) {
+            return $this->reject(sprintf('record %d is not a container element', $containerUid));
+        }
+
+        // Rule 3: the column must belong to THIS container.
+        $available = array_map(intval(...), $this->registry->getAllAvailableColumnsColPos($containerCType));
+        if (!in_array($colPos, $available, true)) {
+            return $this->reject(sprintf('column %d is not registered for container %d', $colPos, $containerUid));
+        }
+
+        // Rule 4: registry-based CType restriction — works without EXT:content_defender.
+        if (!$this->registry->isAllowedInColumn($movedCType, $colPos, $containerCType)) {
+            return $this->reject(sprintf('content type %s is not allowed in column %d', $movedCType, $colPos));
         }
 
         return $this->accept($colPos, $containerUid);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchRecord(int $uid): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $record = $queryBuilder
+            ->select('uid', 'pid', 'CType', 'deleted')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return is_array($record) ? $record : null;
     }
 
     /**

--- a/Classes/Service/Content/ContainerContextResolver.php
+++ b/Classes/Service/Content/ContainerContextResolver.php
@@ -13,14 +13,25 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Service\Content;
 
+use B13\Container\Tca\Registry;
+
+use function array_unique;
+use function array_values;
+use function in_array;
+use function sprintf;
+
 /**
  * ContainerContextResolver.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-final readonly class ContainerContextResolver
+final class ContainerContextResolver
 {
+    public function __construct(
+        private Registry $registry,
+    ) {}
+
     /**
      * Validate a drop target and resolve it to a column context.
      *
@@ -37,6 +48,19 @@ final readonly class ContainerContextResolver
             return $this->accept($colPos, 0);
         }
 
+        // Rule 5: a container element itself must not be nested via drag & drop.
+        // Cycles are caught by EXT:container, but nesting is out of scope entirely.
+        $movedCType = (string) ($movedRecord['CType'] ?? '');
+        if ($this->registry->isContainerElement($movedCType)) {
+            return $this->reject('a container element cannot be dropped into a container');
+        }
+
+        // Rule 3 (first stage): the column must belong to some registered
+        // container. Task 3 narrows this to the specific target container.
+        if (!in_array($colPos, $this->allRegisteredContainerColPos(), true)) {
+            return $this->reject(sprintf('column %d is not a registered container column', $colPos));
+        }
+
         return $this->accept($colPos, $containerUid);
     }
 
@@ -46,5 +70,28 @@ final readonly class ContainerContextResolver
     private function accept(int $colPos, int $containerUid): array
     {
         return ['valid' => true, 'colPos' => $colPos, 'containerUid' => $containerUid, 'error' => null];
+    }
+
+    /**
+     * @return array{valid: bool, colPos: int, containerUid: int, error: string|null}
+     */
+    private function reject(string $error): array
+    {
+        return ['valid' => false, 'colPos' => 0, 'containerUid' => 0, 'error' => $error];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function allRegisteredContainerColPos(): array
+    {
+        $colPositions = [];
+        foreach ($this->registry->getRegisteredCTypes() as $cType) {
+            foreach ($this->registry->getAllAvailableColumnsColPos($cType) as $colPos) {
+                $colPositions[] = (int) $colPos;
+            }
+        }
+
+        return array_values(array_unique($colPositions));
     }
 }

--- a/Classes/Service/Content/ContentMoveService.php
+++ b/Classes/Service/Content/ContentMoveService.php
@@ -34,22 +34,20 @@ final readonly class ContentMoveService
     public function __construct(
         private BackendUserService $backendUserService,
         private SettingsService $settingsService,
+        private ContainerContextResolver $containerContextResolver,
     ) {}
 
     /**
-     * Whether a record is within the MVP scope for frontend drag & drop.
+     * Whether a record is within scope for frontend drag & drop.
      *
-     * Container children (EXT:container) and translated elements are out of scope
-     * and keep the classic backend move button as fallback.
+     * Translated elements follow their parent's ordering, so reordering them
+     * would have no meaningful effect. Container children are in scope; their
+     * target is validated by ContainerContextResolver.
      *
      * @param array<string, mixed> $record
      */
     public function isMovable(array $record): bool
     {
-        if ((int) ($record['tx_container_parent'] ?? 0) > 0) {
-            return false;
-        }
-
         return (int) ($record['sys_language_uid'] ?? 0) <= 0;
     }
 
@@ -58,11 +56,12 @@ final readonly class ContentMoveService
      *
      * The target page is always derived from the record itself, so a crafted
      * request cannot move an element across pages (out of MVP scope). When a
-     * neighbour is given it must live on the same page.
+     * neighbour is given it must live on the same page and in the resolved
+     * column context.
      *
      * @return array{success: bool, statusCode: int, errors: list<string>}
      */
-    public function move(int $uid, int $targetColPos, ?int $targetUid): array
+    public function move(int $uid, int $targetColPos, ?int $targetUid, ?int $targetContainerUid = null): array
     {
         // Fetch all fields: tx_container_parent only exists when EXT:container is
         // installed, so it must not be named explicitly in the SELECT.
@@ -88,14 +87,16 @@ final readonly class ContentMoveService
             return $this->failure(403, 'You are not allowed to edit this content element');
         }
 
-        if (null !== $targetUid && $targetUid > 0) {
-            $neighbour = BackendUtility::getRecord('tt_content', $targetUid);
-            if (null === $neighbour || (int) $neighbour['pid'] !== $pid || !$this->isMovable($neighbour)) {
-                return $this->failure(422, 'Invalid drop target');
-            }
+        $context = $this->containerContextResolver->resolve($targetContainerUid, $targetColPos, $record);
+        if (!$context['valid']) {
+            return $this->failure(422, (string) $context['error']);
         }
 
-        $command = $this->buildMoveCommand($uid, $targetColPos, $targetUid, $pid);
+        if (null !== $targetUid && $targetUid > 0 && !$this->isValidNeighbour($targetUid, $pid, $context)) {
+            return $this->failure(422, 'Invalid drop target');
+        }
+
+        $command = $this->buildMoveCommand($uid, $context['colPos'], $targetUid, $pid, $context['containerUid']);
 
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $dataHandler->start([], $command, $this->backendUserService->getBackendUser());
@@ -109,7 +110,7 @@ final readonly class ContentMoveService
         // rewrite and even unset commands. Confirm the record actually landed
         // where it was asked to go.
         $moved = BackendUtility::getRecord('tt_content', $uid);
-        if (null === $moved || (int) $moved['colPos'] !== $targetColPos) {
+        if (!$this->wasMovedAsRequested($moved, $context)) {
             return $this->failure(409, 'The move was not applied as requested');
         }
 
@@ -153,6 +154,30 @@ final readonly class ContentMoveService
                 ],
             ],
         ];
+    }
+
+    /**
+     * @param array{valid: bool, colPos: int, containerUid: int, error: string|null} $context
+     */
+    private function isValidNeighbour(int $targetUid, int $pid, array $context): bool
+    {
+        $neighbour = BackendUtility::getRecord('tt_content', $targetUid);
+
+        return null !== $neighbour
+            && (int) $neighbour['pid'] === $pid
+            && (int) $neighbour['colPos'] === $context['colPos']
+            && (int) ($neighbour['tx_container_parent'] ?? 0) === $context['containerUid'];
+    }
+
+    /**
+     * @param array<string, mixed>|null                                              $moved
+     * @param array{valid: bool, colPos: int, containerUid: int, error: string|null} $context
+     */
+    private function wasMovedAsRequested(?array $moved, array $context): bool
+    {
+        return null !== $moved
+            && (int) $moved['colPos'] === $context['colPos']
+            && (int) ($moved['tx_container_parent'] ?? 0) === $context['containerUid'];
     }
 
     /**

--- a/Classes/Service/Content/ContentMoveService.php
+++ b/Classes/Service/Content/ContentMoveService.php
@@ -115,10 +115,20 @@ final readonly class ContentMoveService
      * record uid", a non-negative target is the page uid (insert as first element
      * in the target column). The colPos is applied via the move's update payload.
      *
-     * @return array<string, array<int, array{move: array{action: string, target: int, update: array{colPos: int}}}>>
+     * tx_container_parent is ALWAYS part of the payload, including the value 0.
+     * EXT:container forces it to 0 whenever colPos is set without it, which would
+     * silently orphan a container child; and its own target rewriting for the top
+     * of a container column only runs when both fields are present.
+     *
+     * @return array<string, array<int, array{move: array{action: string, target: int, update: array{colPos: int, tx_container_parent: int}}}>>
      */
-    public function buildMoveCommand(int $uid, int $targetColPos, ?int $targetUid, int $pid): array
-    {
+    public function buildMoveCommand(
+        int $uid,
+        int $targetColPos,
+        ?int $targetUid,
+        int $pid,
+        int $targetContainerUid = 0,
+    ): array {
         $target = null !== $targetUid && $targetUid > 0 ? -$targetUid : $pid;
 
         return [
@@ -127,7 +137,10 @@ final readonly class ContentMoveService
                     'move' => [
                         'action' => 'paste',
                         'target' => $target,
-                        'update' => ['colPos' => $targetColPos],
+                        'update' => [
+                            'colPos' => $targetColPos,
+                            'tx_container_parent' => $targetContainerUid,
+                        ],
                     ],
                 ],
             ],

--- a/Classes/Service/Content/ContentMoveService.php
+++ b/Classes/Service/Content/ContentMoveService.php
@@ -105,6 +105,14 @@ final readonly class ContentMoveService
             return $this->failure(400, ...array_map(strval(...), array_values($dataHandler->errorLog)));
         }
 
+        // An empty errorLog is not proof the move happened: EXT:container hooks
+        // rewrite and even unset commands. Confirm the record actually landed
+        // where it was asked to go.
+        $moved = BackendUtility::getRecord('tt_content', $uid);
+        if (null === $moved || (int) $moved['colPos'] !== $targetColPos) {
+            return $this->failure(409, 'The move was not applied as requested');
+        }
+
         return ['success' => true, 'statusCode' => 200, 'errors' => []];
     }
 

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -127,13 +127,16 @@ final readonly class ResourceRendererService
         $dragAndDropLabels = json_encode([
             'handle' => $this->translate('dnd.handle', 'Drag to reorder'),
             'success' => $this->translate('dnd.success', 'Content element moved'),
-            'successDetail' => $this->translate('dnd.successDetail', '“%s” was reordered within the column. The page was reloaded to reflect the change.'),
+            'successDetail' => $this->translate('dnd.successDetail', '”%s” was reordered within the column. The page was reloaded to reflect the change.'),
             'successDetailGeneric' => $this->translate('dnd.successDetailGeneric', 'The content element was reordered within the column. The page was reloaded to reflect the change.'),
-            'successDetailMoved' => $this->translate('dnd.successDetailMoved', '“%s” was moved to another column. The page was reloaded to reflect the change.'),
+            'successDetailMoved' => $this->translate('dnd.successDetailMoved', '”%s” was moved to another column. The page was reloaded to reflect the change.'),
             'successDetailMovedGeneric' => $this->translate('dnd.successDetailMovedGeneric', 'The content element was moved to another column. The page was reloaded to reflect the change.'),
             'error' => $this->translate('dnd.error', 'Could not move the content element'),
-            'errorDetail' => $this->translate('dnd.errorDetail', '“%s” could not be moved. Please try again.'),
+            'errorDetail' => $this->translate('dnd.errorDetail', '”%s” could not be moved. Please try again.'),
             'errorDetailGeneric' => $this->translate('dnd.errorDetailGeneric', 'The content element could not be moved. Please try again.'),
+            'rejected' => $this->translate('dnd.rejected', 'Cannot be dropped here'),
+            'rejectedDetail' => $this->translate('dnd.rejectedDetail', '”%s” cannot be placed at this position. Use the move dialog in the backend instead.'),
+            'rejectedDetailGeneric' => $this->translate('dnd.rejectedDetailGeneric', 'The content element cannot be placed at this position. Use the move dialog in the backend instead.'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $deleteLabels = json_encode([
             'title' => $this->translate('delete.confirm.title', 'Delete this record?'),

--- a/Classes/Service/Ui/ResourceRendererService.php
+++ b/Classes/Service/Ui/ResourceRendererService.php
@@ -127,15 +127,15 @@ final readonly class ResourceRendererService
         $dragAndDropLabels = json_encode([
             'handle' => $this->translate('dnd.handle', 'Drag to reorder'),
             'success' => $this->translate('dnd.success', 'Content element moved'),
-            'successDetail' => $this->translate('dnd.successDetail', '”%s” was reordered within the column. The page was reloaded to reflect the change.'),
+            'successDetail' => $this->translate('dnd.successDetail', '“%s” was reordered within the column. The page was reloaded to reflect the change.'),
             'successDetailGeneric' => $this->translate('dnd.successDetailGeneric', 'The content element was reordered within the column. The page was reloaded to reflect the change.'),
-            'successDetailMoved' => $this->translate('dnd.successDetailMoved', '”%s” was moved to another column. The page was reloaded to reflect the change.'),
+            'successDetailMoved' => $this->translate('dnd.successDetailMoved', '“%s” was moved to another column. The page was reloaded to reflect the change.'),
             'successDetailMovedGeneric' => $this->translate('dnd.successDetailMovedGeneric', 'The content element was moved to another column. The page was reloaded to reflect the change.'),
             'error' => $this->translate('dnd.error', 'Could not move the content element'),
-            'errorDetail' => $this->translate('dnd.errorDetail', '”%s” could not be moved. Please try again.'),
+            'errorDetail' => $this->translate('dnd.errorDetail', '“%s” could not be moved. Please try again.'),
             'errorDetailGeneric' => $this->translate('dnd.errorDetailGeneric', 'The content element could not be moved. Please try again.'),
             'rejected' => $this->translate('dnd.rejected', 'Cannot be dropped here'),
-            'rejectedDetail' => $this->translate('dnd.rejectedDetail', '”%s” cannot be placed at this position. Use the move dialog in the backend instead.'),
+            'rejectedDetail' => $this->translate('dnd.rejectedDetail', '“%s” cannot be placed at this position. Use the move dialog in the backend instead.'),
             'rejectedDetailGeneric' => $this->translate('dnd.rejectedDetailGeneric', 'The content element cannot be placed at this position. Use the move dialog in the backend instead.'),
         ], \JSON_HEX_TAG | \JSON_HEX_AMP) ?: '{}';
         $deleteLabels = json_encode([

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,6 +16,14 @@ services:
             $flashMessageService: '@Xima\XimaTypo3FrontendEdit\Service\Ui\FlashMessageService'
             $backendUserService: '@Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService'
 
+    # B13\Container\Tca\Registry only exists when EXT:container is installed
+    # (require-dev, not require) — '@?' resolves to null instead of a compile
+    # error when the service is absent.
+    Xima\XimaTypo3FrontendEdit\Service\Content\ContainerContextResolver:
+        arguments:
+            $registry: '@?B13\Container\Tca\Registry'
+            $connectionPool: '@TYPO3\CMS\Core\Database\ConnectionPool'
+
     Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator:
         arguments:
             $pageButtonBuilder: '@Xima\XimaTypo3FrontendEdit\Service\Menu\PageButtonBuilder'

--- a/Documentation/Configuration/SiteSettings.rst
+++ b/Documentation/Configuration/SiteSettings.rst
@@ -171,8 +171,9 @@ Appearance Settings
 
     Requires your Fluid template to mark each column with the
     :php:`ColumnTargetViewHelper`; without those markers no drag handle is
-    rendered. Container children and translated elements are out of scope and
-    keep the backend move dialog.
+    rendered. Columns of EXT:container elements are supported when the template passes
+    ``containerUid``. Translated elements and nesting a container inside another
+    container keep the backend move dialog.
 
     See :ref:`drag-and-drop` for details on how to use this feature.
 

--- a/Documentation/Usage/DragAndDrop.rst
+++ b/Documentation/Usage/DragAndDrop.rst
@@ -75,19 +75,40 @@ The target page is always derived from the moved record itself. A manipulated
 request therefore cannot move an element to a different page — cross-page moves
 remain a backend operation.
 
+Container columns
+=================
+
+Columns of an `EXT:container <https://github.com/b13/container>`__ element are
+drop targets as well, as long as the template marks them with the container's
+uid:
+
+..  code-block:: html
+
+    {namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+
+    <xfe:columnTarget colPos="201" containerUid="{data.uid}" />
+
+Content can be reordered inside a container column, moved between the columns of
+a container, moved out into a page column and moved from a page column into a
+container.
+
+A container element itself can be reordered within page columns, but cannot be
+dropped into another container — nesting stays a backend operation.
+
 Limitations
 ===========
 
 The following cases are out of scope and keep the classic **move** button in
 the :ref:`edit menu <edit-menu>` as a fallback:
 
-Container children
-    Content elements nested inside an EXT:container element cannot be dragged.
-
 Translated elements
     Only default-language elements can be reordered. Translations follow the
     ordering of their parent record, so reordering a translation would have no
     meaningful effect.
+
+Nesting containers
+    A container element cannot be dropped into another container. Use the
+    **move** button in the edit menu for that.
 
 Keyboard operation
     Dragging relies on the browser's native drag & drop, which is pointer-only.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This TYPO3 extension adds lightweight editing tools to the frontend, allowing ba
 - **Content Element Editing**
   - [Edit Dropdown Menu](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/EditMenu.html) - Quick access to edit, hide, delete, and move content elements, with confirmation before deleting records
   - [Contextual Editing](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/ContextualEditing.html) - Edit content directly in the frontend (experimental)
-  - [Drag & Drop Reordering](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/DragAndDrop.html) - Reorder content elements within and between columns directly in the frontend (experimental, requires `frontendEdit.enableDragAndDrop`)
+  - [Drag & Drop Reordering](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/DragAndDrop.html) - Reorder content elements within and between columns, including EXT:container columns, directly in the frontend (experimental, requires `frontendEdit.enableDragAndDrop`)
   - New Content Elements - Create new content elements via TYPO3's native New Content Element Wizard, hosted in the slide-in iframe modal on both v13 and v14 (requires `frontendEdit.enableContextualEditing`)
 - **Page Toolbar**
   - [Toolbar](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Usage/Toolbar.html) - Page-level actions and toggle for frontend editing
@@ -50,7 +50,7 @@ Edit content elements directly in the frontend without navigating to the backend
 Reorder content elements directly in the frontend by dragging them within a column or across columns on the same page. The move is persisted through TYPO3's core DataHandler — the same mechanism the backend page module uses. Enable via Site Settings: `frontendEdit.enableDragAndDrop: true`
 
 > [!NOTE]
-> Drag & drop relies on the same `data-xfe-colpos` column markers used by the [column target buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html). Your Fluid template must mark each column so its `colPos` can be resolved. Nested containers (EXT:container) and translated elements are out of scope and keep the classic backend move dialog.
+> Drag & drop relies on the same `data-xfe-colpos` column markers used by the [column target buttons](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/DeveloperCorner/EmptyColumns.html). Your Fluid template must mark each column so its `colPos` can be resolved. Translated elements and nesting a container inside another container keep the classic backend move dialog.
 
 > [!IMPORTANT]
 > **Delineation and classification**: This is **not** a further development of the "original" extension [frontend_editing](https://extensions.typo3.org/extension/frontend_editing). It is similar in some ways to the realisation of the [feedit](https://extensions.typo3.org/extension/feedit) extension. This extension is an independent implementation with a different approach. See the [Delineation](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Delineation/Index.html) page in the documentation for a detailed comparison with related extensions like [visual_editor](https://github.com/FriendsOfTYPO3/visual_editor) and [content_preview](https://github.com/T3-UX/content_preview).

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -167,6 +167,18 @@
 				<source />
 				<target>Das Inhaltselement konnte nicht verschoben werden. Bitte versuche es erneut.</target>
 			</trans-unit>
+			<trans-unit id="dnd.rejected">
+				<source />
+				<target>Hier kann nicht abgelegt werden</target>
+			</trans-unit>
+			<trans-unit id="dnd.rejectedDetail">
+				<source />
+				<target>„%s" kann an dieser Stelle nicht platziert werden. Nutze den Verschieben-Dialog im Backend.</target>
+			</trans-unit>
+			<trans-unit id="dnd.rejectedDetailGeneric">
+				<source />
+				<target>Das Inhaltselement kann an dieser Stelle nicht platziert werden. Nutze den Verschieben-Dialog im Backend.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -173,7 +173,7 @@
 			</trans-unit>
 			<trans-unit id="dnd.rejectedDetail">
 				<source />
-				<target>„%s" kann an dieser Stelle nicht platziert werden. Nutze den Verschieben-Dialog im Backend.</target>
+				<target>„%s“ kann an dieser Stelle nicht platziert werden. Nutze den Verschieben-Dialog im Backend.</target>
 			</trans-unit>
 			<trans-unit id="dnd.rejectedDetailGeneric">
 				<source />

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -130,7 +130,7 @@
 				<source>Cannot be dropped here</source>
 			</trans-unit>
 			<trans-unit id="dnd.rejectedDetail">
-				<source>"%s" cannot be placed at this position. Use the move dialog in the backend instead.</source>
+				<source>“%s” cannot be placed at this position. Use the move dialog in the backend instead.</source>
 			</trans-unit>
 			<trans-unit id="dnd.rejectedDetailGeneric">
 				<source>The content element cannot be placed at this position. Use the move dialog in the backend instead.</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -126,6 +126,15 @@
 			<trans-unit id="dnd.errorDetailGeneric">
 				<source>The content element could not be moved. Please try again.</source>
 			</trans-unit>
+			<trans-unit id="dnd.rejected">
+				<source>Cannot be dropped here</source>
+			</trans-unit>
+			<trans-unit id="dnd.rejectedDetail">
+				<source>"%s" cannot be placed at this position. Use the move dialog in the backend instead.</source>
+			</trans-unit>
+			<trans-unit id="dnd.rejectedDetailGeneric">
+				<source>The content element cannot be placed at this position. Use the move dialog in the backend instead.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -259,6 +259,16 @@
     box-sizing: border-box;
 }
 
+/* Element: toolbar-separator - divides grouped items within a toolbar pill */
+.frontend-edit__toolbar-separator {
+    width: 1px;
+    height: 16px;
+    background: var(--xfe-border-color);
+    opacity: 0.5;
+    margin: 0 2px;
+    flex-shrink: 0;
+}
+
 /* Element: btn - toolbar buttons */
 .frontend-edit__btn {
     position: relative;
@@ -1393,6 +1403,17 @@
 
 .frontend-edit__btn.frontend-edit__btn--drag:active {
     cursor: grabbing;
+}
+
+/* The handle sits inside the slim label pill (not the actions pill), so it
+   shrinks to icon size and drops the button hover background. */
+.frontend-edit__toolbar-label .frontend-edit__btn.frontend-edit__btn--drag {
+    width: 16px;
+    height: 16px;
+}
+
+.frontend-edit__toolbar-label .frontend-edit__btn.frontend-edit__btn--drag:hover {
+    background: transparent;
 }
 
 /* While dragging, let pointer hit-testing (elementFromPoint) fall through the

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -805,12 +805,20 @@
       container.appendChild(editBtn);
 
       if (showContextMenu && contentElement.menu.children && Object.keys(contentElement.menu.children).length > 0) {
+        container.appendChild(this.createSeparator());
         const kebabBtn = this.createKebabButton(uid);
         Tooltip.attach(kebabBtn);
         container.appendChild(kebabBtn);
       }
 
       return container;
+    },
+
+    createSeparator() {
+      const separator = document.createElement('div');
+      separator.className = 'frontend-edit__toolbar-separator';
+      separator.setAttribute('aria-hidden', 'true');
+      return separator;
     },
 
     createEditButton(contentElement) {
@@ -1485,11 +1493,11 @@
         const uid = parseInt(toolbar.dataset.cid, 10);
         if (!Number.isFinite(uid) || !this.findColumnForUid(uid)) return;
 
-        // Place the handle inside the visible action group (with edit/kebab),
-        // not as a bare toolbar child — the toolbar splits label (left) and
-        // actions (right), so a bare child would sit hidden behind the label.
-        const actions = toolbar.querySelector('.frontend-edit__toolbar-actions');
-        if (!actions) return;
+        // Place the handle at the end of the label pill (left side), separated
+        // by a divider — not in the actions group — so it sits next to the
+        // element-type display rather than crowding the edit/kebab buttons.
+        const labelGroup = toolbar.querySelector('.frontend-edit__toolbar-label');
+        if (!labelGroup) return;
 
         const handle = document.createElement('button');
         handle.type = 'button';
@@ -1508,7 +1516,8 @@
         handle.addEventListener('dragstart', (e) => this.onDragStart(e, uid));
         handle.addEventListener('dragend', () => this.onDragEnd());
         Tooltip.attach(handle);
-        actions.insertBefore(handle, actions.firstChild);
+        labelGroup.appendChild(UI.createSeparator());
+        labelGroup.appendChild(handle);
       });
     },
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1377,11 +1377,12 @@
   /**
    * Drag & Drop Reordering (MVP)
    *
-   * Reorders content elements within and between page-level columns by
-   * delegating to the core DataHandler via the move endpoint. Scope is limited
-   * to the default language and columns the integrator marked with
-   * [data-xfe-colpos] (without [data-xfe-container]). Nested container children
-   * and translated elements keep the classic backend move dialog.
+   * Reorders content elements within and between page-level columns and
+   * EXT:container columns by delegating to the core DataHandler via the move
+   * endpoint. Scope is limited to the default language and columns the
+   * integrator marked with [data-xfe-colpos]; container columns additionally
+   * carry [data-xfe-container] with the container's uid. Translated elements
+   * keep the classic backend move dialog.
    */
   const DragReorder = {
     moveUrl: null,
@@ -1418,12 +1419,20 @@
     },
 
     collectColumns() {
-      document.querySelectorAll('[data-xfe-colpos]:not([data-xfe-container])').forEach(marker => {
+      // Container columns carry data-xfe-container with the container's uid; page
+      // columns have no such attribute. Both are drop targets, but only the former
+      // may set tx_container_parent.
+      document.querySelectorAll('[data-xfe-colpos]').forEach(marker => {
         const colPos = parseInt(marker.dataset.xfeColpos, 10);
         const container = marker.parentElement;
         if (!Number.isFinite(colPos) || !container) return;
+        const rawContainerUid = marker.dataset.xfeContainer;
+        const containerUid = rawContainerUid === undefined
+          ? null
+          : parseInt(rawContainerUid, 10);
+        if (containerUid !== null && !Number.isFinite(containerUid)) return;
         if (this.columns.some(c => c.container === container && c.colPos === colPos)) return;
-        this.columns.push({ colPos, container });
+        this.columns.push({ colPos, container, containerUid });
       });
     },
 
@@ -1434,8 +1443,8 @@
     getColumnElements(container) {
       const items = [];
       const containers = this.columns.map(c => c.container);
-      container.querySelectorAll('[id]').forEach(el => {
-        const match = el.id.match(/^c(\d+)$/);
+      container.querySelectorAll('[id^="c"]').forEach(el => {
+        const match = Dom.id(el).match(/^c(\d+)$/);
         if (!match) return;
         const uid = parseInt(match[1], 10);
         if (uid <= 0) return;
@@ -1613,7 +1622,7 @@
         }
       }
 
-      this.dropTarget = { colPos: col.colPos, afterUid };
+      this.dropTarget = { colPos: col.colPos, afterUid, containerUid: col.containerUid };
       this.showIndicator(col.container, indicatorTop);
     },
 
@@ -1621,16 +1630,22 @@
       if (!this.dragging || !this.dropTarget) { this.onDragEnd(); return; }
       e.preventDefault();
       const { uid } = this.dragging;
-      const { colPos, afterUid } = this.dropTarget;
+      const { colPos, afterUid, containerUid } = this.dropTarget;
       const header = this.elementLabel(this.draggingBlock);
       // Distinguish a reorder within the same column from a move to another one.
       // Unknown source (null) is treated as a cross-column move.
       const sameColumn = null != this.dragging.sourceColPos && this.dragging.sourceColPos === colPos;
       this.onDragEnd();
-      void this.persistMove(uid, colPos, afterUid, header, sameColumn);
+      void this.persistMove(uid, colPos, afterUid, header, sameColumn, containerUid);
     },
 
-    async persistMove(uid, targetColPos, targetUid, header, sameColumn) {
+    rememberNotification(title, message, severity) {
+      try {
+        sessionStorage.setItem('xfe-pending-notification', JSON.stringify({ title, message, severity }));
+      } catch (_) { /* storage unavailable — the reload just shows no toast */ }
+    },
+
+    async persistMove(uid, targetColPos, targetUid, header, sameColumn, targetContainerUid) {
       const config = document.getElementById('frontend-edit-toolbar-config');
       const language = config ? parseInt(config.dataset.language || '0', 10) : 0;
       const L = this.labels;
@@ -1645,21 +1660,37 @@
       const errorMsg = header
         ? (L.errorDetail || '“%s” could not be moved. Please try again.').replace('%s', header)
         : (L.errorDetailGeneric || 'The content element could not be moved. Please try again.');
+      const rejectedMsg = header
+        ? (L.rejectedDetail || '“%s” cannot be placed at this position. Use the move dialog in the backend instead.').replace('%s', header)
+        : (L.rejectedDetailGeneric || 'The content element cannot be placed at this position. Use the move dialog in the backend instead.');
       try {
         const response = await fetch(this.moveUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ uid, targetColPos, targetUid, language })
+          body: JSON.stringify({ uid, targetColPos, targetUid, language, targetContainerUid: targetContainerUid ?? null })
         });
+
+        // 422 means the drop is refused for good: retrying changes nothing, so
+        // say that instead of "please try again", and do not reload.
+        if (response.status === 422) {
+          Notification.show({
+            title: L.rejected || 'Cannot be dropped here',
+            message: rejectedMsg,
+            severity: 'error'
+          });
+          return;
+        }
+
+        // 409 means the outcome is uncertain — reload so the editor sees reality.
+        if (response.status === 409) {
+          this.rememberNotification(L.error || 'Could not move the content element', errorMsg, 'error');
+          window.location.reload();
+          return;
+        }
+
         if (!response.ok) throw new Error(`move failed (${response.status})`);
 
-        try {
-          sessionStorage.setItem('xfe-pending-notification', JSON.stringify({
-            title: L.success || 'Content element moved',
-            message: successMsg,
-            severity: 'ok'
-          }));
-        } catch (_) { /* ignore */ }
+        this.rememberNotification(L.success || 'Content element moved', successMsg, 'ok');
         window.location.reload();
       } catch (error) {
         Logger.log('Drag & drop move failed', { error: error.message }, 'error');

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1654,24 +1654,39 @@
       } catch (_) { /* storage unavailable — the reload just shows no toast */ }
     },
 
+    // Picks the header-specific detail label (with "%s" substituted) when a
+    // header is known, otherwise the generic label — falling back to English
+    // defaults if the label itself is missing.
+    formatMoveMessage(detail, detailGeneric, fallback, fallbackGeneric, header) {
+      return header
+        ? (detail || fallback).replace('%s', header)
+        : (detailGeneric || fallbackGeneric);
+    },
+
     async persistMove(uid, targetColPos, targetUid, header, sameColumn, targetContainerUid) {
       const config = document.getElementById('frontend-edit-toolbar-config');
       const language = config ? parseInt(config.dataset.language || '0', 10) : 0;
       const L = this.labels;
       // "OK" is the TYPO3 severity that maps to the green success styling.
-      const detail = sameColumn ? L.successDetail : L.successDetailMoved;
-      const detailGeneric = sameColumn ? L.successDetailGeneric : L.successDetailMovedGeneric;
-      const fallback = sameColumn ? '“%s” was reordered within the column.' : '“%s” was moved to another column.';
-      const fallbackGeneric = sameColumn ? 'The content element was reordered within the column.' : 'The content element was moved to another column.';
-      const successMsg = header
-        ? (detail || fallback).replace('%s', header)
-        : (detailGeneric || fallbackGeneric);
-      const errorMsg = header
-        ? (L.errorDetail || '“%s” could not be moved. Please try again.').replace('%s', header)
-        : (L.errorDetailGeneric || 'The content element could not be moved. Please try again.');
-      const rejectedMsg = header
-        ? (L.rejectedDetail || '“%s” cannot be placed at this position. Use the move dialog in the backend instead.').replace('%s', header)
-        : (L.rejectedDetailGeneric || 'The content element cannot be placed at this position. Use the move dialog in the backend instead.');
+      const successMsg = this.formatMoveMessage(
+        sameColumn ? L.successDetail : L.successDetailMoved,
+        sameColumn ? L.successDetailGeneric : L.successDetailMovedGeneric,
+        sameColumn ? '“%s” was reordered within the column.' : '“%s” was moved to another column.',
+        sameColumn ? 'The content element was reordered within the column.' : 'The content element was moved to another column.',
+        header
+      );
+      const errorMsg = this.formatMoveMessage(
+        L.errorDetail, L.errorDetailGeneric,
+        '“%s” could not be moved. Please try again.',
+        'The content element could not be moved. Please try again.',
+        header
+      );
+      const rejectedMsg = this.formatMoveMessage(
+        L.rejectedDetail, L.rejectedDetailGeneric,
+        '“%s” cannot be placed at this position. Use the move dialog in the backend instead.',
+        'The content element cannot be placed at this position. Use the move dialog in the backend instead.',
+        header
+      );
       try {
         const response = await fetch(this.moveUrl, {
           method: 'POST',

--- a/Tests/Acceptance/Fixtures/demo-content.sql
+++ b/Tests/Acceptance/Fixtures/demo-content.sql
@@ -111,7 +111,9 @@ REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`
 -- Assign backend layout "2 Columns 50/50" to page 8
 UPDATE `pages` SET `backend_layout` = 'pagets__2_columns_50_50' WHERE `uid` = 8;
 
--- sys_template: add sitepackage template override for page templates with <xfe:columnTarget> markers
+-- sys_template: add sitepackage template override for page templates with <xfe:columnTarget> markers,
+-- plus a partial override so EXT:container's 2-column layout marks its columns for drag & drop too
+-- (the bk2k/bootstrap-package stock partial renders container children without any xfe markers).
 REPLACE INTO `sys_template` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `title`, `root`, `clear`, `config`) VALUES
 (2, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'Sitepackage Override', 0, 0,
-'page.10.templateRootPaths.100 = EXT:sitepackage/Resources/Private/Templates/Page/\n');
+'page.10.templateRootPaths.100 = EXT:sitepackage/Resources/Private/Templates/Page/\ntt_content.container_2_columns.partialRootPaths.100 = EXT:sitepackage/Resources/Private/Partials/ContentElements/\n');

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Partials/ContentElements/Container/Rendering/Container2Columns.html
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Partials/ContentElements/Container/Rendering/Container2Columns.html
@@ -1,0 +1,14 @@
+{namespace xfe=Xima\XimaTypo3FrontendEdit\ViewHelpers}
+
+<div class="contentcontainer-column" data-container-column="left">
+    <xfe:columnTarget colPos="201" containerUid="{data.uid}" />
+    <f:for each="{children_201}" as="record">
+        <f:format.raw>{record.renderedContent}</f:format.raw>
+    </f:for>
+</div>
+<div class="contentcontainer-column" data-container-column="right">
+    <xfe:columnTarget colPos="202" containerUid="{data.uid}" />
+    <f:for each="{children_202}" as="record">
+        <f:format.raw>{record.renderedContent}</f:format.raw>
+    </f:for>
+</div>

--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use Composer\Autoload;
 use ShipMonk\ComposerDependencyAnalyser;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 $rootPath = dirname(__DIR__, 2);
 
@@ -31,6 +32,12 @@ $configuration
     ->ignoreUnknownClasses([
         'TYPO3\CMS\Core\Authentication\AccessCheckResult',
     ])
+    // b13/container is a deliberately optional integration: ContainerContextResolver
+    // takes a nullable Registry (Configuration/Services.yaml wires it via the Symfony
+    // "@?" optional service reference), so a site without EXT:container still boots and
+    // simply rejects container-column moves. Moving it to "require" would force every
+    // consumer to install EXT:container even when they never use it.
+    ->ignoreErrorsOnPackage('b13/container', [ErrorType::DEV_DEPENDENCY_IN_PROD])
 ;
 
 return $configuration;

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -251,6 +251,24 @@ final class AjaxControllerTest extends FunctionalTestCase
         self::assertNotSame(403, $response->getStatusCode());
     }
 
+    #[Test]
+    public function moveActionRejectsInvalidContainerUid(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $request = $this->createMoveRequest()->withBody($this->stream((string) json_encode([
+            'uid' => 9999,
+            'targetColPos' => 201,
+            'targetContainerUid' => -5,
+            'language' => 0,
+        ])));
+
+        $response = $this->subject->moveAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('targetContainerUid', (string) $this->decode($response)['error']);
+    }
+
     /**
      * @param array<string, string> $queryParams
      */

--- a/Tests/Functional/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Functional/Service/Content/ContentMoveServiceTest.php
@@ -170,8 +170,6 @@ final class ContentMoveServiceTest extends FunctionalTestCase
     #[Test]
     public function moveRejectsContainerColumnWithoutContainerUid(): void
     {
-        $before = $this->readRecord(1);
-
         // The orphan path: colPos 201 with no container would leave a container
         // column number without a container binding.
         $result = $this->subject->move(1, 201, null, null);

--- a/Tests/Functional/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Functional/Service/Content/ContentMoveServiceTest.php
@@ -135,6 +135,18 @@ final class ContentMoveServiceTest extends FunctionalTestCase
         );
     }
 
+    #[Test]
+    public function moveVerificationAcceptsACorrectlyAppliedMove(): void
+    {
+        // Pins the verification against false negatives: a move that really did
+        // land where it was asked to go must still report success.
+        $result = $this->subject->move(1, 0, 2);
+
+        self::assertTrue($result['success']);
+        self::assertSame(200, $result['statusCode']);
+        self::assertSame(0, (int) $this->readRecord(1)['colPos']);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/Tests/Functional/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Functional/Service/Content/ContentMoveServiceTest.php
@@ -221,6 +221,22 @@ final class ContentMoveServiceTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function moveRejectsNeighbourFromADifferentColumnOfTheSameContainer(): void
+    {
+        $before = $this->readRecord(1);
+
+        // (container 3, column 201) resolves fine, but neighbour 6 actually
+        // lives in column 202 of that same container — isValidNeighbour() must
+        // catch the colPos mismatch that resolve() itself cannot see.
+        $result = $this->subject->move(1, 201, 6, 3);
+
+        self::assertFalse($result['success']);
+        self::assertSame(422, $result['statusCode']);
+        self::assertSame((int) $before['colPos'], (int) $this->readRecord(1)['colPos']);
+        self::assertSame((int) $before['sorting'], (int) $this->readRecord(1)['sorting']);
+    }
+
+    #[Test]
     public function moveReordersPlainElementWithinPageColumn(): void
     {
         $result = $this->subject->move(1, 0, 2);

--- a/Tests/Functional/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Functional/Service/Content/ContentMoveServiceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Functional\Service\Content;
 
+use B13\Container\Tca\{ContainerConfiguration, Registry};
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,6 +47,7 @@ final class ContentMoveServiceTest extends FunctionalTestCase
         parent::setUp();
 
         $this->writeDragAndDropSiteConfiguration();
+        $this->registerTestContainer();
 
         $this->importCSVDataSet(__DIR__.'/Fixtures/pages.csv');
         $this->importCSVDataSet(__DIR__.'/Fixtures/tt_content_container.csv');
@@ -69,24 +71,130 @@ final class ContentMoveServiceTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function moveRejectsContainerChildWithoutTouchingTheRecord(): void
+    public function moveReordersWithinContainerColumn(): void
     {
-        $before = $this->readRecord(4);
+        $result = $this->subject->move(4, 201, 5, 3);
 
-        // Reordering within its own container column — the case that silently
-        // orphaned the record before the guard existed: EXT:container forces
-        // tx_container_parent to 0 whenever a move command sets colPos without
-        // also setting tx_container_parent.
-        $result = $this->subject->move(4, 201, 5);
+        self::assertTrue($result['success']);
+
+        $moved = $this->readRecord(4);
+        self::assertSame(201, (int) $moved['colPos']);
+        self::assertSame(3, (int) $moved['tx_container_parent'], 'container binding must survive');
+        self::assertGreaterThan((int) $this->readRecord(5)['sorting'], (int) $moved['sorting']);
+    }
+
+    #[Test]
+    public function moveBetweenColumnsOfSameContainer(): void
+    {
+        $result = $this->subject->move(4, 202, 6, 3);
+
+        self::assertTrue($result['success']);
+
+        $moved = $this->readRecord(4);
+        self::assertSame(202, (int) $moved['colPos']);
+        self::assertSame(3, (int) $moved['tx_container_parent']);
+    }
+
+    #[Test]
+    public function moveOutOfContainerIntoPageColumn(): void
+    {
+        $result = $this->subject->move(4, 0, 1, null);
+
+        self::assertTrue($result['success']);
+
+        $moved = $this->readRecord(4);
+        self::assertSame(0, (int) $moved['colPos']);
+        self::assertSame(0, (int) $moved['tx_container_parent'], 'must leave the container');
+    }
+
+    #[Test]
+    public function moveFromPageColumnIntoEmptyContainerColumn(): void
+    {
+        // Column 202 of container 8 holds nothing, so there is no neighbour.
+        $result = $this->subject->move(1, 202, null, 8);
+
+        self::assertTrue($result['success']);
+
+        $moved = $this->readRecord(1);
+        self::assertSame(202, (int) $moved['colPos']);
+        self::assertSame(8, (int) $moved['tx_container_parent']);
+    }
+
+    #[Test]
+    public function moveBetweenDifferentContainers(): void
+    {
+        $result = $this->subject->move(4, 201, 9, 8);
+
+        self::assertTrue($result['success']);
+
+        $moved = $this->readRecord(4);
+        self::assertSame(201, (int) $moved['colPos']);
+        self::assertSame(8, (int) $moved['tx_container_parent']);
+    }
+
+    #[Test]
+    public function moveRejectsContainerIntoContainer(): void
+    {
+        $result = $this->subject->move(8, 201, null, 3);
+
+        self::assertFalse($result['success']);
+        self::assertSame(422, $result['statusCode']);
+        self::assertSame(0, (int) $this->readRecord(8)['tx_container_parent']);
+    }
+
+    #[Test]
+    public function moveRejectsDisallowedContentTypeInRestrictedColumn(): void
+    {
+        $before = $this->readRecord(1);
+
+        $result = $this->subject->move(1, 203, null, 3);
 
         self::assertFalse($result['success']);
         self::assertSame(422, $result['statusCode']);
 
-        $after = $this->readRecord(4);
+        $after = $this->readRecord(1);
+        self::assertSame(0, (int) $after['colPos'], 'must stay in its page column');
+        self::assertSame((int) $before['sorting'], (int) $after['sorting']);
+    }
 
-        self::assertSame(3, (int) $after['tx_container_parent'], 'container binding must survive a rejected move');
-        self::assertSame(201, (int) $after['colPos']);
-        self::assertSame((int) $before['sorting'], (int) $after['sorting'], 'sorting must not change');
+    #[Test]
+    public function moveRejectsContainerOnAnotherPage(): void
+    {
+        $result = $this->subject->move(1, 201, null, 11);
+
+        self::assertFalse($result['success']);
+        self::assertSame(422, $result['statusCode']);
+        self::assertSame(0, (int) $this->readRecord(1)['colPos']);
+    }
+
+    #[Test]
+    public function moveRejectsContainerColumnWithoutContainerUid(): void
+    {
+        $before = $this->readRecord(1);
+
+        // The orphan path: colPos 201 with no container would leave a container
+        // column number without a container binding.
+        $result = $this->subject->move(1, 201, null, null);
+
+        self::assertFalse($result['success']);
+        self::assertSame(422, $result['statusCode']);
+
+        $after = $this->readRecord(1);
+        self::assertSame(0, (int) $after['colPos']);
+        self::assertSame(0, (int) $after['tx_container_parent']);
+    }
+
+    #[Test]
+    public function moveRejectsSoftDeletedContainerAsDropTarget(): void
+    {
+        // Container 12 exists (uid matches) but is soft-deleted; the resolver's
+        // "deleted = 0" filter must reject it same as a missing container,
+        // distinct from a plain uid mismatch.
+        $result = $this->subject->move(1, 201, null, 12);
+
+        self::assertFalse($result['success']);
+        self::assertSame(422, $result['statusCode']);
+        self::assertSame(0, (int) $this->readRecord(1)['colPos']);
     }
 
     #[Test]
@@ -99,21 +207,17 @@ final class ContentMoveServiceTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function moveRejectsContainerChildAsDropTarget(): void
+    public function moveRejectsContainerChildAsDropTargetWithoutContainerUid(): void
     {
         $before = $this->readRecord(1);
 
-        // A plain element must not be dropped next to a container child, which
-        // would place it in a container column without a container parent.
-        $result = $this->subject->move(1, 201, 4);
+        // Neighbour 4 lives in container column 201; without a containerUid the
+        // resolver must refuse rather than orphan the element.
+        $result = $this->subject->move(1, 201, 4, null);
 
         self::assertFalse($result['success']);
         self::assertSame(422, $result['statusCode']);
-
-        $after = $this->readRecord(1);
-
-        self::assertSame(0, (int) $after['colPos'], 'rejected element must stay in its page column');
-        self::assertSame((int) $before['sorting'], (int) $after['sorting']);
+        self::assertSame((int) $before['colPos'], (int) $this->readRecord(1)['colPos']);
     }
 
     #[Test]
@@ -135,16 +239,27 @@ final class ContentMoveServiceTest extends FunctionalTestCase
         );
     }
 
-    #[Test]
-    public function moveVerificationAcceptsACorrectlyAppliedMove(): void
+    /**
+     * Registers a container CType via the public b13/container API. The fixture
+     * cannot use bootstrap-package's container_2_columns: that package is only
+     * installed in the ddev demo, not in require-dev.
+     */
+    private function registerTestContainer(): void
     {
-        // Pins the verification against false negatives: a move that really did
-        // land where it was asked to go must still report success.
-        $result = $this->subject->move(1, 0, 2);
+        $configuration = new ContainerConfiguration(
+            'test_container',
+            'Test container',
+            'Two columns plus a restricted one',
+            [
+                [
+                    ['name' => 'Left', 'colPos' => 201],
+                    ['name' => 'Right', 'colPos' => 202],
+                    ['name' => 'Images only', 'colPos' => 203, 'allowedContentTypes' => 'image'],
+                ],
+            ],
+        );
 
-        self::assertTrue($result['success']);
-        self::assertSame(200, $result['statusCode']);
-        self::assertSame(0, (int) $this->readRecord(1)['colPos']);
+        $this->get(Registry::class)->configureContainer($configuration);
     }
 
     /**

--- a/Tests/Functional/Service/Content/Fixtures/tt_content_container.csv
+++ b/Tests/Functional/Service/Content/Fixtures/tt_content_container.csv
@@ -2,8 +2,13 @@
 ,"uid","pid","sys_language_uid","l18n_parent","CType","colPos","tx_container_parent","sorting","header","hidden","deleted"
 ,1,1,0,0,"text",0,0,256,"Plain first",0,0
 ,2,1,0,0,"text",0,0,512,"Plain second",0,0
-,3,1,0,0,"container_2_columns",0,0,768,"Two column container",0,0
+,3,1,0,0,"test_container",0,0,768,"First container",0,0
 ,4,1,0,0,"text",201,3,256,"Left child first",0,0
 ,5,1,0,0,"text",201,3,512,"Left child second",0,0
 ,6,1,0,0,"text",202,3,256,"Right child",0,0
 ,7,1,1,1,"text",0,0,1024,"Translated plain",0,0
+,8,1,0,0,"test_container",0,0,1280,"Second container",0,0
+,9,1,0,0,"text",201,8,256,"Second container child",0,0
+,10,1,0,0,"text",203,3,256,"Restricted column child",0,0
+,11,2,0,0,"test_container",0,0,256,"Container on another page",0,0
+,12,1,0,0,"test_container",0,0,1536,"Soft-deleted container",0,1

--- a/Tests/Unit/Service/Content/ContainerContextResolverTest.php
+++ b/Tests/Unit/Service/Content/ContainerContextResolverTest.php
@@ -17,6 +17,7 @@ use B13\Container\Tca\Registry;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use Xima\XimaTypo3FrontendEdit\Service\Content\ContainerContextResolver;
 
 /**
@@ -45,17 +46,6 @@ final class ContainerContextResolverTest extends TestCase
     }
 
     #[Test]
-    public function resolveRejectsColumnNotRegisteredForAnyContainer(): void
-    {
-        $this->registerContainer('test_container', [201, 202]);
-
-        $result = $this->createSubject()->resolve(3, 999, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
-
-        self::assertFalse($result['valid']);
-        self::assertStringContainsString('column 999', (string) $result['error']);
-    }
-
-    #[Test]
     public function resolveRejectsMovingAContainerIntoAContainer(): void
     {
         $this->registerContainer('test_container', [201, 202]);
@@ -64,6 +54,99 @@ final class ContainerContextResolverTest extends TestCase
 
         self::assertFalse($result['valid']);
         self::assertStringContainsString('container element', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsMissingContainer(): void
+    {
+        $this->registerContainer('test_container', [201]);
+
+        $result = $this->createSubject([])->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('not found', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsContainerOnAnotherPage(): void
+    {
+        $this->registerContainer('test_container', [201]);
+
+        $result = $this->createSubject([
+            ['uid' => 3, 'pid' => 99, 'CType' => 'test_container'],
+        ])->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('different page', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsTargetThatIsNotAContainerElement(): void
+    {
+        $this->registerContainer('test_container', [201]);
+
+        $result = $this->createSubject([
+            ['uid' => 3, 'pid' => 1, 'CType' => 'text'],
+        ])->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('not a container', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsColumnNotBelongingToThisContainer(): void
+    {
+        $this->registerContainer('test_container', [201]);
+        $this->registerContainer('other_container', [301]);
+
+        // 301 is a registered container column, but not one of test_container's.
+        $result = $this->createSubject([
+            ['uid' => 3, 'pid' => 1, 'CType' => 'test_container'],
+        ])->resolve(3, 301, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('column 301', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsDisallowedContentType(): void
+    {
+        $this->registerContainer('test_container', [201]);
+        $GLOBALS['TCA']['tt_content']['containerConfiguration']['test_container']['grid'][0][0]['allowedContentTypes'] = 'image';
+
+        $result = $this->createSubject([
+            ['uid' => 3, 'pid' => 1, 'CType' => 'test_container'],
+        ])->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('not allowed', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsContainerColumnWithoutContainerUid(): void
+    {
+        $this->registerContainer('test_container', [201]);
+
+        // Rule 6 — the orphan path: colPos 201 with no container would leave a
+        // container column number without a container binding.
+        $result = $this->createSubject()->resolve(null, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('no container was given', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveAcceptsValidContainerColumn(): void
+    {
+        $this->registerContainer('test_container', [201]);
+
+        $result = $this->createSubject([
+            ['uid' => 3, 'pid' => 1, 'CType' => 'test_container'],
+        ])->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertTrue($result['valid']);
+        self::assertSame(201, $result['colPos']);
+        self::assertSame(3, $result['containerUid']);
     }
 
     /**
@@ -83,10 +166,42 @@ final class ContainerContextResolverTest extends TestCase
         ];
     }
 
-    private function createSubject(): ContainerContextResolver
+    /**
+     * @param list<array<string, mixed>> $records
+     */
+    private function createSubject(array $records = []): ContainerContextResolver
     {
         return new ContainerContextResolver(
             new Registry($this->createMock(EventDispatcherInterface::class)),
+            $this->createConnectionPoolReturning($records),
         );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $records
+     */
+    private function createConnectionPoolReturning(array $records): ConnectionPool
+    {
+        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result->method('fetchAssociative')->willReturn($records[0] ?? false);
+
+        $expressionBuilder = $this->createMock(\TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('');
+
+        $restrictions = $this->createMock(\TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer::class);
+
+        $queryBuilder = $this->createMock(\TYPO3\CMS\Core\Database\Query\QueryBuilder::class);
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder->method('select')->willReturn($queryBuilder);
+        $queryBuilder->method('from')->willReturn($queryBuilder);
+        $queryBuilder->method('where')->willReturn($queryBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        return $connectionPool;
     }
 }

--- a/Tests/Unit/Service/Content/ContainerContextResolverTest.php
+++ b/Tests/Unit/Service/Content/ContainerContextResolverTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Xima\XimaTypo3FrontendEdit\Service\Content\ContainerContextResolver;
+
+/**
+ * ContainerContextResolverTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ContainerContextResolver::class)]
+final class ContainerContextResolverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TCA']);
+    }
+
+    #[Test]
+    public function resolveAcceptsPageColumnWhenNoContainerGiven(): void
+    {
+        $subject = new ContainerContextResolver();
+
+        $result = $subject->resolve(null, 0, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertTrue($result['valid']);
+        self::assertSame(0, $result['colPos']);
+        self::assertSame(0, $result['containerUid']);
+        self::assertNull($result['error']);
+    }
+}

--- a/Tests/Unit/Service/Content/ContainerContextResolverTest.php
+++ b/Tests/Unit/Service/Content/ContainerContextResolverTest.php
@@ -136,6 +136,27 @@ final class ContainerContextResolverTest extends TestCase
     }
 
     #[Test]
+    public function resolveAcceptsPageColumnWhenRegistryIsAbsent(): void
+    {
+        // EXT:container is not installed (require-dev only) — the registry
+        // service does not exist, so it is null. Plain drag & drop must still
+        // work: a page column with no container given is accepted as usual.
+        $result = $this->createSubjectWithoutRegistry()->resolve(null, 0, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertTrue($result['valid']);
+        self::assertSame(0, $result['containerUid']);
+    }
+
+    #[Test]
+    public function resolveRejectsContainerUidWhenRegistryIsAbsent(): void
+    {
+        $result = $this->createSubjectWithoutRegistry()->resolve(3, 201, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('not installed', (string) $result['error']);
+    }
+
+    #[Test]
     public function resolveAcceptsValidContainerColumn(): void
     {
         $this->registerContainer('test_container', [201]);
@@ -175,6 +196,11 @@ final class ContainerContextResolverTest extends TestCase
             new Registry($this->createMock(EventDispatcherInterface::class)),
             $this->createConnectionPoolReturning($records),
         );
+    }
+
+    private function createSubjectWithoutRegistry(): ContainerContextResolver
+    {
+        return new ContainerContextResolver(null, $this->createConnectionPoolReturning([]));
     }
 
     /**

--- a/Tests/Unit/Service/Content/ContainerContextResolverTest.php
+++ b/Tests/Unit/Service/Content/ContainerContextResolverTest.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 
+use B13\Container\Tca\Registry;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Xima\XimaTypo3FrontendEdit\Service\Content\ContainerContextResolver;
 
 /**
@@ -34,13 +36,57 @@ final class ContainerContextResolverTest extends TestCase
     #[Test]
     public function resolveAcceptsPageColumnWhenNoContainerGiven(): void
     {
-        $subject = new ContainerContextResolver();
-
-        $result = $subject->resolve(null, 0, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+        $result = $this->createSubject()->resolve(null, 0, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
 
         self::assertTrue($result['valid']);
         self::assertSame(0, $result['colPos']);
         self::assertSame(0, $result['containerUid']);
         self::assertNull($result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsColumnNotRegisteredForAnyContainer(): void
+    {
+        $this->registerContainer('test_container', [201, 202]);
+
+        $result = $this->createSubject()->resolve(3, 999, ['uid' => 1, 'pid' => 1, 'CType' => 'text']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('column 999', (string) $result['error']);
+    }
+
+    #[Test]
+    public function resolveRejectsMovingAContainerIntoAContainer(): void
+    {
+        $this->registerContainer('test_container', [201, 202]);
+
+        $result = $this->createSubject()->resolve(3, 201, ['uid' => 9, 'pid' => 1, 'CType' => 'test_container']);
+
+        self::assertFalse($result['valid']);
+        self::assertStringContainsString('container element', (string) $result['error']);
+    }
+
+    /**
+     * @param int[] $colPositions
+     */
+    private function registerContainer(string $cType, array $colPositions): void
+    {
+        $columns = [];
+        foreach ($colPositions as $colPos) {
+            $columns[] = ['name' => 'Column '.$colPos, 'colPos' => $colPos];
+        }
+
+        // Mirrors the shape b13/container writes via Tca\Registry::configureContainer().
+        $GLOBALS['TCA']['tt_content']['containerConfiguration'][$cType] = [
+            'cType' => $cType,
+            'grid' => [$columns],
+        ];
+    }
+
+    private function createSubject(): ContainerContextResolver
+    {
+        return new ContainerContextResolver(
+            new Registry($this->createMock(EventDispatcherInterface::class)),
+        );
     }
 }

--- a/Tests/Unit/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Unit/Service/Content/ContentMoveServiceTest.php
@@ -54,7 +54,7 @@ final class ContentMoveServiceTest extends TestCase
                     'move' => [
                         'action' => 'paste',
                         'target' => -456,
-                        'update' => ['colPos' => 2],
+                        'update' => ['colPos' => 2, 'tx_container_parent' => 0],
                     ],
                 ],
             ],
@@ -67,7 +67,7 @@ final class ContentMoveServiceTest extends TestCase
         $command = $this->subject->buildMoveCommand(123, 0, null, 10);
 
         self::assertSame(10, $command['tt_content'][123]['move']['target']);
-        self::assertSame(['colPos' => 0], $command['tt_content'][123]['move']['update']);
+        self::assertSame(['colPos' => 0, 'tx_container_parent' => 0], $command['tt_content'][123]['move']['update']);
     }
 
     #[Test]
@@ -112,5 +112,27 @@ final class ContentMoveServiceTest extends TestCase
     {
         yield 'container child' => [['sys_language_uid' => 0, 'tx_container_parent' => 99]];
         yield 'translated element' => [['sys_language_uid' => 1, 'tx_container_parent' => 0]];
+    }
+
+    #[Test]
+    public function buildMoveCommandAlwaysSetsContainerParentEvenForPageColumns(): void
+    {
+        $command = $this->subject->buildMoveCommand(5, 0, null, 1);
+
+        self::assertArrayHasKey(
+            'tx_container_parent',
+            $command['tt_content'][5]['move']['update'],
+            'tx_container_parent must never be omitted — EXT:container would null it silently',
+        );
+        self::assertSame(0, $command['tt_content'][5]['move']['update']['tx_container_parent']);
+    }
+
+    #[Test]
+    public function buildMoveCommandSetsGivenContainerParent(): void
+    {
+        $command = $this->subject->buildMoveCommand(5, 201, null, 1, 3);
+
+        self::assertSame(201, $command['tt_content'][5]['move']['update']['colPos']);
+        self::assertSame(3, $command['tt_content'][5]['move']['update']['tx_container_parent']);
     }
 }

--- a/Tests/Unit/Service/Content/ContentMoveServiceTest.php
+++ b/Tests/Unit/Service/Content/ContentMoveServiceTest.php
@@ -13,13 +13,16 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 
+use B13\Container\Tca\Registry;
 use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test};
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
-use Xima\XimaTypo3FrontendEdit\Service\Content\ContentMoveService;
+use Xima\XimaTypo3FrontendEdit\Service\Content\{ContainerContextResolver, ContentMoveService};
 
 /**
  * ContentMoveServiceTest.
@@ -39,6 +42,10 @@ final class ContentMoveServiceTest extends TestCase
             new SettingsService(
                 $this->createMock(ExtensionConfiguration::class),
                 $this->createMock(SiteFinder::class),
+            ),
+            new ContainerContextResolver(
+                new Registry($this->createMock(EventDispatcherInterface::class)),
+                $this->createMock(ConnectionPool::class),
             ),
         );
     }
@@ -99,6 +106,16 @@ final class ContentMoveServiceTest extends TestCase
     }
 
     #[Test]
+    public function isMovableAcceptsContainerChild(): void
+    {
+        self::assertTrue($this->subject->isMovable([
+            'uid' => 1,
+            'sys_language_uid' => 0,
+            'tx_container_parent' => 99,
+        ]));
+    }
+
+    #[Test]
     #[DataProvider('nonMovableRecordProvider')]
     public function isMovableRejectsOutOfScopeRecords(array $record): void
     {
@@ -110,7 +127,6 @@ final class ContentMoveServiceTest extends TestCase
      */
     public static function nonMovableRecordProvider(): iterable
     {
-        yield 'container child' => [['sys_language_uid' => 0, 'tx_container_parent' => 99]];
         yield 'translated element' => [['sys_language_uid' => 1, 'tx_container_parent' => 0]];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		"eliashaeussler/version-bumper": "^4.0.3",
 		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+		"psr/event-dispatcher": "^1.0",
 		"typo3/cms-base-distribution": "^13.4 || ^14.0",
 		"typo3/cms-lowlevel": "^13.4 || ^14.0",
 		"typo3/testing-framework": "^8.0 || ^9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "313664c1300a1c5383210a0e547d410f",
+    "content-hash": "847941ab66091cef878633497528141a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

Extends frontend drag & drop reordering (introduced in #187) to support EXT:container columns. Content elements inside a container can now be reordered within a column, moved between columns of the same container, moved out into a page column, and moved from a page column into a container. Container elements themselves remain reorderable within page columns but cannot be nested into another container via drag & drop.

## The core finding this design is built on

EXT:container's `CommandMapBeforeStartHook` forces `tx_container_parent` to `0` whenever a DataHandler move command sets `colPos` without also setting `tx_container_parent`:

```php
if (isset($cmd['update']['colPos']) && !isset($cmd['update']['tx_container_parent'])) {
    $cmd['update']['tx_container_parent'] = 0;
}
```

Measured against a real container child (`colPos 201`, `tx_container_parent 30`), moved within its own column:

| | colPos | tx_container_parent | errorLog |
|---|---|---|---|
| before | 201 | 30 | — |
| after (field omitted) | 201 | **0** | **empty** |
| after (field explicit) | 201 | 30 | empty |

The element becomes an orphan — a container-column number with no container binding, invisible in the frontend — while `DataHandler` reports success and the UI would show a green "moved" notification. `ContentMoveService::buildMoveCommand()` therefore sets `tx_container_parent` unconditionally, including the value `0` when the target is a page column.

## ContainerContextResolver

A new service validates every drop target against six rules before a move is attempted:

| # | Rule |
|---|---|
| 1 | Container exists, isn't deleted, lives on the same page as the moved record |
| 2 | Target is actually a registered container element |
| 3 | The requested `colPos` belongs to *that* container |
| 4 | The moved record's CType is allowed in that column (registry-based — works without EXT:content_defender) |
| 5 | The moved record isn't itself a container (no nesting via drag) |
| 6 | A container-column `colPos` given without a `containerUid` is rejected (prevents the orphan path above) |

`ContentMoveService::move()` also verifies after `process_cmdmap()` that the record actually landed where requested — an empty `errorLog` isn't proof, since EXT:container hooks can rewrite or silently drop commands.

## Notes for reviewers

- `b13/container` is a `require-dev`-only dependency. `ContainerContextResolver` takes a nullable `Registry` (wired via Symfony's `@?` optional service reference in `Configuration/Services.yaml`), so a site without EXT:container still boots correctly and simply has no containers to validate against.
- The JavaScript changes (`collectColumns`, `getColumnElements`, `persistMove` status handling) have **no automated test coverage** — this project has no JS test suite, and `Tests/Acceptance/` holds fixtures only. Verified manually via a real browser session (chrome-devtools MCP) on both TYPO3 13 and 14: markers render correctly, a synthetic drag of a container child into a sibling column produces the expected DB state end-to-end (JS → AjaxController → ContentMoveService → DataHandler → DB).
- Also restores a drag-handle placement fix (moving the handle from the actions group to the label group, with a divider) that was committed locally on the old feature branch but never pushed, so it never made it into #187's merge.
- Two pre-existing DRY violations (repeated int-parameter parsing in `AjaxController`, repeated message-formatting in `persistMove`) were extracted while working in these files.
- Fixes a curly-quote mismatch in the drag & drop notification strings (`”%s”` instead of `“%s”`) introduced when the rejection labels were added.

## Changes

- `Classes/Service/Content/ContainerContextResolver.php` — new: the six-rule validator described above
- `Classes/Service/Content/ContentMoveService.php` — `tx_container_parent` always set; post-move verification; container-aware neighbour check
- `Classes/Controller/AjaxController.php` — accepts `targetContainerUid`; parameter parsing extracted into shared helpers
- `Classes/Service/Ui/ResourceRendererService.php` — new `dnd.rejected*` labels; quote fix
- `Configuration/Services.yaml` — optional `Registry` wiring for `ContainerContextResolver`
- `Resources/Public/JavaScript/frontend_edit.js` — container columns as drop targets; 422/409 status handling; drag-handle placement restored; `formatMoveMessage` extraction
- `Resources/Public/Css/FrontendEdit.css` — toolbar separator styling for the restored handle placement
- `Resources/Private/Language/{locallang,de.locallang}.xlf` — new labels; quote fix
- `Documentation/Usage/DragAndDrop.rst`, `Documentation/Configuration/SiteSettings.rst`, `README.md` — container support documented
- `Tests/Acceptance/Fixtures/demo-content.sql` + new sitepackage partial — marks the ddev demo's container columns as drop targets
- `Tests/Unit/Service/Content/ContainerContextResolverTest.php`, `Tests/Functional/Service/Content/ContentMoveServiceTest.php`, `Tests/Functional/Controller/AjaxControllerTest.php` — coverage for all six rules, all four movement directions, and the rejection paths
- `composer.json`, `Tests/CGL/composer-dependency-analyser.php` — `psr/event-dispatcher` declared as a direct dev dependency; `b13/container`'s dev-dependency-in-prod-code finding waived with rationale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering now supports columns inside containers, including moves within and between containers.
  * Added clear feedback when content cannot be dropped in a selected location.
  * Improved toolbar layout with separators and refined drag-handle styling.

* **Bug Fixes**
  * Added validation to prevent invalid, cross-page, nested-container, and unsupported-column moves.
  * Translated content continues to use the standard move dialog.

* **Documentation**
  * Updated drag-and-drop setup, container support, limitations, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->