### PR TITLE
fix: permission-gate the hide button on non_exclude_fields access

### DIFF
--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -78,6 +78,22 @@ final class BackendUserService
     }
 
     /**
+     * Check field-level access (non_exclude_fields), e.g. whether the user may
+     * change tt_content's "hidden" field. Distinct from hasRecordEditAccess(),
+     * which covers language access and editlock but not individual fields.
+     */
+    public function hasFieldAccess(string $table, string $field): bool
+    {
+        $backendUser = $this->getBackendUser();
+
+        if (null === $backendUser || null === $backendUser->user) {
+            return false;
+        }
+
+        return $backendUser->check('non_exclude_fields', $table.':'.$field);
+    }
+
+    /**
      * Check if frontend edit is disabled by the user's toggle (UC state).
      *
      * This reflects the user's personal on/off toggle and can be changed

--- a/Classes/Service/Menu/ContentElementButtonBuilder.php
+++ b/Classes/Service/Menu/ContentElementButtonBuilder.php
@@ -159,12 +159,16 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
         int $languageUid,
         string $returnUrlAnchor,
         bool $showInsertButtons = true,
+        bool $canHide = true,
     ): void {
         $this->addButton($menuButton, 'div_action', ButtonType::Divider);
 
-        // Hide button
-        $hideUrl = $this->urlBuilderService->buildHideUrl($contentElement['uid'], $returnUrlAnchor);
-        $this->addButton($menuButton, 'hide', ButtonType::Link, url: $hideUrl, icon: 'actions-toggle-on');
+        // Hide button — gated on non_exclude_fields access to tt_content:hidden;
+        // showing it regardless would let the click fail in the DataHandler.
+        if ($canHide) {
+            $hideUrl = $this->urlBuilderService->buildHideUrl($contentElement['uid'], $returnUrlAnchor);
+            $this->addButton($menuButton, 'hide', ButtonType::Link, url: $hideUrl, icon: 'actions-toggle-on');
+        }
 
         // Info button
         $infoUrl = $this->urlBuilderService->buildInfoUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
@@ -200,7 +204,10 @@ final readonly class ContentElementButtonBuilder extends AbstractMenuButtonBuild
             $this->addButton($menuButton, 'new_content_after', ButtonType::Link, url: $newContentUrl, icon: 'actions-add');
         }
 
-        // Delete button
+        // Delete button — needs no field-level gate like hide: for tt_content,
+        // the page permission "edit content" (already checked via hasRecordEditAccess()
+        // in ContentElementFilter) covers delete access too; there is no separate
+        // non_exclude_fields dimension for deleting a record, unlike hiding it.
         $deleteUrl = $this->urlBuilderService->buildDeleteUrl($contentElement['uid'], 'tt_content', $returnUrlAnchor);
         $this->addButton($menuButton, 'delete', ButtonType::Link, url: $deleteUrl, icon: 'actions-delete');
     }

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -103,6 +103,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         // after the previous element (first element → column top).
         $showInsertButtons = $this->settingsService->isShowInsertButtons($request);
         $previousSiblingByUid = $this->buildPreviousSiblingMap($filteredElements, $showInsertButtons);
+        $canHide = $this->backendUserService->hasFieldAccess('tt_content', 'hidden');
 
         $result = [];
         foreach ($filteredElements as $contentElement) {
@@ -117,7 +118,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
                 continue;
             }
 
-            $menuButton = $this->createMenuButton($contentElement, $languageUid, $pid, $returnUrlAnchor, $contentElementConfig, $request, $contextualUrl, $showInsertButtons);
+            $menuButton = $this->createMenuButton($contentElement, $languageUid, $pid, $returnUrlAnchor, $contentElementConfig, $request, $contextualUrl, $showInsertButtons, $canHide);
             $this->handleAdditionalData($menuButton, $contentElement, $contentElementConfig, $data, $languageUid, $returnUrlAnchor);
 
             /** @var FrontendEditDropdownModifyEvent $event */
@@ -222,6 +223,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         ServerRequestInterface $request,
         ?string $contextualUrl = null,
         bool $showInsertButtons = true,
