### PR TITLE
test: add Playwright E2E suite for the JS integration layer

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,15 +5,15 @@ on:
     branches:
       - main
     paths:
+      - 'Classes/**'
       - 'Resources/**'
-      - 'Classes/Middleware/**'
       - 'Tests/Playwright/**'
       - 'Tests/Acceptance/Fixtures/**'
       - '.github/workflows/e2e.yml'
   pull_request:
     paths:
+      - 'Classes/**'
       - 'Resources/**'
-      - 'Classes/Middleware/**'
       - 'Tests/Playwright/**'
       - 'Tests/Acceptance/Fixtures/**'
       - '.github/workflows/e2e.yml'
@@ -21,14 +21,18 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typo3-version: ['13', '14']
     steps:
       - uses: actions/checkout@v4
 
       - name: Install ddev
         uses: ddev/github-action-setup-ddev@v1
 
-      - name: Install TYPO3 13
-        run: ddev install 13
+      - name: Install TYPO3 ${{ matrix.typo3-version }}
+        run: ddev install ${{ matrix.typo3-version }}
 
       - name: Install Playwright dependencies
         run: ddev exec -d /var/www/html/Tests/Playwright npm ci
@@ -40,11 +44,12 @@ jobs:
         run: ddev exec -d /var/www/html/Tests/Playwright npx playwright test
         env:
           CI: true
+          TYPO3_VERSION: ${{ matrix.typo3-version }}
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.typo3-version }}
           path: Tests/Playwright/playwright-report/
           retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,10 +41,13 @@ jobs:
         run: ddev exec -d /var/www/html/Tests/Playwright npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: ddev exec -d /var/www/html/Tests/Playwright npx playwright test
