### PR TITLE
refactor: extract generic TYPO3/ddev Playwright helpers

### DIFF
--- a/Tests/Playwright/playwright.config.ts
+++ b/Tests/Playwright/playwright.config.ts
@@ -1,33 +1,5 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineTypo3PlaywrightConfig } from './support/typo3/config';
 
-const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
-const BASE_URL = `https://${TYPO3_VERSION}.xima-typo3-frontend-edit.ddev.site`;
-// Namespaced by version: switching TYPO3_VERSION must not clobber the other
-// version's saved backend session (13.* and 14.* are different origins/cookies).
-const AUTH_FILE = `.auth/state-${TYPO3_VERSION}.json`;
-
-export default defineConfig({
-  testDir: '.',
-  fullyParallel: false,
-  workers: 1,
-  retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
-  use: {
-    baseURL: BASE_URL,
-    ignoreHTTPSErrors: true,
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
-  },
-  projects: [
-    {
-      name: 'setup',
-      testMatch: 'support/typo3/auth.setup.ts',
-    },
-    {
-      name: 'chromium',
-      testMatch: 'tests/**/*.spec.ts',
-      use: { ...devices['Desktop Chrome'], storageState: AUTH_FILE },
-      dependencies: ['setup'],
-    },
-  ],
+export default defineTypo3PlaywrightConfig({
+  hostname: 'xima-typo3-frontend-edit.ddev.site',
 });

--- a/Tests/Playwright/support/frontend-edit/fixtures.ts
+++ b/Tests/Playwright/support/frontend-edit/fixtures.ts
@@ -1,8 +1,4 @@
-import { execSync } from 'node:child_process';
-
-const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
-const DATABASE = `database_${TYPO3_VERSION}`;
-const TYPO3_BIN = `/var/www/html/.Build/${TYPO3_VERSION}/vendor/bin/typo3`;
+import { flushCache, runSql } from '../typo3/environment';
 
 /**
  * Un-hides a tt_content record via a direct DB write, restoring
@@ -20,6 +16,6 @@ export function restoreHiddenContentElement(uid: number): void {
     throw new Error(`Invalid content element uid: ${uid}`);
   }
 
-  execSync(`mysql -h db -u root -proot ${DATABASE} -e "UPDATE tt_content SET hidden = 0 WHERE uid = ${uid};"`);
-  execSync(`${TYPO3_BIN} cache:flush`);
+  runSql(`UPDATE tt_content SET hidden = 0 WHERE uid = ${uid};`);
+  flushCache();
 }

--- a/Tests/Playwright/support/typo3/auth.setup.ts
+++ b/Tests/Playwright/support/typo3/auth.setup.ts
@@ -1,13 +1,15 @@
 import { test as setup } from '@playwright/test';
 import { BackendPage } from './backend.page';
+import { typo3AuthStateFile } from './environment';
 
-const TYPO3_VERSION = process.env.TYPO3_VERSION || '13';
-// Must match playwright.config.ts's AUTH_FILE — namespaced by version so
-// switching TYPO3_VERSION doesn't clobber the other version's saved session.
-const AUTH_FILE = `.auth/state-${TYPO3_VERSION}.json`;
+// Matches this repo's .ddev/.setup admin bootstrap
+// (.ddev/docker-compose.typo3-setup.yaml's TYPO3_SETUP_ADMIN_PASSWORD);
+// override via env for a ddev setup with different credentials.
+const USERNAME = process.env.TYPO3_ADMIN_USERNAME || 'admin';
+const PASSWORD = process.env.TYPO3_ADMIN_PASSWORD || 'Password1!';
 
 setup('authenticate as backend admin', async ({ page }) => {
   const backend = new BackendPage(page);
-  await backend.login('admin', 'Password1!');
-  await page.context().storageState({ path: AUTH_FILE });
+  await backend.login(USERNAME, PASSWORD);
+  await page.context().storageState({ path: typo3AuthStateFile() });
 });

--- a/Tests/Playwright/support/typo3/auth.setup.ts
+++ b/Tests/Playwright/support/typo3/auth.setup.ts
@@ -3,10 +3,9 @@ import { BackendPage } from './backend.page';
 import { typo3AuthStateFile } from './environment';
 
 // Matches this repo's .ddev/.setup admin bootstrap
-// (.ddev/docker-compose.typo3-setup.yaml's TYPO3_SETUP_ADMIN_PASSWORD);
-// override via env for a ddev setup with different credentials.
-const USERNAME = process.env.TYPO3_ADMIN_USERNAME || 'admin';
-const PASSWORD = process.env.TYPO3_ADMIN_PASSWORD || 'Password1!';
+// (.ddev/docker-compose.typo3-setup.yaml's TYPO3_SETUP_ADMIN_PASSWORD).
+const USERNAME = 'admin';
+const PASSWORD = 'Password1!';
 
 setup('authenticate as backend admin', async ({ page }) => {
   const backend = new BackendPage(page);

--- a/Tests/Playwright/support/typo3/config.ts
+++ b/Tests/Playwright/support/typo3/config.ts
@@ -4,18 +4,13 @@ import { resolveTypo3Version, typo3AuthStateFile, typo3BaseUrl } from './environ
 export interface Typo3PlaywrightConfigOptions {
   /** ddev hostname suffix this suite's per-version sites are registered under, e.g. "xima-typo3-frontend-edit.ddev.site". */
   hostname: string;
-  /** Path (relative to the project root) matched by the login setup project. */
-  setupProject?: string;
-  /** Glob matched by the main spec project. */
-  testMatch?: string;
 }
 
 /**
  * TYPO3-generic Playwright config factory — the extraction candidate for a
  * future shared typo3-playwright package. Wires up the version-parametrized
  * baseURL/storageState convention (see environment.ts) and the two-project
- * login-then-test structure; extension-specific test directories and specs
- * are supplied by the caller.
+ * login-then-test structure.
  */
 export function defineTypo3PlaywrightConfig(options: Typo3PlaywrightConfigOptions): PlaywrightTestConfig {
   const version = resolveTypo3Version();
@@ -35,11 +30,11 @@ export function defineTypo3PlaywrightConfig(options: Typo3PlaywrightConfigOption
     projects: [
       {
         name: 'setup',
-        testMatch: options.setupProject ?? 'support/typo3/auth.setup.ts',
+        testMatch: 'support/typo3/auth.setup.ts',
       },
       {
         name: 'chromium',
-        testMatch: options.testMatch ?? 'tests/**/*.spec.ts',
+        testMatch: 'tests/**/*.spec.ts',
         use: { ...devices['Desktop Chrome'], storageState: typo3AuthStateFile(version) },
         dependencies: ['setup'],
       },

--- a/Tests/Playwright/support/typo3/config.ts
+++ b/Tests/Playwright/support/typo3/config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test';
+import { resolveTypo3Version, typo3AuthStateFile, typo3BaseUrl } from './environment';
+
+export interface Typo3PlaywrightConfigOptions {
+  /** ddev hostname suffix this suite's per-version sites are registered under, e.g. "xima-typo3-frontend-edit.ddev.site". */
+  hostname: string;
+  /** Path (relative to the project root) matched by the login setup project. */
+  setupProject?: string;
+  /** Glob matched by the main spec project. */
+  testMatch?: string;
+}
+
+/**
+ * TYPO3-generic Playwright config factory — the extraction candidate for a
+ * future shared typo3-playwright package. Wires up the version-parametrized
+ * baseURL/storageState convention (see environment.ts) and the two-project
+ * login-then-test structure; extension-specific test directories and specs
+ * are supplied by the caller.
+ */
+export function defineTypo3PlaywrightConfig(options: Typo3PlaywrightConfigOptions): PlaywrightTestConfig {
+  const version = resolveTypo3Version();
+
+  return defineConfig({
+    testDir: '.',
+    fullyParallel: false,
+    workers: 1,
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+    use: {
+      baseURL: typo3BaseUrl(options.hostname, version),
+      ignoreHTTPSErrors: true,
+      trace: 'retain-on-failure',
+      screenshot: 'only-on-failure',
+    },
+    projects: [
+      {
+        name: 'setup',
+        testMatch: options.setupProject ?? 'support/typo3/auth.setup.ts',
+      },
+      {
+        name: 'chromium',
+        testMatch: options.testMatch ?? 'tests/**/*.spec.ts',
+        use: { ...devices['Desktop Chrome'], storageState: typo3AuthStateFile(version) },
+        dependencies: ['setup'],
+      },
+    ],
+  });
+}

--- a/Tests/Playwright/support/typo3/environment.ts
+++ b/Tests/Playwright/support/typo3/environment.ts
@@ -1,0 +1,50 @@
+import { execSync } from 'node:child_process';
+
+/**
+ * TYPO3-generic ddev environment helpers. Nothing here knows about any
+ * specific extension — this is the extraction candidate for a future
+ * shared typo3-playwright package. Assumes the `.ddev/.setup` conventions
+ * this comes from: per-version instances under `.Build/${version}`, a
+ * `database_${version}` MariaDB schema, reachable via the ddev-provided
+ * `mysql` client from inside the web container.
+ */
+
+export function resolveTypo3Version(): string {
+  return process.env.TYPO3_VERSION || '13';
+}
+
+export function typo3DatabaseName(version = resolveTypo3Version()): string {
+  return `database_${version}`;
+}
+
+export function typo3BinPath(version = resolveTypo3Version()): string {
+  return `/var/www/html/.Build/${version}/vendor/bin/typo3`;
+}
+
+export function typo3BaseUrl(hostname: string, version = resolveTypo3Version()): string {
+  return `https://${version}.${hostname}`;
+}
+
+export function typo3AuthStateFile(version = resolveTypo3Version()): string {
+  return `.auth/state-${version}.json`;
+}
+
+/**
+ * Runs a raw SQL statement against this TYPO3 version's database via the
+ * ddev-provided mysql client. Bypasses DataHandler entirely — pair with
+ * flushCache() if the write affects anything TYPO3 might have cached.
+ */
+export function runSql(query: string, version = resolveTypo3Version()): void {
+  execSync(`mysql -h db -u root -proot ${typo3DatabaseName(version)} -e "${query}"`);
+}
+
+/**
+ * Flushes TYPO3's cache. Needed after any direct DB write that bypasses
+ * DataHandler — DataHandler normally clears the affected caches itself,
+ * a raw SQL write never does, and a page can keep serving a stale cached
+ * render otherwise (confirmed live: a second run of a test that un-hides
+ * a record via runSql() timed out until this was added).
+ */
+export function flushCache(version = resolveTypo3Version()): void {
+  execSync(`${typo3BinPath(version)} cache:flush`);
+}


### PR DESCRIPTION
## Summary

- Pulls the TYPO3/ddev-generic parts of the Playwright suite out of extension-specific files, so they can be lifted wholesale into another extension's suite later
- Prepares `Tests/Playwright/support/typo3/` as a real extraction boundary for a future shared `typo3-playwright` package

## Changes

- `Tests/Playwright/support/typo3/environment.ts` (new) - version/database-name/binary-path/baseURL/auth-file resolution, plus `runSql()`/`flushCache()` helpers
- `Tests/Playwright/support/typo3/config.ts` (new) - `defineTypo3PlaywrightConfig()` factory wiring the version-parametrized baseURL/storageState convention and the login-then-test project structure
- `Tests/Playwright/playwright.config.ts` - now just calls the factory with this extension's hostname
- `Tests/Playwright/support/frontend-edit/fixtures.ts` - delegates to `runSql()`/`flushCache()` instead of duplicating DB/cache-binary plumbing
- `Tests/Playwright/support/typo3/auth.setup.ts` - uses the shared `typo3AuthStateFile()` helper

No behavior change — verified via typecheck and the full suite passing on both TYPO3 13 and 14.