+        bool $canHide = true,
     ): Button {
         if (!$this->settingsService->isShowContextMenu($request)) {
             return $this->contentElementButtonBuilder->createSimpleEditButton(
@@ -237,7 +239,7 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
 
         $this->contentElementButtonBuilder->addInfoSection($menuButton, $contentElement, $contentElementConfig);
         $this->contentElementButtonBuilder->addEditSection($menuButton, $contentElement, $languageUid, $pid, $returnUrlAnchor, $contextualUrl);
-        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $languageUid, $returnUrlAnchor, $showInsertButtons);
+        $this->contentElementButtonBuilder->addActionSection($menuButton, $contentElement, $languageUid, $returnUrlAnchor, $showInsertButtons, $canHide);
 
         return $menuButton;
     }

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Functional\Controller;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\{ServerRequest, Stream};
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Controller\AjaxController;
@@ -46,7 +47,7 @@ final class AjaxControllerTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['BE_USER']);
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG']);
 
         parent::tearDown();
     }
@@ -214,6 +215,27 @@ final class AjaxControllerTest extends FunctionalTestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertArrayHasKey('contentElements', $payload);
         self::assertArrayHasKey('columnTargets', $payload);
+    }
+
+    #[Test]
+    public function editInformationActionOmitsHideButtonForRestrictedEditor(): void
+    {
+        $this->importCSVDataSet(__DIR__.'/Fixtures/be_groups.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/tt_content.csv');
+        $backendUser = $this->setUpBackendUser(2);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $response = $this->subject->editInformationAction($this->createRequest(['pid' => '1', 'returnUrl' => '/']));
+
+        $payload = $this->decode($response);
+        $menuChildren = $payload['contentElements'][10]['menu']['children'] ?? [];
+
+        self::assertArrayNotHasKey('hide', $menuChildren);
+        self::assertArrayHasKey('delete', $menuChildren);
+        $menuChildren = $payload['contentElements'][10]['menu']['children'] ?? [];
+
+        self::assertArrayNotHasKey('hide', $menuChildren);
+        self::assertArrayHasKey('delete', $menuChildren);
     }
 
     #[Test]

--- a/Tests/Functional/Controller/Fixtures/be_groups.csv
+++ b/Tests/Functional/Controller/Fixtures/be_groups.csv
@@ -1,0 +1,3 @@
+"be_groups"
+,"uid","pid","title","non_exclude_fields","explicit_allowdeny","deleted","hidden"
+,1,0,"Restricted Editors","","tt_content:CType:text",0,0

--- a/Tests/Functional/Controller/Fixtures/be_users.csv
+++ b/Tests/Functional/Controller/Fixtures/be_users.csv
@@ -1,3 +1,4 @@
 "be_users"
-,"uid","pid","username","admin","disable","deleted"
-,1,0,"admin",1,0,0
+,"uid","pid","username","admin","disable","deleted","usergroup","db_mountpoints"
+,1,0,"admin",1,0,0,,
+,2,0,"editor",0,0,0,1,1

--- a/Tests/Functional/Controller/Fixtures/tt_content.csv
+++ b/Tests/Functional/Controller/Fixtures/tt_content.csv
@@ -1,0 +1,3 @@
+"tt_content"
+,"uid","pid","CType","header","colPos","sorting","hidden","deleted","sys_language_uid","l10n_source"
+,10,1,"text","Restricted test element",0,100,0,0,0,0

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -230,4 +230,40 @@ final class BackendUserServiceTest extends TestCase
 
         self::assertTrue($service->isFrontendEditAllowed());
     }
+
+    #[Test]
+    public function hasFieldAccessReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasFieldAccess('tt_content', 'hidden'));
+    }
+
+    #[Test]
+    public function hasFieldAccessDelegatesToBackendUserNonExcludeFieldsCheck(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('check')->with('non_exclude_fields', 'tt_content:hidden')->willReturn(true);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->hasFieldAccess('tt_content', 'hidden'));
+    }
+
+    #[Test]
+    public function hasFieldAccessReturnsFalseWhenCheckDenies(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasFieldAccess('tt_content', 'hidden'));
+    }
 }