-        env:
-          CI: true
-          TYPO3_VERSION: ${{ matrix.typo3-version }}
+        # `ddev exec` runs its argument string inside the container; a step-level
+        # `env:` only sets variables for the host runner process, so it never
+        # reaches Playwright's config in there (confirmed live: both matrix legs
+        # would silently run against the same TYPO3 version, and CI-specific
+        # config would never activate). `env VAR=val ...` as ddev exec arguments
+        # sets them inside the container instead.
+        run: ddev exec -d /var/www/html/Tests/Playwright env CI=true TYPO3_VERSION=${{ matrix.typo3-version }} npx playwright test
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Resources/**'
+      - 'Classes/Middleware/**'
+      - 'Tests/Playwright/**'
+      - 'Tests/Acceptance/Fixtures/**'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'Resources/**'
+      - 'Classes/Middleware/**'
+      - 'Tests/Playwright/**'
+      - 'Tests/Acceptance/Fixtures/**'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ddev
+        uses: ddev/github-action-setup-ddev@v1
+
+      - name: Install TYPO3 13
+        run: ddev install 13
+
+      - name: Install Playwright dependencies
+        run: ddev exec -d /var/www/html/Tests/Playwright npm ci
+
+      - name: Install Playwright browsers
+        run: ddev exec -d /var/www/html/Tests/Playwright npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: ddev exec -d /var/www/html/Tests/Playwright npx playwright test
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: Tests/Playwright/playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ phpstan.xml
 .Build/
 .phpunit.result.cache
 .superpowers/
+Tests/Playwright/.auth/
+Tests/Playwright/test-results/
+Tests/Playwright/playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ php-cs-fixer.xml
 phpstan.xml
 .Build/
 .phpunit.result.cache
-.superpowers/
 Tests/Playwright/.auth/
 Tests/Playwright/test-results/
 Tests/Playwright/playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ php-cs-fixer.xml
 phpstan.xml
 .Build/
 .phpunit.result.cache
+.superpowers/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,22 @@ ddev 13 composer install
 ddev all typo3 database:updateschema
 ```
 
+## Run E2E tests (Playwright)
+
+E2E tests live in `Tests/Playwright/` and run against an installed TYPO3 instance (see "TYPO3 Setup" above).
+
+```bash
+# Install once
+ddev exec -d /var/www/html/Tests/Playwright npm install
+ddev exec -d /var/www/html/Tests/Playwright npx playwright install --with-deps chromium
+
+# Run the suite (targets TYPO3 13 by default)
+ddev exec -d /var/www/html/Tests/Playwright npx playwright test
+
+# Target TYPO3 14 instead
+TYPO3_VERSION=14 ddev exec -d /var/www/html/Tests/Playwright npx playwright test
+```
+
 ## Submit a pull request
 
 After completing your work, **open a pull request** and provide a description of your changes. Ideally, your PR should reference an issue that explains the problem you are addressing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ ddev exec -d /var/www/html/Tests/Playwright npx playwright install --with-deps c
 ddev exec -d /var/www/html/Tests/Playwright npx playwright test
 
 # Target TYPO3 14 instead
-TYPO3_VERSION=14 ddev exec -d /var/www/html/Tests/Playwright npx playwright test
+ddev exec -d /var/www/html/Tests/Playwright env TYPO3_VERSION=14 npx playwright test
 ```
 
 ## Submit a pull request

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -162,12 +162,14 @@
     height: 0;
     z-index: 1;
     opacity: 0;
+    visibility: hidden;
     pointer-events: none;
-    transition: opacity 0.15s ease;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
 }
 
 .frontend-edit__overlay--active .frontend-edit__toolbar {
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
 }
 

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -162,14 +162,12 @@
     height: 0;
     z-index: 1;
     opacity: 0;
-    visibility: hidden;
     pointer-events: none;
-    transition: opacity 0.15s ease, visibility 0.15s ease;
+    transition: opacity 0.15s ease;
 }
 
 .frontend-edit__overlay--active .frontend-edit__toolbar {
     opacity: 1;
-    visibility: visible;
     pointer-events: auto;
 }
 

--- a/Tests/Playwright/package-lock.json
+++ b/Tests/Playwright/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "xima-typo3-frontend-edit-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xima-typo3-frontend-edit-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.62.0",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/Tests/Playwright/package-lock.json
+++ b/Tests/Playwright/package-lock.json
@@ -7,6 +7,7 @@
       "name": "xima-typo3-frontend-edit-e2e",
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@types/node": "^24.0.0",
         "typescript": "^5.7.2"
       }
     },
@@ -24,6 +25,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/fsevents": {
@@ -86,6 +97,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/Tests/Playwright/package.json
+++ b/Tests/Playwright/package.json
@@ -2,10 +2,12 @@
   "name": "xima-typo3-frontend-edit-e2e",
   "private": true,
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@types/node": "^24.0.0",
     "typescript": "^5.7.2"
   }
 }

--- a/Tests/Playwright/package.json
+++ b/Tests/Playwright/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "xima-typo3-frontend-edit-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/Tests/Playwright/playwright.config.ts
+++ b/Tests/Playwright/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
 const BASE_URL = `https://${TYPO3_VERSION}.xima-typo3-frontend-edit.ddev.site`;
+// Namespaced by version: switching TYPO3_VERSION must not clobber the other
+// version's saved backend session (13.* and 14.* are different origins/cookies).
+const AUTH_FILE = `.auth/state-${TYPO3_VERSION}.json`;
 
 export default defineConfig({
   testDir: '.',
@@ -23,7 +26,7 @@ export default defineConfig({
     {
       name: 'chromium',
       testMatch: 'tests/**/*.spec.ts',
-      use: { ...devices['Desktop Chrome'], storageState: '.auth/state.json' },
+      use: { ...devices['Desktop Chrome'], storageState: AUTH_FILE },
       dependencies: ['setup'],
     },
   ],

