### PR TITLE
feat: add expand-to-backend button to the v13 iframe modal

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1321,7 +1321,12 @@
 }
 
 .frontend-edit__modal-header {
-    display: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+    background: #21232b;
 }
 
 .frontend-edit__modal-title {

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1330,18 +1330,20 @@
 }
 
 .frontend-edit__modal-title {
+    flex: 1;
+    text-align: center;
     color: #fff;
     font-size: 14px;
     font-weight: 500;
 }
 
-.frontend-edit__modal-close {
+.frontend-edit__modal-close,
+.frontend-edit__modal-expand {
     width: 28px;
     height: 28px;
     background: transparent;
     border: none;
     color: #fff;
-    font-size: 20px;
     line-height: 1;
     cursor: pointer;
     display: flex;
@@ -1351,11 +1353,22 @@
     transition: background-color 0.2s ease;
 }
 
-.frontend-edit__modal-close:hover {
+.frontend-edit__modal-close {
+    font-size: 20px;
+}
+
+.frontend-edit__modal-expand svg {
+    width: 16px;
+    height: 16px;
+}
+
+.frontend-edit__modal-close:hover,
+.frontend-edit__modal-expand:hover {
     background: rgba(255, 255, 255, 0.1);
 }
 
-.frontend-edit__modal-close:focus-visible {
+.frontend-edit__modal-close:focus-visible,
+.frontend-edit__modal-expand:focus-visible {
     outline: 2px solid #fff;
     outline-offset: 2px;
     background: rgba(255, 255, 255, 0.1);

--- a/Resources/Public/JavaScript/backend_stubs.js
+++ b/Resources/Public/JavaScript/backend_stubs.js
@@ -186,6 +186,7 @@
 
     // Expose helpers used by iframe_edit.js
     window.XimaFrontendEdit = window.XimaFrontendEdit || {};
+    window.XimaFrontendEdit.IFRAME_ID = IFRAME_ID;
     window.XimaFrontendEdit.ensureReturnUrl = ensureReturnUrl;
     window.XimaFrontendEdit.openWizardOverlay = openWizardOverlay;
 

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -28,7 +28,9 @@
   // cleanly instead of accumulating handles.
 
   const MODAL_ID = 'xima-typo3-frontend-edit-modal';
-  const IFRAME_ID = 'xima-typo3-frontend-edit-modal-iframe';
+  // Single source of truth is backend_stubs.js (loads first); the literal
+  // here only covers the loading-bug case where stubs failed to load.
+  const IFRAME_ID = window.XimaFrontendEdit?.IFRAME_ID || 'xima-typo3-frontend-edit-modal-iframe';
   const ANIMATION_DELAY_MS = 10;
   const ANIMATION_DURATION_MS = 300;
 
@@ -48,6 +50,9 @@
   const WIZARD_CLICK_DELAY_MS = 800;
 
   const WIZARD_SELECTORS = 'typo3-backend-new-record-wizard, typo3-backend-new-content-element-wizard';
+
+  // Feather "external-link" icon (MIT) — used for the expand-to-backend button.
+  const EXPAND_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>';
 
   /**
    * Poll until predicate() returns truthy or timeout elapses.
@@ -121,12 +126,45 @@
     return url;
   }
 
+  /**
+   * Strip the iframe-only markers from a backend edit URL before opening it
+   * as a full backend page (expand button).
+   *
+   * 1. Drops the top-level `tx_ximatypo3frontendedit` marker so the
+   *    extension's injected "Save & Close" button doesn't show up
+   *    redundantly next to the backend's native Save/Close UI.
+   * 2. The `returnUrl` param carries a nested `tx_ximatypo3frontendedit_iframe=1`
+   *    marker (see ensureReturnUrl) that tells ToolRendererMiddleware to skip
+   *    flash-message collection on the post-save redirect. Once we're in the
+   *    full backend this is no longer an iframe flow, so that marker must be
+   *    removed from inside the returnUrl too — otherwise the success flash
+   *    silently disappears after Save.
+   */
+  function buildExpandUrl(url) {
+    try {
+      const backendUrl = new URL(url, window.location.origin);
+      backendUrl.searchParams.delete('tx_ximatypo3frontendedit');
+
+      const returnUrl = backendUrl.searchParams.get('returnUrl');
+      if (returnUrl) {
+        const cleanedReturnUrl = new URL(returnUrl, window.location.origin);
+        cleanedReturnUrl.searchParams.delete('tx_ximatypo3frontendedit_iframe');
+        backendUrl.searchParams.set('returnUrl', cleanedReturnUrl.toString());
+      }
+
+      return backendUrl.toString();
+    } catch (e) {
+      return url;
+    }
+  }
+
   // ── Modal ──────────────────────────────────────────────────────────
 
   const Modal = {
     element: null,
     iframe: null,
     closeTimer: null,
+    linkTargetBlank: false,
 
     getOrCreate() {
       if (this.element) return this.element;
@@ -138,6 +176,7 @@
         '<div class="frontend-edit__modal-overlay"></div>' +
         '<div class="frontend-edit__modal-panel">' +
           '<div class="frontend-edit__modal-header">' +
+            '<button class="frontend-edit__modal-expand" title="Open in backend">' + EXPAND_ICON + '</button>' +
             '<span class="frontend-edit__modal-title"></span>' +
             '<button class="frontend-edit__modal-close" title="Close">&times;</button>' +
           '</div>' +
@@ -153,6 +192,7 @@
       const close = () => this.close();
       modal.querySelector('.frontend-edit__modal-overlay').addEventListener('click', close);
       modal.querySelector('.frontend-edit__modal-close').addEventListener('click', close);
+      modal.querySelector('.frontend-edit__modal-expand').addEventListener('click', () => this.expandToBackend());
       document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
 
       this.element = modal;
@@ -161,7 +201,32 @@
       return modal;
     },
 
-    open(url) {
+    /**
+     * Open the current iframe URL in the full backend — the escape hatch for
+     * limitations the modal can't handle (complex IRRE, RTE issues, file
+     * relations). Uses contentWindow.location so it reflects wizard steps and
+     * in-form navigation, not just the URL the modal was opened with.
+     */
+    expandToBackend() {
+      let currentUrl;
+      try {
+        currentUrl = this.iframe?.contentWindow?.location.href;
+      } catch (_) { /* cross-origin */ }
+      currentUrl = currentUrl || this.iframe?.src;
+      if (!currentUrl || currentUrl === 'about:blank') return;
+
+      const backendUrl = buildExpandUrl(currentUrl);
+      this.close();
+      if (this.linkTargetBlank) {
+        window.open(backendUrl, '_blank');
+      } else {
+        window.location.href = backendUrl;
+      }
+      Logger.log('Expanded to backend', { url: backendUrl });
+    },
+
+    open(url, linkTargetBlank) {
+      this.linkTargetBlank = !!linkTargetBlank;
       // Ensure the returnUrl carries tx_ximatypo3frontendedit_iframe=1
       // so the post-save redirect to the frontend URL does not consume the
       // flash message queue inside the iframe — the parent reload picks
@@ -748,7 +813,7 @@
         if (target?.href && isBackendUrl(target.href)) {
           e.preventDefault();
           e.stopPropagation();
-          Modal.open(target.href);
+          Modal.open(target.href, target.target === '_blank');
           Logger.log('Link intercepted → modal', { href: target.href });
         }
       }, true);

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -218,7 +218,7 @@
       const backendUrl = buildExpandUrl(currentUrl);
       this.close();
       if (this.linkTargetBlank) {
-        window.open(backendUrl, '_blank');
+        window.open(backendUrl, '_blank', 'noopener');
       } else {
         window.location.href = backendUrl;
       }

--- a/Tests/Playwright/tests/iframe-modal-expand.spec.ts
+++ b/Tests/Playwright/tests/iframe-modal-expand.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
+const CONTENT_ELEMENT_UID = 2;
+
+test('expand button opens the current edit URL in the full backend, same tab', async ({ page, context }) => {
+  // See edit-menu.spec.ts: the listener must be registered before goto(), not after.
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+  await hoverMenu.editButton(CONTENT_ELEMENT_UID).click();
+
+  // On v13 (no contextual-edit route) this is the iframe_edit.js modal — see
+  // edit-action.spec.ts for why the same demo config resolves to the modal
+  // rather than the contextual sidebar.
+  const editIframe = page.locator('iframe[src*="/typo3/record/edit"]');
+  await expect(editIframe).toHaveCount(1);
+
+  const expandButton = page.locator('.frontend-edit__modal-expand');
+  await expect(expandButton).toBeVisible();
+
+  await expandButton.click();
+
+  // Same tab: no popup window was opened, and the top-level page itself now
+  // shows the backend edit form (the modal's escape hatch, not a new one).
+  expect(context.pages()).toHaveLength(1);
+  await page.waitForURL((url) => url.pathname.includes('/typo3/record/edit'));
+  expect(decodeURIComponent(page.url())).toContain(`edit[tt_content][${CONTENT_ELEMENT_UID}]=edit`);
+
+  // The extension's own "Save & Close" marker must not leak into the full
+  // backend view (see buildExpandUrl in iframe_edit.js).
+  const url = new URL(page.url());
+  expect(url.searchParams.has('tx_ximatypo3frontendedit')).toBe(false);
+});

--- a/Tests/Playwright/tests/iframe-modal-expand.spec.ts
+++ b/Tests/Playwright/tests/iframe-modal-expand.spec.ts
@@ -1,10 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { HoverMenu } from '../support/frontend-edit/hover-menu';
+import { resolveTypo3Version } from '../support/typo3/environment';
 
 // "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
 const CONTENT_ELEMENT_UID = 2;
 
 test('expand button opens the current edit URL in the full backend, same tab', async ({ page, context }) => {
+  // The expand button only exists in the v13-only iframe modal (iframe_edit.js) —
+  // on v14.2+ the contextual sidebar handles editing and this modal is never loaded
+  // for a plain edit click (see ResourceRendererService::render()).
+  test.skip(resolveTypo3Version() !== '13', 'expand button is part of the v13-only iframe modal');
+
   // See edit-menu.spec.ts: the listener must be registered before goto(), not after.
   const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
   await page.goto('/');


### PR DESCRIPTION
## Summary

- Fix a pre-existing bug where the iframe modal header (and its close button) was permanently invisible due to a stray `display: none`
- Add an escape-hatch button that opens the current iframe edit URL in the full backend, for cases the modal can't handle well (complex IRRE fields, RTE issues, file relations)
- Button respects the intercepted link's own `target="_blank"` instead of introducing a new settings flag
- Clean both the top-level `tx_ximatypo3frontendedit` marker and the nested `tx_ximatypo3frontendedit_iframe` marker inside `returnUrl` before navigating, so the post-save success flash still shows up after expanding

## Changes

- `Resources/Public/Css/FrontendEdit.css` - Fix modal header visibility; style the new expand button consistent with the existing close button
- `Resources/Public/JavaScript/iframe_edit.js` - Add expand button markup/click handler, `buildExpandUrl()` marker cleanup, capture `targetBlank` per link
- `Resources/Public/JavaScript/backend_stubs.js` - Expose `IFRAME_ID` as a single source of truth for both scripts
- `Tests/Playwright/tests/iframe-modal-expand.spec.ts` - E2E coverage for the new button (v13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expand control to the iframe editing modal.
  * Open the full editing page in the current or a new window, depending on the original link.
  * Improved modal header layout, title alignment, controls, and hover/focus styling.

* **Bug Fixes**
  * Ensured expanded editing links retain the correct content context while removing iframe-specific parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->