### PR TITLE
fix: validate returnUrl origin in AjaxController

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -24,6 +24,7 @@ use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
 use Xima\XimaTypo3FrontendEdit\Service\Content\{ContentMoveService, EmptyColumnService};
 use Xima\XimaTypo3FrontendEdit\Service\Menu\ContentElementMenuGenerator;
+use Xima\XimaTypo3FrontendEdit\Service\Security\ReturnUrlValidator;
 
 use function in_array;
 use function is_array;
@@ -44,6 +45,7 @@ readonly class AjaxController
         private EmptyColumnService $emptyColumnService,
         private SettingsService $settingsService,
         private ContentMoveService $contentMoveService,
+        private ReturnUrlValidator $returnUrlValidator,
     ) {}
 
     /**
@@ -118,6 +120,9 @@ readonly class AjaxController
         $returnUrl = (string) ($params['returnUrl'] ?? '');
         if ('' === $returnUrl) {
             return new JsonResponse(['error' => 'Missing required parameter: returnUrl'], 400);
+        }
+        if (!$this->returnUrlValidator->isValid($returnUrl, $request, $pid)) {
+            return new JsonResponse(['error' => 'Invalid parameter: returnUrl host not allowed'], 400);
         }
 
         if (!$this->backendUserService->hasPageAccess($pid)) {

--- a/Classes/Service/Security/ReturnUrlValidator.php
+++ b/Classes/Service/Security/ReturnUrlValidator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Service\Security;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+use function array_filter;
+use function array_values;
+use function parse_url;
+use function strcasecmp;
+
+/**
+ * ReturnUrlValidator.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class ReturnUrlValidator
+{
+    public function __construct(
+        private SiteFinder $siteFinder,
+    ) {}
+
+    /**
+     * Accepts a relative returnUrl, or one whose host matches the current request
+     * or one of the resolved site's base URLs (including per-language bases).
+     * Rejects malformed URLs and everything else.
+     */
+    public function isValid(string $returnUrl, ServerRequestInterface $request, int $pid): bool
+    {
+        $host = parse_url($returnUrl, \PHP_URL_HOST);
+        if (false === $host) {
+            return false;
+        }
+        if (null === $host) {
+            return true;
+        }
+
+        if (0 === strcasecmp($host, $request->getUri()->getHost())) {
+            return true;
+        }
+
+        try {
+            $site = $this->siteFinder->getSiteByPageId($pid);
+        } catch (SiteNotFoundException) {
+            return false;
+        }
+
+        foreach ($this->allowedSiteHosts($site) as $allowedHost) {
+            if (0 === strcasecmp($host, $allowedHost)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedSiteHosts(Site $site): array
+    {
+        $hosts = [$site->getBase()->getHost()];
+
+        foreach ($site->getLanguages() as $language) {
+            $hosts[] = $language->getBase()->getHost();
+        }
+
+        return array_values(array_filter($hosts, static fn (string $host): bool => '' !== $host));
+    }
+}

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -49,6 +49,10 @@ After closing the edit form, I am redirected to the wrong frontend location (e.g
 
 This could be caused by a strict referer header in your request. If the return url could not be determined correctly, you can force the url generation by pid and language in the extension setting: :code:`forceReturnUrlGeneration`.
 
+**Cross-domain setups**
+
+If your frontend and backend run on different domains, the extension only accepts a :code:`returnUrl` whose host matches the current request or one of the site's configured base URLs (including per-language bases). A :code:`returnUrl` pointing at any other host is rejected with an HTTP 400 error instead of silently redirecting to the root page, so a rejected return url is a sign to check your site configuration's base URLs rather than a bug.
+
 .. rst-class:: panel panel-default
 
 I can't change the language within a content element.

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -178,6 +178,33 @@ final class AjaxControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function editInformationActionReturns400OnForeignReturnUrlHost(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest([
+            'pid' => '1',
+            'returnUrl' => 'https://evil.example/',
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertArrayHasKey('error', $this->decode($response));
+    }
+
+    #[Test]
+    public function editInformationActionAcceptsSameOriginAbsoluteReturnUrl(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $response = $this->subject->editInformationAction($this->createRequest([
+            'pid' => '1',
+            'returnUrl' => 'https://example.com/return',
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
     public function editInformationActionReturns400OnInvalidJsonBody(): void
     {
         $this->setUpBackendUser(1);

--- a/Tests/Unit/Service/Security/ReturnUrlValidatorTest.php
+++ b/Tests/Unit/Service/Security/ReturnUrlValidatorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Security;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Site\Entity\{Site, SiteLanguage};
+use TYPO3\CMS\Core\Site\SiteFinder;
+use Xima\XimaTypo3FrontendEdit\Service\Security\ReturnUrlValidator;
+
+/**
+ * ReturnUrlValidatorTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ReturnUrlValidator::class)]
+final class ReturnUrlValidatorTest extends TestCase
+{
+    #[Test]
+    public function isValidReturnsTrueForRelativeUrl(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->expects(self::never())->method('getSiteByPageId');
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertTrue($validator->isValid('/some/path', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsTrueForSameOriginAbsoluteUrl(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->expects(self::never())->method('getSiteByPageId');
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertTrue($validator->isValid('https://example.com/return', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForMalformedUrl(): void
+    {
+        $validator = new ReturnUrlValidator($this->createMock(SiteFinder::class));
+
+        self::assertFalse($validator->isValid('https://example.com:-1/redirect', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsFalseWhenSiteCannotBeResolved(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->willThrowException(new SiteNotFoundException('none', 1));
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertFalse($validator->isValid('https://evil.example/', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForForeignHostNotMatchingSiteBases(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->willReturn($this->createSite('example.com', ['example.de']));
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertFalse($validator->isValid('https://evil.example/', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsTrueForSiteBaseHost(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->willReturn($this->createSite('example.org', []));
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertTrue($validator->isValid('https://example.org/return', $this->createRequest('https://example.com/'), 1));
+    }
+
+    #[Test]
+    public function isValidReturnsTrueForSiteLanguageBaseHost(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->willReturn($this->createSite('example.com', ['example.de']));
+        $validator = new ReturnUrlValidator($siteFinder);
+
+        self::assertTrue($validator->isValid('https://example.de/return', $this->createRequest('https://example.com/'), 1));
+    }
+
+    private function createRequest(string $uri): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getUri')->willReturn(new Uri($uri));
+
+        return $request;
+    }
+
+    /**
+     * @param list<string> $languageBaseHosts
+     */
+    private function createSite(string $baseHost, array $languageBaseHosts): Site
+    {
+        $site = $this->createMock(Site::class);
+        $site->method('getBase')->willReturn(new Uri('https://'.$baseHost.'/'));
+
+        $languages = array_map(function (string $host): SiteLanguage {
+            $language = $this->createMock(SiteLanguage::class);
+            $language->method('getBase')->willReturn(new Uri('https://'.$host.'/'));
+
+            return $language;
+        }, $languageBaseHosts);
+
+        $site->method('getLanguages')->willReturn($languages);
+
+        return $site;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ReturnUrlValidator` service: accepts a relative `returnUrl`, or one whose host matches the current request or one of the resolved site's base URLs (including per-language bases); rejects malformed URLs and foreign hosts
- Wire it into `AjaxController::editInformationAction()` — invalid `returnUrl` now returns HTTP 400 with an explicit error instead of relying on TYPO3 core's `sanitizeLocalUrl()` as an implementation detail
- Update the FAQ's cross-domain redirect entry to document the new explicit validation behavior

Closes #213

## Changes

- `Classes/Service/Security/ReturnUrlValidator.php` - new service, origin/host validation logic
- `Classes/Controller/AjaxController.php` - inject and call the validator in `editInformationAction()`
- `Tests/Unit/Service/Security/ReturnUrlValidatorTest.php` - unit tests (relative URL, same-origin, malformed URL, foreign host, site base host, site language base host)
- `Tests/Functional/Controller/AjaxControllerTest.php` - functional coverage for the 400 rejection and same-origin acceptance
- `Documentation/FAQ/Index.rst` - cross-domain diagnostics note

## Test plan

- [x] `ddev composer test` - 312 unit + 71 functional tests pass
- [x] `ddev cgl lint` - clean
- [x] `ddev cgl sca` - clean (PHPStan)