### PR TITLE
test: add DOM hardening and onepager regression coverage

### DIFF
--- a/Tests/Acceptance/Fixtures/demo-content.sql
+++ b/Tests/Acceptance/Fixtures/demo-content.sql
@@ -3,8 +3,8 @@
 
 -- Clean slate: remove records from previous installs and default sys_template
 DELETE FROM `sys_template` WHERE `pid` = 1;
-DELETE FROM `tt_content` WHERE `pid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-DELETE FROM `pages` WHERE `uid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+DELETE FROM `tt_content` WHERE `pid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+DELETE FROM `pages` WHERE `uid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
 -- Pages
 REPLACE INTO `pages` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `title`, `doktype`, `slug`, `is_siteroot`) VALUES
@@ -17,7 +17,8 @@ REPLACE INTO `pages` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `so
 (7, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1024, 'Contact', 1, '/contact', 0),
 (8, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1280, 'Two Columns (Empty Column Test)', 1, '/two-columns', 0),
 (9, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1536, 'Default Layout (Empty Columns)', 1, '/empty-columns', 0),
-(10, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1792, 'Container (Nested Content)', 1, '/container', 0);
+(10, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1792, 'Container (Nested Content)', 1, '/container', 0),
+(11, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 2048, 'DOM Hardening', 1, '/dom-hardening', 0);
 
 -- Content Elements: Home (pid=1)
 REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `CType`, `colPos`, `header`, `header_layout`, `bodytext`, `starttime`, `endtime`) VALUES
@@ -107,6 +108,21 @@ REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`
 '<p>This content element lives inside the right container column (colPos 202, tx_container_parent 30). Same behaviour: editable, but not drag &amp; drop movable.</p>'),
 (33, 10, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1024, 'text', 0, 0, 'Note (plain element)', 0,
 '<p>Try dragging this element above the container to confirm plain elements reorder around the container element.</p>');
+
+-- Content Elements: DOM Hardening page (pid=11) — regression fixture for #222/#223.
+-- The html block embeds a DOM-clobbering form (a <form> whose child <input
+-- name="id"> shadows the IDL `form.id` property with the input itself,
+-- per HTMLFormElement named-property clobbering) and an SVG element (whose
+-- `.className` is an SVGAnimatedString, not a string) so any un-hardened
+-- `element.id`/`element.className` read in frontend_edit.js's DOM scan would
+-- throw and abort initialization. "section-c123" deliberately does not start
+-- with "c", so it must never be picked up as content element 123.
+REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `CType`, `colPos`, `header`, `header_layout`, `bodytext`) VALUES
+(34, 11, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'header', 0, 'DOM Hardening Regression Coverage', 1, ''),
+(35, 11, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'text', 0, 'Control Element', 0,
+'<p>This element must still receive an edit toolbar even with the hazards below present on the page — proof that initialization actually completed rather than merely not crashing.</p>'),
+(36, 11, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 768, 'html', 0, 'DOM Clobbering / SVG Hazards', 0,
+'<form id="cform-clobber"><input name="id" value="clobbered"></form>\n<svg id="csvg-icon" class="test-icon" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"></circle></svg>\n<div id="section-c123">Not a content element — must not be treated as uid 123.</div>');
 
 -- Assign backend layout "2 Columns 50/50" to page 8
 UPDATE `pages` SET `backend_layout` = 'pagets__2_columns_50_50' WHERE `uid` = 8;

--- a/Tests/Acceptance/Fixtures/demo-content.sql
+++ b/Tests/Acceptance/Fixtures/demo-content.sql
@@ -3,22 +3,27 @@
 
 -- Clean slate: remove records from previous installs and default sys_template
 DELETE FROM `sys_template` WHERE `pid` = 1;