--- a/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementButtonBuilderTest.php
@@ -220,6 +220,22 @@ final class ContentElementButtonBuilderTest extends TestCase
         self::assertArrayHasKey('delete', $children);
     }
 
+    #[Test]
+    public function addActionSectionOmitsHideButtonWhenNotPermitted(): void
+    {
+        $builder = new ContentElementButtonBuilder($this->iconService, $this->urlBuilderService());
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addActionSection($menuButton, ['uid' => 1, 'pid' => 1], 0, '/return', true, false);
+
+        $children = $menuButton->getChildren();
+        self::assertArrayNotHasKey('hide', $children);
+        self::assertArrayHasKey('info', $children);
+        self::assertArrayHasKey('move', $children);
+        self::assertArrayHasKey('history', $children);
+        self::assertArrayHasKey('delete', $children);
+    }
+
     /**
      * Lazily constructed: #[WithSingleton] only takes effect once the test method starts running, after setUp().
      */

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -240,6 +240,22 @@ final class ContentElementMenuGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function getDropdownOmitsHideButtonWhenFieldAccessDenied(): void
+    {
+        $this->setUpAuthenticatedBackendUser(canHide: false);
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(91);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertArrayNotHasKey('hide', $result[91]['menu']['children']);
+    }
+
+    #[Test]
     public function getDropdownRespectsEventListenerModifiedButton(): void
     {
         $this->setUpAuthenticatedBackendUser();
@@ -294,12 +310,13 @@ final class ContentElementMenuGeneratorTest extends TestCase
         ];
     }
 
-    private function setUpAuthenticatedBackendUser(bool $hasEditAccess = true): void
+    private function setUpAuthenticatedBackendUser(bool $hasEditAccess = true, bool $canHide = true): void
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1, 'admin' => 1];
         $backendUser->uc = [];
         $backendUser->method('recordEditAccessInternals')->willReturn($hasEditAccess);
+        $backendUser->method('check')->willReturn($canHide);
         $GLOBALS['BE_USER'] = $backendUser;
     }
 


### PR DESCRIPTION
## Summary

- Add `BackendUserService::hasFieldAccess(string $table, string $field): bool`, delegating to `BackendUserAuthentication::check('non_exclude_fields', "$table:$field")` — a distinct permission dimension from `hasRecordEditAccess()` (which covers language access and editlock, but not individual fields)
- Gate `ContentElementButtonBuilder::addActionSection()`'s hide button on `hasFieldAccess('tt_content', 'hidden')`, computed once per dropdown render in `ContentElementMenuGenerator::getDropdown()` and threaded through like the existing `$showInsertButtons` flag
- Document in a code comment why the delete button needs no equivalent gate: for tt_content, page permission "edit content" (already checked via `hasRecordEditAccess()`) covers delete too, unlike hide which has its own `non_exclude_fields` dimension

Closes #214

## Changes

- `Classes/Service/Authentication/BackendUserService.php` - new `hasFieldAccess()` method
- `Classes/Service/Menu/ContentElementButtonBuilder.php` - hide button gated behind `$canHide`, comment on the delete button
- `Classes/Service/Menu/ContentElementMenuGenerator.php` - compute `$canHide` once, thread through `createMenuButton()`
- `Tests/Unit/Service/Authentication/BackendUserServiceTest.php`, `Tests/Unit/Service/Menu/{ContentElementButtonBuilder,ContentElementMenuGenerator}Test.php` - unit coverage
- `Tests/Functional/Controller/AjaxControllerTest.php` + new `be_groups.csv`/`tt_content.csv` fixtures - functional test with a restricted editor (no `tt_content:CType:text` explicit-allow beyond what's needed, and no `tt_content:hidden` non_exclude_fields entry) confirming the hide button is omitted while delete remains

## Test plan

- [x] `ddev composer test` - 310 unit + 70 functional tests pass
- [x] `ddev cgl lint` - clean
- [x] `ddev cgl sca` - clean (PHPStan)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-aware control for the content element “Hide” action.
  * Restricted editors no longer see the “Hide” option when they lack field access.
  * Other available actions, including “Delete,” remain accessible according to existing permissions.

* **Tests**
  * Added coverage for field permissions and menu behavior for restricted editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->