### PR TITLE
test: adopt konradmichalik/ttt for declarative unit test sandboxing

### DIFF
--- a/Tests/Unit/Fixtures/FakeUriBuilder.php
+++ b/Tests/Unit/Fixtures/FakeUriBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures;
+
+use Psr\Http\Message\UriInterface;
+use Throwable;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+
+/**
+ * FakeUriBuilder.
+ *
+ * Constructor-only stand-in for UriBuilder, for use with #[WithSingleton]: instantiable
+ * without the real constructor's Router/FormProtectionFactory/RequestContextFactory dependencies.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class FakeUriBuilder extends UriBuilder
+{
+    public function __construct(
+        private readonly UriInterface|Throwable $result = new Uri('/typo3/mock'),
+    ) {}
+
+    public function buildUriFromRoute($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): UriInterface
+    {
+        if ($this->result instanceof Throwable) {
+            throw $this->result;
+        }
+
+        return $this->result;
+    }
+}

--- a/Tests/Unit/Service/Content/ContentElementFilterTest.php
+++ b/Tests/Unit/Service/Content/ContentElementFilterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 
 use Doctrine\DBAL\Result;
+use KonradMichalik\Ttt\Http\Requests;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,8 +22,6 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder};
-use TYPO3\CMS\Core\Settings\SettingsInterface;
-use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\{GeneralUtility, RootlineUtility};
 use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
@@ -92,7 +91,7 @@ final class ContentElementFilterTest extends TestCase
             ['uid' => 2, 'CType' => 'text', 'list_type' => ''],
         ];
 
-        $request = $this->createRequest(['frontendEdit.filter.ignoreUids' => '1']);
+        $request = $this->createRequest(['frontendEdit' => ['filter' => ['ignoreUids' => '1']]]);
         $result = $filter->filterContentElements($elements, $backendUser, $request);
 
         self::assertCount(1, $result);
@@ -113,7 +112,7 @@ final class ContentElementFilterTest extends TestCase
             ['uid' => 2, 'CType' => 'html', 'list_type' => ''],
         ];
 
-        $request = $this->createRequest(['frontendEdit.filter.ignoreCTypes' => 'html']);
+        $request = $this->createRequest(['frontendEdit' => ['filter' => ['ignoreCTypes' => 'html']]]);
         $result = $filter->filterContentElements($elements, $backendUser, $request);
 
         self::assertCount(1, $result);
@@ -134,7 +133,7 @@ final class ContentElementFilterTest extends TestCase
             ['uid' => 2, 'CType' => 'list', 'list_type' => 'other'],
         ];
 
-        $request = $this->createRequest(['frontendEdit.filter.ignoreListTypes' => 'news_pi1']);
+        $request = $this->createRequest(['frontendEdit' => ['filter' => ['ignoreListTypes' => 'news_pi1']]]);
         $result = $filter->filterContentElements($elements, $backendUser, $request);
 
         self::assertCount(1, $result);
@@ -151,7 +150,7 @@ final class ContentElementFilterTest extends TestCase
             $this->createRepository(),
         );
 
-        $request = $this->createRequest(['frontendEdit.filter.ignorePids' => '5']);
+        $request = $this->createRequest(['frontendEdit' => ['filter' => ['ignorePids' => '5']]]);
         self::assertTrue($filter->isPageIgnored(10, $request));
     }
 
@@ -166,8 +165,7 @@ final class ContentElementFilterTest extends TestCase
         );
 
         $request = $this->createRequest([
-            'frontendEdit.filter.ignorePids' => '5',
-            'frontendEdit.filter.ignoreDoktypes' => '254',
+            'frontendEdit' => ['filter' => ['ignorePids' => '5', 'ignoreDoktypes' => '254']],
         ]);
         self::assertTrue($filter->isPageIgnored(10, $request));
     }
@@ -183,8 +181,7 @@ final class ContentElementFilterTest extends TestCase
         );
 
         $request = $this->createRequest([
-            'frontendEdit.filter.ignorePids' => '5',
-            'frontendEdit.filter.ignoreDoktypes' => '254',
+            'frontendEdit' => ['filter' => ['ignorePids' => '5', 'ignoreDoktypes' => '254']],
         ]);
         self::assertFalse($filter->isPageIgnored(10, $request));
     }
@@ -200,8 +197,7 @@ final class ContentElementFilterTest extends TestCase
         );
 
         $request = $this->createRequest([
-            'frontendEdit.filter.ignorePids' => '5',
-            'frontendEdit.filter.ignoreDoktypes' => '254',
+            'frontendEdit' => ['filter' => ['ignorePids' => '5', 'ignoreDoktypes' => '254']],
         ]);
         self::assertFalse($filter->isPageIgnored(10, $request));
     }
@@ -271,21 +267,12 @@ final class ContentElementFilterTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $settingsTree
      */