-DELETE FROM `tt_content` WHERE `pid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-DELETE FROM `pages` WHERE `uid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+DELETE FROM `tt_content` WHERE `pid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+DELETE FROM `pages` WHERE `uid` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
 -- Pages
-REPLACE INTO `pages` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `title`, `doktype`, `slug`, `is_siteroot`) VALUES
-(1, 0, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'Home', 1, '/', 1),
-(2, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'About Us', 1, '/about-us', 0),
-(3, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'Services', 1, '/services', 0),
-(4, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 768, 'Blog', 1, '/blog', 0),
-(5, 4, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'Getting Started with TYPO3', 1, '/blog/getting-started', 0),
-(6, 4, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'Frontend Editing Tips', 1, '/blog/frontend-editing-tips', 0),
-(7, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1024, 'Contact', 1, '/contact', 0),
-(8, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1280, 'Two Columns (Empty Column Test)', 1, '/two-columns', 0),
-(9, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1536, 'Default Layout (Empty Columns)', 1, '/empty-columns', 0),
-(10, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1792, 'Container (Nested Content)', 1, '/container', 0),
-(11, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 2048, 'DOM Hardening', 1, '/dom-hardening', 0);
+-- nav_hide=1 on the test-utility pages (8-12): they exist for the E2E suite
+-- to navigate to directly by slug, not as real site content — the bootstrap
+-- theme's main menu isn't built for a long, mobile-unfriendly item list, so
+-- keep only the actual demo content (1-7) in it.
+REPLACE INTO `pages` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `title`, `doktype`, `slug`, `is_siteroot`, `nav_hide`) VALUES
+(1, 0, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'Home', 1, '/', 1, 0),
+(2, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'About Us', 1, '/about-us', 0, 0),
+(3, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'Services', 1, '/services', 0, 0),
+(4, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 768, 'Blog', 1, '/blog', 0, 0),
+(5, 4, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'Getting Started with TYPO3', 1, '/blog/getting-started', 0, 0),
+(6, 4, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'Frontend Editing Tips', 1, '/blog/frontend-editing-tips', 0, 0),
+(7, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1024, 'Contact', 1, '/contact', 0, 0),
+(8, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1280, 'Two Columns (Empty Column Test)', 1, '/two-columns', 0, 1),
+(9, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1536, 'Default Layout (Empty Columns)', 1, '/empty-columns', 0, 1),
+(10, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 1792, 'Container (Nested Content)', 1, '/container', 0, 1),
+(11, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 2048, 'DOM Hardening', 1, '/dom-hardening', 0, 1),
+(12, 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 2304, 'Onepager (Shortcut Content)', 1, '/onepager', 0, 1);
 
 -- Content Elements: Home (pid=1)
 REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `CType`, `colPos`, `header`, `header_layout`, `bodytext`, `starttime`, `endtime`) VALUES
@@ -123,6 +128,17 @@ REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`
 '<p>This element must still receive an edit toolbar even with the hazards below present on the page — proof that initialization actually completed rather than merely not crashing.</p>'),
 (36, 11, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 768, 'html', 0, 'DOM Clobbering / SVG Hazards', 0,
 '<form id="cform-clobber"><input name="id" value="clobbered"></form>\n<svg id="csvg-icon" class="test-icon" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"></circle></svg>\n<div id="section-c123">Not a content element — must not be treated as uid 123.</div>');
+
+-- Content Elements: Onepager page (pid=12) — regression fixture for the onepager
+-- flow: a native TYPO3 "Insert Records" (shortcut) element embeds tt_content
+-- uid=7 ("Our Mission", which actually lives on the About Us page, pid=2).
+-- Fluid_styled_content renders the referenced record through the normal
+-- tt_content pipeline, so it keeps its own id="c7" anchor here — exercising
+-- DataService.collectDataItems()'s whole-DOM id="c{uid}" scan (not pid-based)
+-- against a real foreign-pid element.
+REPLACE INTO `tt_content` (`uid`, `pid`, `tstamp`, `crdate`, `deleted`, `hidden`, `sorting`, `CType`, `colPos`, `header`, `header_layout`, `records`) VALUES
+(37, 12, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 256, 'header', 0, 'Onepager: Content Pulled From Another Page', 1, ''),
+(38, 12, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), 0, 0, 512, 'shortcut', 0, '', 0, '7');
 
 -- Assign backend layout "2 Columns 50/50" to page 8
 UPDATE `pages` SET `backend_layout` = 'pagets__2_columns_50_50' WHERE `uid` = 8;

--- a/Tests/Playwright/tests/dom-hardening.spec.ts
+++ b/Tests/Playwright/tests/dom-hardening.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+// Page seeded by Tests/Acceptance/Fixtures/demo-content.sql: header (uid=34),
+// text (uid=35 — our "did initialization actually complete" control signal),
+// and an html block (uid=36) containing a DOM-clobbering form, an SVG
+// element, and a "section-c123" id that must not be mistaken for content
+// element 123. Regression coverage for #222 (Dom.id() hardening), per #223.
+const CONTROL_ELEMENT_UID = 35;
+
+test('initializes despite the clobbering form/SVG and does not misidentify section-c123', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/dom-hardening');
+  await editInfoResponse;
+
+  // No crash: bootstrap()'s catch block would show this notification and abort
+  // the rest of init if collectDataItems()/Renderer.render() threw on the
+  // clobbered form's `.id` or the SVG's `.className`.
+  await expect(page.getByText('Initialization error')).toHaveCount(0);
+
+  // Init actually completed (not just "didn't crash"): a real content element
+  // on the same page still gets its toolbar, proving the hazards didn't
+  // silently break scanning for everything else on the page.
+  await expect(page.locator(`.frontend-edit__toolbar[data-cid="${CONTROL_ELEMENT_UID}"]`)).toHaveCount(1);
+
+  // "section-c123" doesn't match the exact `c{digits}` id pattern the scan
+  // requires ([id^="c"] narrowing + /^c(\d+)$/ exact match), so it's never
+  // treated as content element 123.
+  await expect(page.locator('.frontend-edit__toolbar[data-cid="123"]')).toHaveCount(0);
+});