--- a/Tests/Playwright/playwright.config.ts
+++ b/Tests/Playwright/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
+const BASE_URL = `https://${TYPO3_VERSION}.xima-typo3-frontend-edit.ddev.site`;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: BASE_URL,
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: 'support/typo3/auth.setup.ts',
+    },
+    {
+      name: 'chromium',
+      testMatch: 'tests/**/*.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: '.auth/state.json' },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/Tests/Playwright/support/frontend-edit/fixtures.ts
+++ b/Tests/Playwright/support/frontend-edit/fixtures.ts
@@ -2,11 +2,18 @@ import { execSync } from 'node:child_process';
 
 const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
 const DATABASE = `database_${TYPO3_VERSION}`;
+const TYPO3_BIN = `/var/www/html/.Build/${TYPO3_VERSION}/vendor/bin/typo3`;
 
 /**
  * Un-hides a tt_content record via a direct DB write, restoring
  * Tests/Acceptance/Fixtures/demo-content.sql's baseline state after a hide-action
  * test. Cheaper than re-importing the whole SQL fixture between tests.
+ *
+ * The direct SQL write bypasses DataHandler, so it never clears TYPO3's page
+ * cache the way a real backend edit would — the next page load would still
+ * serve the stale "hidden" render (missing #c{uid}) even though the DB is
+ * correct again. Flushing the cache after the write closes that gap; verified
+ * live: without it, a second hide-action run times out waiting for #c5.
  */
 export function restoreHiddenContentElement(uid: number): void {
   if (!Number.isInteger(uid) || uid <= 0) {
@@ -14,4 +21,5 @@ export function restoreHiddenContentElement(uid: number): void {
   }
 
   execSync(`mysql -h db -u root -proot ${DATABASE} -e "UPDATE tt_content SET hidden = 0 WHERE uid = ${uid};"`);
+  execSync(`${TYPO3_BIN} cache:flush`);
 }

--- a/Tests/Playwright/support/frontend-edit/fixtures.ts
+++ b/Tests/Playwright/support/frontend-edit/fixtures.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'node:child_process';
+
+const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
+const DATABASE = `database_${TYPO3_VERSION}`;
+
+/**
+ * Un-hides a tt_content record via a direct DB write, restoring
+ * Tests/Acceptance/Fixtures/demo-content.sql's baseline state after a hide-action
+ * test. Cheaper than re-importing the whole SQL fixture between tests.
+ */
+export function restoreHiddenContentElement(uid: number): void {
+  if (!Number.isInteger(uid) || uid <= 0) {
+    throw new Error(`Invalid content element uid: ${uid}`);
+  }
+
+  execSync(`mysql -h db -u root -proot ${DATABASE} -e "UPDATE tt_content SET hidden = 0 WHERE uid = ${uid};"`);
+}

--- a/Tests/Playwright/support/frontend-edit/hover-menu.ts
+++ b/Tests/Playwright/support/frontend-edit/hover-menu.ts
@@ -1,0 +1,34 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class HoverMenu {
+  constructor(private readonly page: Page) {}
+
+  contentElement(uid: number): Locator {
+    return this.page.locator(`#c${uid}`);
+  }
+
+  toolbar(uid: number): Locator {
+    return this.page.locator(`.frontend-edit__toolbar[data-cid="${uid}"]`);
+  }
+
+  editButton(uid: number): Locator {
+    return this.toolbar(uid).locator('.frontend-edit__btn--edit');
+  }
+
+  kebabButton(uid: number): Locator {
+    return this.toolbar(uid).locator('.frontend-edit__btn--kebab');
+  }
+
+  dropdown(uid: number): Locator {
+    return this.page.locator(`.frontend-edit__dropdown[data-cid="${uid}"]`);
+  }
+
+  async hover(uid: number): Promise<void> {
+    await this.contentElement(uid).hover();
+  }
+
+  async openDropdown(uid: number): Promise<void> {
+    await this.hover(uid);
+    await this.kebabButton(uid).click();
+  }
+}

--- a/Tests/Playwright/support/typo3/auth.setup.ts
+++ b/Tests/Playwright/support/typo3/auth.setup.ts
@@ -1,0 +1,10 @@
+import { test as setup } from '@playwright/test';
+import { BackendPage } from './backend.page';
+
+const AUTH_FILE = '.auth/state.json';
+
+setup('authenticate as backend admin', async ({ page }) => {
+  const backend = new BackendPage(page);
+  await backend.login('admin', 'Password1!');
+  await page.context().storageState({ path: AUTH_FILE });
+});

--- a/Tests/Playwright/support/typo3/auth.setup.ts
+++ b/Tests/Playwright/support/typo3/auth.setup.ts
@@ -1,7 +1,10 @@
 import { test as setup } from '@playwright/test';
 import { BackendPage } from './backend.page';
 
-const AUTH_FILE = '.auth/state.json';
+const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
+// Must match playwright.config.ts's AUTH_FILE — namespaced by version so
+// switching TYPO3_VERSION doesn't clobber the other version's saved session.
+const AUTH_FILE = `.auth/state-${TYPO3_VERSION}.json`;
 
 setup('authenticate as backend admin', async ({ page }) => {
   const backend = new BackendPage(page);

--- a/Tests/Playwright/support/typo3/backend.page.ts
+++ b/Tests/Playwright/support/typo3/backend.page.ts
@@ -1,0 +1,16 @@
+import type { Page } from '@playwright/test';
+
+export class BackendPage {
+  constructor(private readonly page: Page) {}
+
+  async login(username: string, password: string): Promise<void> {
+    await this.page.goto('/typo3/');
+    await this.page.locator('#t3-username').fill(username);
+    await this.page.locator('#t3-password').fill(password);
+    await this.page.locator('#t3-login-submit').click();
+    // The login form is a real page (no SPA routing), so a successful login
+    // fully replaces the DOM. Waiting for the username field to detach avoids
+    // depending on the exact markup of whichever module loads after login.
+    await this.page.locator('#t3-username').waitFor({ state: 'detached', timeout: 15_000 });
+  }
+}

--- a/Tests/Playwright/tests/edit-action.spec.ts
+++ b/Tests/Playwright/tests/edit-action.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
+const CONTENT_ELEMENT_UID = 2;
+
+test('edit action opens FormEngine for exactly the hovered record, same tab', async ({ page, context }) => {
+  // See edit-menu.spec.ts: the listener must be registered before goto(), not after.
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+
+  // The ddev demo site sets frontendEdit.enableContextualEditing: true
+  // (.ddev/.setup/templates/config/sites/main/settings.yaml), so the edit
+  // button's click is intercepted (UI.createEditButton()'s openContextualEdit
+  // call in frontend_edit.js) and loads FormEngine into an iframe modal
+  // instead of navigating the top-level page. page.url() never changes —
+  // assert against the iframe's src instead. This is a real .click(), not a
+  // simulated navigation: it exercises the actual interception path.
+  await hoverMenu.editButton(CONTENT_ELEMENT_UID).click();
+
+  const editIframe = page.locator('iframe[src*="/typo3/record/edit"]');
+  await expect(editIframe).toHaveCount(1);
+
+  // Same tab: no popup window was opened.
+  expect(context.pages()).toHaveLength(1);
+
+  const src = await editIframe.getAttribute('src');
+  const url = new URL(src ?? '', page.url());
+  expect(url.pathname).toContain('/typo3/record/edit');
+  // Decode so the assertion reads the logical param shape, not its URL-encoded form.
+  expect(decodeURIComponent(url.search)).toContain(`edit[tt_content][${CONTENT_ELEMENT_UID}]=edit`);
+});

--- a/Tests/Playwright/tests/edit-menu.spec.ts
+++ b/Tests/Playwright/tests/edit-menu.spec.ts
@@ -14,13 +14,23 @@ test('edit menu opens on hover with the default actions', async ({ page }) => {
   await editInfoResponse;
 
   const hoverMenu = new HoverMenu(page);
+  const toolbar = hoverMenu.toolbar(CONTENT_ELEMENT_UID);
 
-  // Before hovering, the toolbar for this element must not be visible.
-  await expect(hoverMenu.editButton(CONTENT_ELEMENT_UID)).toBeHidden();
+  // The toolbar is always in the DOM; OverlayManager toggles it via opacity/
+  // pointer-events on the TOOLBAR element itself (see
+  // Resources/Public/Css/FrontendEdit.css: `.frontend-edit__toolbar { opacity: 0; }`,
+  // `.frontend-edit__overlay--active .frontend-edit__toolbar { opacity: 1; }`) —
+  // not display/visibility, and not on the child buttons. Two consequences:
+  // (1) Playwright's toBeVisible()/toBeHidden() only check display/visibility +
+  // bounding box, so they can't tell the two opacity states apart — assert
+  // toHaveCSS('opacity', ...) instead. (2) CSS `opacity` is NOT inherited into
+  // a descendant's own computed style (verified live: the toolbar reports
+  // opacity 0 while its child edit button independently reports opacity 1) —
+  // so the assertion must target the toolbar element, not editButton()/kebabButton().
+  await expect(toolbar).toHaveCSS('opacity', '0');
 
   await hoverMenu.hover(CONTENT_ELEMENT_UID);
-  await expect(hoverMenu.editButton(CONTENT_ELEMENT_UID)).toBeVisible();
-  await expect(hoverMenu.kebabButton(CONTENT_ELEMENT_UID)).toBeVisible();
+  await expect(toolbar).toHaveCSS('opacity', '1');
 
   await hoverMenu.kebabButton(CONTENT_ELEMENT_UID).click();
   const dropdown = hoverMenu.dropdown(CONTENT_ELEMENT_UID);

--- a/Tests/Playwright/tests/edit-menu.spec.ts
+++ b/Tests/Playwright/tests/edit-menu.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
+const CONTENT_ELEMENT_UID = 2;
+
+test('edit menu opens on hover with the default actions', async ({ page }) => {
+  // Start listening BEFORE navigating: the editInformation fetch fires during
+  // FrontendEdit.bootstrap() (on DOMContentLoaded), which can complete before
+  // page.goto()'s default 'load' wait resolves. Awaiting goto() first would
+  // race past the response and hang for the full timeout.
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+
+  // Before hovering, the toolbar for this element must not be visible.
+  await expect(hoverMenu.editButton(CONTENT_ELEMENT_UID)).toBeHidden();
+
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+  await expect(hoverMenu.editButton(CONTENT_ELEMENT_UID)).toBeVisible();
+  await expect(hoverMenu.kebabButton(CONTENT_ELEMENT_UID)).toBeVisible();
+
+  await hoverMenu.kebabButton(CONTENT_ELEMENT_UID).click();
+  const dropdown = hoverMenu.dropdown(CONTENT_ELEMENT_UID);
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.locator('[role="menuitem"]').first()).toBeVisible();
+  await expect(dropdown.locator('.hide')).toBeVisible();
+  await expect(dropdown.locator('.delete')).toBeVisible();
+});

--- a/Tests/Playwright/tests/hide-action.spec.ts
+++ b/Tests/Playwright/tests/hide-action.spec.ts
@@ -20,8 +20,13 @@ test.describe('hide action', () => {
     const hoverMenu = new HoverMenu(page);
     await hoverMenu.openDropdown(CONTENT_ELEMENT_UID);
 
+    // Not waitForURL('**/'): we start on '/', so that pattern already matches
+    // the current URL and would resolve immediately instead of waiting for
+    // the tce_db redirect round trip. A 3xx redirect never fires 'load' for
+    // the intermediate hop — only for the final destination — so waiting for
+    // the next 'load' event genuinely waits for the redirect to land back home.
     await Promise.all([
-      page.waitForURL('**/'),
+      page.waitForEvent('load'),
       hoverMenu.dropdown(CONTENT_ELEMENT_UID).locator('.hide').click(),
     ]);
 

--- a/Tests/Playwright/tests/hide-action.spec.ts
+++ b/Tests/Playwright/tests/hide-action.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+import { restoreHiddenContentElement } from '../support/frontend-edit/fixtures';
+
+// "Quick Links" bullets element on the Home page — dedicated to this spec so it
+// doesn't collide with the uid=2 element used by edit-menu.spec.ts / edit-action.spec.ts.
+const CONTENT_ELEMENT_UID = 5;
+
+test.describe('hide action', () => {
+  test.afterEach(() => {
+    restoreHiddenContentElement(CONTENT_ELEMENT_UID);
+  });
+
+  test('hides the content element and redirects back to the page', async ({ page }) => {
+    // See edit-menu.spec.ts: the listener must be registered before goto(), not after.
+    const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+    await page.goto('/');
+    await editInfoResponse;
+
+    const hoverMenu = new HoverMenu(page);
+    await hoverMenu.openDropdown(CONTENT_ELEMENT_UID);
+
+    await Promise.all([
+      page.waitForURL('**/'),
+      hoverMenu.dropdown(CONTENT_ELEMENT_UID).locator('.hide').click(),
+    ]);
+
+    await expect(page.locator(`#c${CONTENT_ELEMENT_UID}`)).toHaveCount(0);
+  });
+});

--- a/Tests/Playwright/tests/onepager.spec.ts
+++ b/Tests/Playwright/tests/onepager.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+
+test.describe('onepager foreign-pid menus', () => {
+  test.fixme(
+    'needs an onepager fixture page — see follow-up issue filed after #220 merges',
+    async () => {
+      // Tests/Acceptance/Fixtures/demo-content.sql has no onepager page yet (a page
+      // rendering tt_content records whose pid differs from the page being viewed).
+      // Once added: navigate to that page, wait for the editInformation response,
+      // and assert the foreign-pid content elements still receive a working edit
+      // menu — DataService.collectDataItems() in frontend_edit.js scans the whole
+      // DOM by id="c{uid}", not by pid, so this should already work; the point of
+      // this test is to catch a regression in that assumption.
+    },
+  );
+});

--- a/Tests/Playwright/tests/sticky-toolbar.spec.ts
+++ b/Tests/Playwright/tests/sticky-toolbar.spec.ts
@@ -13,11 +13,14 @@ test.describe('sticky toolbar', () => {
     const isDisabled = (await page.locator('#frontend-edit-toolbar-config').getAttribute('data-disabled')) === 'true';
     if (!isDisabled) return;
 
+    // waitForLoadState('load') alone can resolve against the page's current
+    // (pre-reload) state rather than the upcoming one — wait for the actual
+    // future 'load' event registered concurrently with the click instead.
     await Promise.all([
       page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+      page.waitForEvent('load'),
       page.locator('.frontend-edit__sticky-btn--toggle').click(),
     ]);
-    await page.waitForLoadState('load');
   });
 
   test('renders and the toggle persists across reload', async ({ page }) => {
@@ -30,11 +33,14 @@ test.describe('sticky toolbar', () => {
     const toggleButton = toolbar.locator('.frontend-edit__sticky-btn--toggle');
 
     // Disable frontend editing. The client reloads the page itself on success.
+    // Wait for the actual future 'load' event (registered concurrently with
+    // the click) rather than waitForLoadState('load') after the fact, which
+    // can resolve against the page's current state instead of the reload.
     await Promise.all([
       page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+      page.waitForEvent('load'),
       toggleButton.click(),
     ]);
-    await page.waitForLoadState('load');
     await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
 
     // Prove persistence: reload again without touching the toggle.

--- a/Tests/Playwright/tests/sticky-toolbar.spec.ts
+++ b/Tests/Playwright/tests/sticky-toolbar.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+const DISABLED_CLASS = /frontend-edit__sticky-toolbar--disabled/;
+
+test('sticky toolbar renders and the toggle persists across reload', async ({ page }) => {
+  await page.goto('/');
+
+  const toolbar = page.locator('.frontend-edit__sticky-toolbar');
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar).not.toHaveClass(DISABLED_CLASS);
+
+  const toggleButton = toolbar.locator('.frontend-edit__sticky-btn--toggle');
+
+  // Disable frontend editing. The client reloads the page itself on success.
+  await Promise.all([
+    page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+    toggleButton.click(),
+  ]);
+  await page.waitForLoadState('load');
+  await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+
+  // Prove persistence: reload again without touching the toggle.
+  await page.reload();
+  await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+
+  // Restore: re-enable so later specs run with frontend edit active.
+  await Promise.all([
+    page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+    page.locator('.frontend-edit__sticky-btn--toggle').click(),
+  ]);
+  await page.waitForLoadState('load');
+  await expect(page.locator('.frontend-edit__sticky-toolbar')).not.toHaveClass(DISABLED_CLASS);
+});

--- a/Tests/Playwright/tests/sticky-toolbar.spec.ts
+++ b/Tests/Playwright/tests/sticky-toolbar.spec.ts
@@ -2,32 +2,45 @@ import { test, expect } from '@playwright/test';
 
 const DISABLED_CLASS = /frontend-edit__sticky-toolbar--disabled/;
 
-test('sticky toolbar renders and the toggle persists across reload', async ({ page }) => {
-  await page.goto('/');
+test.describe('sticky toolbar', () => {
+  // The toggle persists in the backend user's uc, shared across every spec
+  // and every future run. If the test below throws between disabling and
+  // re-enabling, frontend edit would stay disabled forever after — this
+  // afterEach guarantees it ends up enabled regardless of how the test
+  // finished, not just on the happy path.
+  test.afterEach(async ({ page }) => {
+    await page.goto('/');
+    const isDisabled = (await page.locator('#frontend-edit-toolbar-config').getAttribute('data-disabled')) === 'true';
+    if (!isDisabled) return;
 
-  const toolbar = page.locator('.frontend-edit__sticky-toolbar');
-  await expect(toolbar).toBeVisible();
-  await expect(toolbar).not.toHaveClass(DISABLED_CLASS);
+    await Promise.all([
+      page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+      page.locator('.frontend-edit__sticky-btn--toggle').click(),
+    ]);
+    await page.waitForLoadState('load');
+  });
 
-  const toggleButton = toolbar.locator('.frontend-edit__sticky-btn--toggle');
+  test('renders and the toggle persists across reload', async ({ page }) => {
+    await page.goto('/');
 
-  // Disable frontend editing. The client reloads the page itself on success.
-  await Promise.all([
-    page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
-    toggleButton.click(),
-  ]);
-  await page.waitForLoadState('load');
-  await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+    const toolbar = page.locator('.frontend-edit__sticky-toolbar');
+    await expect(toolbar).toBeVisible();
+    await expect(toolbar).not.toHaveClass(DISABLED_CLASS);
 
-  // Prove persistence: reload again without touching the toggle.
-  await page.reload();
-  await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+    const toggleButton = toolbar.locator('.frontend-edit__sticky-btn--toggle');
 
-  // Restore: re-enable so later specs run with frontend edit active.
-  await Promise.all([
-    page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
-    page.locator('.frontend-edit__sticky-btn--toggle').click(),
-  ]);
-  await page.waitForLoadState('load');
-  await expect(page.locator('.frontend-edit__sticky-toolbar')).not.toHaveClass(DISABLED_CLASS);
+    // Disable frontend editing. The client reloads the page itself on success.
+    await Promise.all([
+      page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/toggle')),
+      toggleButton.click(),
+    ]);
+    await page.waitForLoadState('load');
+    await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+
+    // Prove persistence: reload again without touching the toggle.
+    await page.reload();
+    await expect(page.locator('.frontend-edit__sticky-toolbar')).toHaveClass(DISABLED_CLASS);
+
+    // afterEach re-enables it — no need to duplicate that here.
+  });
 });

--- a/Tests/Playwright/tests/translated-page.spec.ts
+++ b/Tests/Playwright/tests/translated-page.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '@playwright/test';
+
+test.describe('translated page (connected mode)', () => {
+  test.fixme(
+    'needs a second site language in the ddev setup — see follow-up issue filed after #220 merges',
+    async () => {
+      // Regression test for issue #212 (connected-mode translated content elements
+      // got no edit menu). The fix — matching via l18n_parent, see the anchorUid
+      // fallback in frontend_edit.js Renderer.render() — is already on main, but
+      // there is no second site language configured yet to exercise it end-to-end.
+      // Once added: navigate to a translated page, hover a translated content
+      // element, and assert the edit action's URL targets the translation uid
+      // (edit[tt_content][<translationUid>]=edit), not the L0 uid rendered in the
+      // id="c{l0uid}" DOM anchor.
+    },
+  );
+});

--- a/Tests/Playwright/tsconfig.json
+++ b/Tests/Playwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@playwright/test"]
+  }
+}

--- a/Tests/Playwright/tsconfig.json
+++ b/Tests/Playwright/tsconfig.json
@@ -4,6 +4,6 @@
     "module": "commonjs",
     "strict": true,
     "skipLibCheck": true,
-    "types": ["@playwright/test"]
+    "types": ["@playwright/test", "node"]
   }
 }


### PR DESCRIPTION
## Summary

- Add a Playwright E2E suite (`Tests/Playwright/`) covering the JS integration chain end-to-end (rendered HTML → uid collection → `editInformation` AJAX → DOM assignment → backend routes) against a live ddev instance
- Add a GitHub Actions workflow running the suite against TYPO3 13 and 14
- Document how to run it locally

## Changes

- `Tests/Playwright/playwright.config.ts` - Config: version-parametrized baseURL/DB/storageState via `TYPO3_VERSION`, serial execution
- `Tests/Playwright/support/typo3/` - Generic TYPO3 backend login helper (`auth.setup.ts`, `backend.page.ts`), kept extraction-friendly for reuse in other TYPO3 extensions
- `Tests/Playwright/support/frontend-edit/` - Extension-specific hover-menu helper and DB fixture restore helper
- `Tests/Playwright/tests/sticky-toolbar.spec.ts` - Sticky toolbar renders for backend users, toggle persists across reload
- `Tests/Playwright/tests/edit-menu.spec.ts` - Hover opens the edit menu with the default actions
- `Tests/Playwright/tests/edit-action.spec.ts` - Edit action targets exactly the hovered record
- `Tests/Playwright/tests/hide-action.spec.ts` - Hide action routes through `tce_db`, redirects back, fixture restored afterward
- `Tests/Playwright/tests/onepager.spec.ts`, `translated-page.spec.ts` - `test.fixme()` stubs pending fixtures (onepager page, second site language) — follow-up issues to be filed separately
- `.github/workflows/e2e.yml` - CI workflow, matrixed over TYPO3 13/14
- `CONTRIBUTING.md` - "Run E2E tests (Playwright)" section

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end browser tests covering frontend editing, hover menus, hide actions, and sticky toolbar behavior.
  - Added support for testing against TYPO3 versions 13 and 14.
  - Added authenticated test sessions and reusable browser interaction helpers.

- **Chores**
  - Automated E2E test execution on pushes and pull requests.
  - Added Playwright setup, artifact reporting, and generated-file exclusions.

- **Documentation**
  - Added instructions for installing and running Playwright E2E tests locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->