-    private function createRequest(array $settings): ServerRequestInterface
+    private function createRequest(array $settingsTree): ServerRequestInterface
     {
-        $settingsInterface = $this->createMock(SettingsInterface::class);
-        $settingsInterface->method('has')->willReturn(false);
-        $settingsInterface->method('getIdentifiers')->willReturn([]);
-        $siteSettings = new SiteSettings($settingsInterface, [], $settings);
-
-        $site = $this->createMock(Site::class);
-        $site->method('getSettings')->willReturn($siteSettings);
-
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')->with('site')->willReturn($site);
-
-        return $request;
+        return Requests::get('/')
+            ->withSiteSettings($settingsTree)
+            ->build();
     }
 }

--- a/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
+++ b/Tests/Unit/Service/Content/EmptyColumnServiceTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Content;
 
 use Doctrine\DBAL\Result;
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -24,6 +25,7 @@ use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Service\Content\EmptyColumnService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 use function is_array;
 
@@ -34,24 +36,18 @@ use function is_array;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(EmptyColumnService::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder(new Uri('/typo3/record/content/wizard/new')))]
 final class EmptyColumnServiceTest extends TestCase
 {
     private ConnectionPool $connectionPool;
 
-    private UrlBuilderService $urlBuilderService;
+    private ?UrlBuilderService $urlBuilderService = null;
 
     private LanguageServiceFactory $languageServiceFactory;
 
     protected function setUp(): void
     {
-        // Mock UriBuilder singleton so real UrlBuilderService picks it up
-        $uriBuilderMock = $this->createMock(UriBuilder::class);
-        $uriBuilderMock->method('buildUriFromRoute')
-            ->willReturn(new Uri('/typo3/record/content/wizard/new'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
-
         $this->connectionPool = $this->createMock(ConnectionPool::class);
-        $this->urlBuilderService = new UrlBuilderService();
         $this->languageServiceFactory = $this->createMock(LanguageServiceFactory::class);
 
         // Default: EXT:container not installed (tx_container_parent absent from TCA)
@@ -71,7 +67,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -89,7 +85,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -106,7 +102,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -123,7 +119,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -141,7 +137,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $this->connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -169,7 +165,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -204,7 +200,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -232,7 +228,7 @@ final class EmptyColumnServiceTest extends TestCase
 
         $service = new EmptyColumnService(
             $connectionPool,
-            $this->urlBuilderService,
+            $this->urlBuilderService(),
             $this->languageServiceFactory,
         );
 
@@ -248,6 +244,14 @@ final class EmptyColumnServiceTest extends TestCase
 
         $containerResults = array_filter($result, static fn (array $r): bool => isset($r['containerUid']));
         self::assertEmpty($containerResults);
+    }
+
+    /**
+     * Lazily constructed: #[WithSingleton] only takes effect once the test method starts running, after setUp().
+     */
+    private function urlBuilderService(): UrlBuilderService
+    {
+        return $this->urlBuilderService ??= new UrlBuilderService();
     }
 
     private function registerContainerField(): void

--- a/Tests/Unit/Service/Menu/AbstractMenuButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/AbstractMenuButtonBuilderTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -24,6 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\AbstractMenuButtonBuilder;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * AbstractMenuButtonBuilderTest.
@@ -32,6 +33,7 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(AbstractMenuButtonBuilder::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class AbstractMenuButtonBuilderTest extends TestCase
 {
     private Icon $iconMock;
@@ -44,10 +46,6 @@ final class AbstractMenuButtonBuilderTest extends TestCase
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($this->iconMock);
         $this->iconService = new IconService($iconFactoryMock);
-
-        $uriBuilderMock = $this->createMock(UriBuilder::class);
-        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
     }
 
     protected function tearDown(): void

--- a/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
+++ b/Tests/Unit/Service/Menu/AdditionalDataHandlerTest.php
@@ -15,13 +15,13 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
 use Doctrine\DBAL\Result;
 use Generator;
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\{Expression\ExpressionBuilder, QueryBuilder, Restriction\DefaultRestrictionContainer};
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
@@ -30,6 +30,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\AdditionalDataHandler;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * AdditionalDataHandlerTest.
@@ -38,15 +39,9 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(AdditionalDataHandler::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class AdditionalDataHandlerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $uriBuilder = $this->createMock(UriBuilder::class);
-        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
-    }
-
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -23,6 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementButtonBuilder;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * ContentElementButtonBuilderTest.
@@ -31,11 +33,11 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(ContentElementButtonBuilder::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder(new Uri('/typo3/record/edit')))]
 final class ContentElementButtonBuilderTest extends TestCase
 {
     private IconService $iconService;
-    private UrlBuilderService $urlBuilderService;
-    private UriBuilder $uriBuilderMock;
+    private ?UrlBuilderService $urlBuilderService = null;
 
     protected function setUp(): void
     {
@@ -43,11 +45,6 @@ final class ContentElementButtonBuilderTest extends TestCase
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($iconMock);
         $this->iconService = new IconService($iconFactoryMock);
-
-        $this->uriBuilderMock = $this->createMock(UriBuilder::class);
-        $this->uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/record/edit'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $this->uriBuilderMock);
-        $this->urlBuilderService = new UrlBuilderService();
     }
 
     protected function tearDown(): void
@@ -59,7 +56,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function createSimpleEditButtonReturnsLinkButton(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
 
         $button = $builder->createSimpleEditButton(
             ['uid' => 1, 'CType' => 'text'],
@@ -76,7 +73,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function createSimpleEditButtonSetsContextualUrl(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
 
         $button = $builder->createSimpleEditButton(
             ['uid' => 1, 'CType' => 'text'],
@@ -92,7 +89,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function createSimpleEditButtonWithoutContextualUrlSetsNull(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
 
         $button = $builder->createSimpleEditButton(
             ['uid' => 1, 'CType' => 'text'],
@@ -107,7 +104,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function createFullMenuButtonReturnsMenuButton(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
 
         $button = $builder->createFullMenuButton();
 
@@ -117,7 +114,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addInfoSectionAddsChildrenToMenuButton(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $languageService = $this->createMock(\TYPO3\CMS\Core\Localization\LanguageService::class);
@@ -136,7 +133,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addInfoSectionHandlesEmptyHeader(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $languageService = $this->createMock(\TYPO3\CMS\Core\Localization\LanguageService::class);
@@ -153,7 +150,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addInfoSectionHandlesMissingHeader(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $languageService = $this->createMock(\TYPO3\CMS\Core\Localization\LanguageService::class);
@@ -170,7 +167,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addEditSectionAddsEditAndPageButtons(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addEditSection($menuButton, ['uid' => 1, 'CType' => 'text'], 0, 1, '/return');
@@ -184,7 +181,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addEditSectionSetsContextualUrlOnEditButton(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addEditSection($menuButton, ['uid' => 1, 'CType' => 'text'], 0, 1, '/return', '/typo3/contextual');
@@ -195,7 +192,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addActionSectionAddsAllActionButtons(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], 0, '/return');
@@ -212,7 +209,7 @@ final class ContentElementButtonBuilderTest extends TestCase
     #[Test]
     public function addActionSectionOmitsNewContentButtonWhenInsertButtonsDisabled(): void
     {
-        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], 0, '/return', false);
@@ -221,5 +218,13 @@ final class ContentElementButtonBuilderTest extends TestCase
         self::assertArrayNotHasKey('new_content_after', $children);
         self::assertArrayHasKey('hide', $children);
         self::assertArrayHasKey('delete', $children);
+    }
+
+    /**
+     * Lazily constructed: #[WithSingleton] only takes effect once the test method starts running, after setUp().
+     */
+    private function urlBuilderService(): UrlBuilderService
+    {
+        return $this->urlBuilderService ??= new UrlBuilderService();
     }
 }

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
 use Doctrine\DBAL\Result;
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -25,7 +26,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -39,6 +39,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Content\ContentElementFilter;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\{AdditionalDataHandler, ContentElementButtonBuilder, ContentElementMenuGenerator};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * ContentElementMenuGeneratorTest.
@@ -47,14 +48,11 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(ContentElementMenuGenerator::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class ContentElementMenuGeneratorTest extends TestCase
 {
     protected function setUp(): void
     {
-        $uriBuilderMock = $this->createMock(UriBuilder::class);
-        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
-
         for ($i = 0; $i < 10; ++$i) {
             $versionMock = $this->createMock(Typo3Version::class);
             $versionMock->method('getMajorVersion')->willReturn(13);

--- a/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
@@ -13,16 +13,17 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Imaging\{Icon, IconFactory};
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\PageButtonBuilder;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * PageButtonBuilderTest.
@@ -31,10 +32,11 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(PageButtonBuilder::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class PageButtonBuilderTest extends TestCase
 {
     private IconService $iconService;
-    private UrlBuilderService $urlBuilderService;
+    private ?UrlBuilderService $urlBuilderService = null;
 
     protected function setUp(): void
     {
@@ -42,11 +44,6 @@ final class PageButtonBuilderTest extends TestCase
         $iconFactoryMock = $this->createMock(IconFactory::class);
         $iconFactoryMock->method('getIcon')->willReturn($iconMock);
         $this->iconService = new IconService($iconFactoryMock);
-
-        $uriBuilderMock = $this->createMock(UriBuilder::class);
-        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
-        $this->urlBuilderService = new UrlBuilderService();
     }
 
     protected function tearDown(): void
@@ -60,7 +57,7 @@ final class PageButtonBuilderTest extends TestCase
     {
         $this->setUpGlobals();
 
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addInfoSection($menuButton, ['uid' => 1, 'title' => 'Test Page', 'doktype' => 1]);
@@ -75,7 +72,7 @@ final class PageButtonBuilderTest extends TestCase
     {
         $this->setUpGlobals();
 
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addInfoSection($menuButton, ['uid' => 1, 'title' => '', 'doktype' => 1]);
@@ -88,7 +85,7 @@ final class PageButtonBuilderTest extends TestCase
     {
         $this->setUpGlobals();
 
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addInfoSection($menuButton, ['uid' => 1, 'doktype' => 1]);
@@ -101,7 +98,7 @@ final class PageButtonBuilderTest extends TestCase
     {
         $this->setUpGlobals();
 
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addInfoSection($menuButton, ['uid' => 1]);
@@ -112,7 +109,7 @@ final class PageButtonBuilderTest extends TestCase
     #[Test]
     public function addEditSectionAddsEditButtons(): void
     {
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addEditSection($menuButton, 1, 0, '/return');
@@ -126,7 +123,7 @@ final class PageButtonBuilderTest extends TestCase
     #[Test]
     public function addEditSectionSetsContextualUrl(): void
     {
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addEditSection($menuButton, 1, 0, '/return', '/typo3/contextual');
@@ -137,7 +134,7 @@ final class PageButtonBuilderTest extends TestCase
     #[Test]
     public function addActionSectionAddsInfoAndHistoryButtons(): void
     {
-        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService);
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
         $menuButton = new Button('Menu', ButtonType::Menu);
 
         $builder->addActionSection($menuButton, 1, '/return');
@@ -146,6 +143,14 @@ final class PageButtonBuilderTest extends TestCase
         self::assertArrayHasKey('div_action', $children);
         self::assertArrayHasKey('info', $children);
         self::assertArrayHasKey('history', $children);
+    }
+
+    /**
+     * Lazily constructed: #[WithSingleton] only takes effect once the test method starts running, after setUp().
+     */
+    private function urlBuilderService(): UrlBuilderService
+    {
+        return $this->urlBuilderService ??= new UrlBuilderService();
     }
 
     private function setUpGlobals(): void

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Menu;
 
 use Doctrine\DBAL\Result;
+use KonradMichalik\Ttt\Attribute\WithSingleton;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,6 +35,7 @@ use Xima\XimaTypo3FrontendEdit\Event\FrontendEditPageDropdownModifyEvent;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\{PageButtonBuilder, PageMenuGenerator};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 /**
  * PageMenuGeneratorTest.
@@ -42,15 +44,9 @@ use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(PageMenuGenerator::class)]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class PageMenuGeneratorTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $uriBuilderMock = $this->createMock(UriBuilder::class);
-        $uriBuilderMock->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilderMock);
-    }
-
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();

--- a/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
+++ b/Tests/Unit/Service/Ui/BackendSettingsServiceTest.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
 
+use KonradMichalik\Ttt\Attribute\{WithEnvironment, WithSingleton, WithTypo3ConfVars};
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Package\{PackageInterface, PackageManager};
 use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\BackendSettingsService;
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 use function dirname;
 
@@ -33,14 +33,12 @@ use function dirname;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(BackendSettingsService::class)]
+#[WithEnvironment(context: 'Testing')]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class BackendSettingsServiceTest extends TestCase
 {
     protected function setUp(): void
     {
-        $uriBuilder = $this->createMock(UriBuilder::class);
-        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/ajax/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
-
         $package = $this->createMock(PackageInterface::class);
         $package->method('getPackagePath')->willReturn(dirname(__DIR__, 4).'/');
 
@@ -52,24 +50,12 @@ final class BackendSettingsServiceTest extends TestCase
         $packageManager->method('getActivePackages')->willReturn([]);
         GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
         ExtensionManagementUtility::setPackageManager($packageManager);
-
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
     }
 
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        unset($GLOBALS['LANG'], $GLOBALS['TYPO3_CONF_VARS']);
+        unset($GLOBALS['LANG']);
     }
 
     #[Test]
@@ -116,13 +102,9 @@ final class BackendSettingsServiceTest extends TestCase
     }
 
     #[Test]
+    #[WithSingleton(UriBuilder::class, new FakeUriBuilder(new RouteNotFoundException('missing')))]
     public function getSettingsScriptSkipsMissingAjaxRoutes(): void
     {
-        $uriBuilder = $this->createMock(UriBuilder::class);
-        $uriBuilder->method('buildUriFromRoute')
-            ->willThrowException(new RouteNotFoundException('missing'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
-
         $service = new BackendSettingsService();
 
         $result = $service->getSettingsScript();
@@ -172,10 +154,9 @@ final class BackendSettingsServiceTest extends TestCase
     }
 
     #[Test]
+    #[WithTypo3ConfVars(['SYS' => ['ddmmyy' => 'd.m.Y']])]
     public function getSettingsScriptUsesConfiguredDateFormat(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] = 'd.m.Y';
-
         $service = new BackendSettingsService();
 
         $result = $service->getSettingsScript();

--- a/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
+++ b/Tests/Unit/Service/Ui/ResourceRendererServiceTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Ui;
 
+use KonradMichalik\Ttt\Attribute\{WithEnvironment, WithSingleton};
+use KonradMichalik\Ttt\Http\Requests;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,11 +22,7 @@ use ReflectionClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Package\{PackageInterface, PackageManager};
-use TYPO3\CMS\Core\Settings\SettingsInterface;
-use TYPO3\CMS\Core\Site\Entity\{Site, SiteSettings};
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
 use TYPO3\CMS\Core\View\{ViewFactoryInterface, ViewInterface};
@@ -32,6 +30,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\PageMenuGenerator;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{BackendSettingsService, ResourceRendererService, UrlBuilderService};
+use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 
 use function dirname;
 
@@ -42,14 +41,12 @@ use function dirname;
  * @license GPL-2.0-or-later
  */
 #[CoversClass(ResourceRendererService::class)]
+#[WithEnvironment(context: 'Testing')]
+#[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class ResourceRendererServiceTest extends TestCase
 {
     protected function setUp(): void
     {
-        $uriBuilder = $this->createMock(UriBuilder::class);
-        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/mock'));
-        GeneralUtility::setSingletonInstance(UriBuilder::class, $uriBuilder);
-
         $package = $this->createMock(PackageInterface::class);
         $package->method('getPackagePath')->willReturn(dirname(__DIR__, 4).'/');
 
@@ -61,18 +58,6 @@ final class ResourceRendererServiceTest extends TestCase
         $packageManager->method('getActivePackages')->willReturn([]);
         GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
         ExtensionManagementUtility::setPackageManager($packageManager);
-
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
     }
 
     protected function tearDown(): void
@@ -104,7 +89,7 @@ final class ResourceRendererServiceTest extends TestCase
 
         $service = $this->createService(true);
 
-        $service->render($this->createRequest(['frontendEdit.enableContextualEditing' => true]));
+        $service->render($this->createRequest(['frontendEdit' => ['enableContextualEditing' => true]]));
 
         self::assertArrayHasKey('backend_stubs', $captured);
         self::assertArrayHasKey('iframe_edit', $captured);
@@ -146,7 +131,7 @@ final class ResourceRendererServiceTest extends TestCase
 
         $service = $this->createService(false);
 
-        $service->render($this->createRequest(['frontendEdit.showStickyToolbar' => false]));
+        $service->render($this->createRequest(['frontendEdit' => ['showStickyToolbar' => false]]));
 
         self::assertArrayNotHasKey('sticky_toolbar', $captured);
         self::assertArrayNotHasKey('sticky_toolbar_config', $captured);
@@ -226,24 +211,12 @@ final class ResourceRendererServiceTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $settingsTree
      */
-    private function createRequest(array $settings): ServerRequestInterface
+    private function createRequest(array $settingsTree): ServerRequestInterface
     {
-        $settingsInterface = $this->createMock(SettingsInterface::class);
-        $settingsInterface->method('has')->willReturn(false);
-        $settingsInterface->method('getIdentifiers')->willReturn([]);
-        $siteSettings = new SiteSettings($settingsInterface, [], $settings);
-
-        $site = $this->createMock(Site::class);
-        $site->method('getSettings')->willReturn($siteSettings);
-
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')->willReturnCallback(
-            static fn (string $name): mixed => 'site' === $name ? $site : null,
-        );
-        $request->method('getUri')->willReturn(new Uri('https://example.com/page'));
-
-        return $request;
+        return Requests::get('https://example.com/page')
+            ->withSiteSettings($settingsTree)
+            ->build();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 		"b13/container": "^4.0.2",
 		"composer/class-map-generator": "^1.7.3",
 		"eliashaeussler/version-bumper": "^4.0.3",
+		"konradmichalik/ttt": "^0.4.0",
 		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
 		"psr/event-dispatcher": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "847941ab66091cef878633497528141a",
+    "content-hash": "178e502e565bd7e52c15f1c4cd5d5b3e",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5758,6 +5758,73 @@
                 "source": "https://github.com/eliashaeussler/version-bumper/tree/4.0.3"
             },
             "time": "2026-06-04T05:37:13+00:00"
+        },
+        {
+            "name": "konradmichalik/ttt",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/konradmichalik/ttt.git",
+                "reference": "2b36b0ce42b7f980f0c23bc5f61a3da6e10cba8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/konradmichalik/ttt/zipball/2b36b0ce42b7f980f0c23bc5f61a3da6e10cba8d",
+                "reference": "2b36b0ce42b7f980f0c23bc5f61a3da6e10cba8d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^2.0",
+                "ergebnis/composer-normalize": "^2.44",
+                "konradmichalik/php-cs-fixer-preset": "^0.2.0",
+                "konradmichalik/php-doc-block-header-fixer": "^0.3.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "rector/rector": "^2.2",
+                "typo3/cms-core": "^13.4 || ^14.0",
+                "typo3/cms-frontend": "^13.4 || ^14.0"
+            },
+            "suggest": {
+                "typo3/cms-core": "Required for TYPO3-specific attributes like InApplicationContext and WithEnvironment (^13.4 || ^14.0)",
+                "typo3/cms-frontend": "Required for WithFrontendUser (^13.4 || ^14.0)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "KonradMichalik\\Ttt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Konrad Michalik",
+                    "email": "hej@konradmichalik.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "ttt - TYPO3 Testing Terrarium. Declarative test sandboxing via PHP attributes: TYPO3_CONF_VARS, application context, environment and more - applied before the test, guaranteed to be restored afterwards.",
+            "keywords": [
+                "Toolbox",
+                "attributes",
+                "php",
+                "phpunit",
+                "sandbox",
+                "testing",
+                "ttt",
+                "typo3"
+            ],
+            "support": {
+                "issues": "https://github.com/konradmichalik/ttt/issues",
+                "source": "https://github.com/konradmichalik/ttt/tree/0.4.0"
+            },
+            "time": "2026-07-30T09:47:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,9 @@
     <php>
         <env name="COLUMNS" value="300" />
     </php>
+    <extensions>
+        <bootstrap class="KonradMichalik\Ttt\TttExtension"/>
+    </extensions>
     <testsuites>
         <testsuite name="Tests">
             <directory>Tests/Unit</directory>


### PR DESCRIPTION
## Summary

- Add `konradmichalik/ttt` (v0.4.0) as a dev dependency and register its PHPUnit extension for the unit test suite
- Replace hand-rolled `Environment::initialize()`/`ApplicationContext` bootstrapping with `#[WithEnvironment]`
- Replace a manual `SiteSettings`/`Site` mock builder with ttt's Request Kit (`Requests::get(...)->withSiteSettings(...)->build()`)
- Introduce `FakeUriBuilder` test double and replace `GeneralUtility::setSingletonInstance(UriBuilder::class, ...)` + `purgeInstances()` boilerplate with `#[WithSingleton]` across menu/content unit tests
- Replace one hand-set `$GLOBALS['TYPO3_CONF_VARS']` value with `#[WithTypo3ConfVars]`
- Leave BE_USER mocks and two `createRequest()` helpers untouched where tests need per-test dynamic mock behavior (`uc`, `getTSConfig()`, `getSessionData()` maps) that ttt's declarative attributes can't express

## Changes

- `composer.json` / `composer.lock` - add `konradmichalik/ttt:^0.4.0` (dev)
- `phpunit.xml` - register `KonradMichalik\Ttt\TttExtension` bootstrap
- `Tests/Unit/Fixtures/FakeUriBuilder.php` - new lightweight `UriBuilder` stand-in for `#[WithSingleton]`
- `Tests/Unit/Service/Ui/BackendSettingsServiceTest.php`, `ResourceRendererServiceTest.php` - `#[WithEnvironment]`, `#[WithSingleton]`, `#[WithTypo3ConfVars]`, Request Kit
- `Tests/Unit/Service/Content/ContentElementFilterTest.php` - Request Kit site-settings migration
- `Tests/Unit/Service/Menu/{PageMenuGenerator,ContentElementMenuGenerator,AbstractMenuButtonBuilder,AdditionalDataHandler,ContentElementButtonBuilder,PageButtonBuilder}Test.php`, `Tests/Unit/Service/Content/EmptyColumnServiceTest.php` - `#[WithSingleton]` migration (with a lazy-getter fix in three of them since `#[WithSingleton]` only takes effect once the test method starts running, after `setUp()`)

## Test plan

- [x] `ddev composer test:unit` - 305/305 tests pass
- [x] `ddev cgl lint` - clean
- [x] `ddev cgl sca` - clean (PHPStan)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test setup for URI generation and request configuration.
  * Added reusable fixtures for simulating successful and failing URI-building scenarios.
  * Simplified environment and singleton handling across service tests.
  * Updated request-based tests to use consistent nested settings structures.
* **Chores**
  * Added testing utilities and PHPUnit extension configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->