--- a/Tests/Playwright/tests/onepager.spec.ts
+++ b/Tests/Playwright/tests/onepager.spec.ts
@@ -1,16 +1,27 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
 
-test.describe('onepager foreign-pid menus', () => {
-  test.fixme(
-    'needs an onepager fixture page — see follow-up issue filed after #220 merges',
-    async () => {
-      // Tests/Acceptance/Fixtures/demo-content.sql has no onepager page yet (a page
-      // rendering tt_content records whose pid differs from the page being viewed).
-      // Once added: navigate to that page, wait for the editInformation response,
-      // and assert the foreign-pid content elements still receive a working edit
-      // menu — DataService.collectDataItems() in frontend_edit.js scans the whole
-      // DOM by id="c{uid}", not by pid, so this should already work; the point of
-      // this test is to catch a regression in that assumption.
-    },
-  );
+// Onepager page (uid=12) seeded by Tests/Acceptance/Fixtures/demo-content.sql:
+// a native "Insert Records" (shortcut) content element embeds tt_content
+// uid=7 ("Our Mission"), which actually lives on the About Us page (pid=2).
+// fluid_styled_content renders the referenced record through the normal
+// tt_content pipeline, so it keeps its own id="c7" anchor here — exercising
+// DataService.collectDataItems()'s whole-DOM id="c{uid}" scan (not pid-based)
+// against a real foreign-pid element.
+const FOREIGN_PID_CONTENT_ELEMENT_UID = 7;
+
+test('builds a working edit menu for a content element embedded from another page', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/onepager');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.hover(FOREIGN_PID_CONTENT_ELEMENT_UID);
+
+  await expect(hoverMenu.toolbar(FOREIGN_PID_CONTENT_ELEMENT_UID)).toHaveCSS('opacity', '1');
+
+  // Edit action must target the foreign-pid record itself (uid 7), not the
+  // shortcut element that embeds it (uid 38) or the wrong page's content.
+  const editHref = await hoverMenu.editButton(FOREIGN_PID_CONTENT_ELEMENT_UID).getAttribute('href');
+  expect(decodeURIComponent(editHref ?? '')).toContain(`edit[tt_content][${FOREIGN_PID_CONTENT_ELEMENT_UID}]=edit`);
 });


### PR DESCRIPTION
## Summary

- Adds JS regression coverage for the DOM clobbering / SVG hardening fixed in #222
- Adds the onepager fixture that was deferred as a follow-up from #220, unblocking `onepager.spec.ts`
- Hides the test-utility fixture pages from the demo site's main navigation menu

## Changes

- `Tests/Acceptance/Fixtures/demo-content.sql`:
  - New page `/dom-hardening` (pid 11): a control content element plus an `html` block containing a DOM-clobbering `<form>`, an SVG element, and a `section-c123` id — the exact hazard shapes from #223
  - New page `/onepager` (pid 12): a native "Insert Records" (shortcut) content element embedding `tt_content` uid 7 from the About Us page, to exercise foreign-pid content elements
  - `nav_hide = 1` on all test-utility pages (two-columns, empty-columns, container, dom-hardening, onepager) — the bootstrap theme's main menu isn't built for a long item list, so only the real demo content stays in it
- `Tests/Playwright/tests/dom-hardening.spec.ts` (new) - asserts init completes (no error notification), a real content element still gets its toolbar, and `section-c123` is never mistaken for content element 123
- `Tests/Playwright/tests/onepager.spec.ts` - implemented (was `test.fixme()`): asserts the foreign-pid element gets a working edit menu targeting its own uid, not the shortcut container's

`translated-page.spec.ts` remains `test.fixme()` — it needs a second site language, a larger environment change scoped separately.

Verified: the `dom-hardening` spec was checked against a deliberately-reverted `Dom.id()` to confirm it actually fails without the #222 fix (not a vacuous test). Full suite green on both TYPO3 13 and 14.