### PR TITLE
feat: add public JavaScript API facade and lifecycle events

### DIFF
--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -14,6 +14,8 @@ Three opportunities exist to extend the Edit Menu with custom entries:
 
 Additionally, you can provide a :ref:`custom css <custom-styling>` file to adjust the styling.
 
+For UI that needs to run in the browser, see the :ref:`JavaScript API <javascript-api>`.
+
 ..  toctree::
     :maxdepth: 3
 
@@ -21,3 +23,4 @@ Additionally, you can provide a :ref:`custom css <custom-styling>` file to adjus
     DataAttributes
     EmptyColumns
     CustomStyling
+    JavaScriptApi

--- a/Documentation/DeveloperCorner/JavaScriptApi.rst
+++ b/Documentation/DeveloperCorner/JavaScriptApi.rst
@@ -1,0 +1,156 @@
+..  include:: /Includes.rst.txt
+
+..  _javascript-api:
+
+=========================
+Extending the frontend UI
+=========================
+
+For UI that needs to run in the browser - status badges, comment indicators,
+custom toolbar buttons - the extension exposes a small, stable facade on
+:code:`window.XimaFrontendEdit` and dispatches DOM :code:`CustomEvent`\ s at
+defined lifecycle points. Internal refactors of the underlying JavaScript do
+not change these method signatures or event :code:`detail` shapes - this is
+the one part of the frontend JavaScript covered by a semver guarantee.
+
+..  note::
+    Everything described here requires frontend editing to be active for the
+    current backend user (see :ref:`Introduction <introduction>`). When
+    editing is disabled, :code:`xfe:ready` still fires once with an empty
+    element map, but no elements are ever registered.
+
+Facade methods
+===============
+
+``getElementInfo(uid)``
+------------------------
+
+Returns the resolved target element and payload for a content element uid, so
+consumers never have to re-do DOM resolution (anchor pattern, translation
+mapping). Returns :code:`null` if the uid was not rendered.
+
+..  code-block:: javascript
+
+    const info = window.XimaFrontendEdit.getElementInfo(42);
+    // { uid: 42, element: HTMLElement, payload: { element: {...}, menu: {...} } }
+
+``notify({ title, message, severity })``
+------------------------------------------
+
+Shows a toast notification using the extension's own notification manager.
+:code:`severity` is one of :code:`ok`, :code:`info`, :code:`warning`,
+:code:`error`.
+
+..  code-block:: javascript
+
+    window.XimaFrontendEdit.notify({
+        title: 'Comment added',
+        message: 'A new comment was posted on this element.',
+        severity: 'info',
+    });
+
+``registerToolbarItem(uid, buttonSpec)``
+------------------------------------------
+
+Adds a button to a content element's hover toolbar, next to the built-in
+Edit/More actions buttons. :code:`buttonSpec`:
+
+- ``html`` - inner HTML of the button (e.g. an inline SVG icon)
+- ``label`` - accessible label, also used as the tooltip
+- ``href`` - renders an :code:`<a>` instead of a :code:`<button>`
+- ``onClick`` - click handler
+
+..  code-block:: javascript
+
+    window.XimaFrontendEdit.registerToolbarItem(42, {
+        html: '<svg>...</svg>',
+        label: 'Show comments',
+        onClick: () => openCommentsPanel(42),
+    });
+
+``registerBadge(uid, spec)``
+------------------------------
+
+Renders a persistent, hover-independent indicator on a content element's
+overlay - useful for "live annotating" a page, where a marker must be
+visible at a glance rather than only on hover. :code:`spec`:
+
+- ``html`` or ``element`` - the badge content (HTML string or a DOM element)
+- ``position`` - one of ``top-left``, ``top-right`` (default), ``bottom-left``, ``bottom-right``
+- ``onClick`` - click handler; the badge only receives pointer events when this is set
+
+..  code-block:: javascript
+
+    window.XimaFrontendEdit.registerBadge(42, {
+        html: '<span class="my-badge" title="3 comments">3</span>',
+        position: 'top-left',
+        onClick: () => openCommentsPanel(42),
+    });
+
+``openBackendView(url, options)``
+------------------------------------
+
+Opens a backend URL in the version-appropriate container: the contextual
+sidebar (v14.2+, when enabled), the v13 iframe modal, or a new tab as a
+fallback. :code:`options.target = 'tab'` forces a new tab regardless of
+version.
+
+..  code-block:: javascript
+
+    window.XimaFrontendEdit.openBackendView(commentsBackendUrl, { target: 'tab' });
+
+Lifecycle events
+==================
+
+All events are dispatched on :code:`document`.
+
+``xfe:ready``
+--------------
+
+Fired once, after the initial AJAX render (or immediately, with an empty map,
+when frontend editing is disabled).
+
+- ``detail.elements`` - plain object keyed by content element uid, each value shaped like the ``getElementInfo()`` return value
+
+``xfe:element-rendered``
+--------------------------
+
+Fired once per content element, right after its overlay/toolbar is built.
+
+- ``detail.uid``, ``detail.element``, ``detail.payload`` - same as ``getElementInfo()``
+- ``detail.overlay``, ``detail.toolbar``, ``detail.dropdown`` - the underlying DOM nodes (``dropdown`` is ``null`` when the element has no context menu)
+
+``xfe:dropdown-open`` / ``xfe:dropdown-close``
+-------------------------------------------------
+
+Fired when a content element's "More actions" dropdown opens or closes.
+:code:`detail.uid` identifies the element. Only fires for an actual
+open/close interaction - hovering between elements does not trigger a
+spurious :code:`xfe:dropdown-close` for a dropdown that was never open.
+
+..  code-block:: javascript
+
+    document.addEventListener('xfe:element-rendered', (event) => {
+        const { uid, payload } = event.detail;
+        if (payload.element.CType === 'list' && payload.element.list_type === 'news_pi1') {
+            window.XimaFrontendEdit.registerBadge(uid, { html: '<span>News</span>' });
+        }
+    });
+
+Minimal integration example
+==============================
+
+..  code-block:: javascript
+    :caption: A third-party extension listening for rendered elements
+
+    document.addEventListener('xfe:ready', (event) => {
+        console.log('Frontend Edit ready with', Object.keys(event.detail.elements).length, 'element(s)');
+    });
+
+    document.addEventListener('xfe:element-rendered', (event) => {
+        const { uid } = event.detail;
+        window.XimaFrontendEdit.registerToolbarItem(uid, {
+            label: 'Open comments',
+            onClick: () => window.XimaFrontendEdit.openBackendView('/comments/' + uid),
+        });
+    });

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -153,6 +153,19 @@
     opacity: 1;
 }
 
+/* Public API: persistent badge (PublicApi.registerBadge) - unlike the outline
+   and toolbar above, badges stay visible regardless of hover state. */
+.frontend-edit__badge {
+    position: absolute;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.frontend-edit__badge--top-left { top: -6px; left: -6px; }
+.frontend-edit__badge--top-right { top: -6px; right: -6px; }
+.frontend-edit__badge--bottom-left { bottom: -6px; left: -6px; }
+.frontend-edit__badge--bottom-right { bottom: -6px; right: -6px; }
+
 /* Element: toolbar - invisible container for label and actions */
 .frontend-edit__toolbar {
     position: absolute;

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -62,6 +62,53 @@
   };
 
   /**
+   * Dispatches the public `xfe:*` lifecycle events (see PublicApi below) on
+   * `document`, so third-party listeners can use standard event delegation.
+   */
+  const Events = {
+    dispatch(name, detail) {
+      document.dispatchEvent(new CustomEvent(name, { detail }));
+    }
+  };
+
+  /**
+   * Registry - Tracks rendered content elements for the public API
+   * (PublicApi.getElementInfo/registerBadge/registerToolbarItem) and the
+   * `xfe:ready` element snapshot.
+   *
+   * Entries are stored under both the DOM anchor uid and the record's own
+   * uid (see Renderer.render()'s translation mapping) so consumers can look
+   * elements up by either.
+   */
+  const Registry = {
+    entries: new Map(), // Map<number uid, {uid, element, payload, overlay, toolbar, dropdown}>
+
+    set(uid, entry) {
+      this.entries.set(Number(uid), entry);
+    },
+
+    get(uid) {
+      return this.entries.get(Number(uid)) || null;
+    },
+
+    /**
+     * Plain-object snapshot for `xfe:ready`, keyed by the record's own uid and
+     * deduplicated so translation-mapped entries (registered under two uids)
+     * appear once.
+     */
+    snapshot() {
+      const seen = new Set();
+      const out = {};
+      this.entries.forEach((entry) => {
+        if (seen.has(entry)) return;
+        seen.add(entry);
+        out[entry.uid] = { uid: entry.uid, element: entry.element, payload: entry.payload };
+      });
+      return out;
+    }
+  };
+
+  /**
    * Tooltip Manager
    */
   const Tooltip = {
@@ -160,6 +207,12 @@
 
     closeAll() {
       document.querySelectorAll('.frontend-edit__dropdown').forEach(d => {
+        // Only fire xfe:dropdown-close for dropdowns that were actually open.
+        // closeAll() also runs on every hover switch (OverlayManager.updateActiveFromPointer),
+        // so firing unconditionally would spam the event on plain mouse movement.
+        if (d.style.display === 'block') {
+          Events.dispatch('xfe:dropdown-close', { uid: Number(d.dataset.cid) });
+        }
         d.style.display = 'none';
       });
       document.querySelectorAll('.frontend-edit__btn--kebab').forEach(btn => {
@@ -1060,6 +1113,127 @@
   };
 
   /**
+   * Public API - the stable surface exposed on window.XimaFrontendEdit for
+   * third-party extensions (see Documentation/DeveloperCorner/JavaScriptApi.rst).
+   * Internal refactors of this file must not change these method signatures
+   * or the `xfe:*` event detail shapes.
+   */
+  const PublicApi = {
+    /**
+     * Resolves target element + payload for a uid, so consumers never re-do
+     * DOM resolution. Returns null if the uid is unknown (not rendered, or
+     * frontend editing is disabled).
+     */
+    getElementInfo(uid) {
+      const entry = Registry.get(uid);
+      if (!entry) return null;
+      return { uid: entry.uid, element: entry.element, payload: entry.payload };
+    },
+
+    /**
+     * Shows a toast notification, reusing the internal Notification manager.
+     */
+    notify(message) {
+      Notification.show(message || {});
+    },
+
+    /**
+     * Adds a button to a content element's hover toolbar actions.
+     * buttonSpec: { html, label, href, onClick }
+     * Returns the created button, or null if the uid is unknown.
+     */
+    registerToolbarItem(uid, buttonSpec) {
+      const entry = Registry.get(uid);
+      const actions = entry?.toolbar?.querySelector('.frontend-edit__toolbar-actions');
+      if (!actions) return null;
+
+      const spec = buttonSpec || {};
+      const btn = document.createElement(spec.href ? 'a' : 'button');
+      btn.className = 'frontend-edit__btn frontend-edit__btn--custom';
+      if (!spec.href) btn.type = 'button';
+      if (spec.html) btn.innerHTML = spec.html;
+      if (spec.label) {
+        btn.setAttribute('aria-label', spec.label);
+        btn.dataset.tooltip = spec.label;
+        Tooltip.attach(btn);
+      }
+      if (spec.href && UI.isValidUrl(spec.href)) btn.href = spec.href;
+      if (typeof spec.onClick === 'function') btn.addEventListener('click', spec.onClick);
+
+      actions.appendChild(btn);
+      return btn;
+    },
+
+    /**
+     * Renders a persistent, hover-independent indicator on a content element's
+     * overlay. spec: { html | element, position, onClick }; position is one of
+     * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' (default 'top-right').
+     * Returns the created badge, or null if the uid is unknown.
+     *
+     * This is deliberately minimal: stacking of multiple badges per element and
+     * a dedicated always-on-top badge layer are covered by a later iteration
+     * (issue #211); this appends directly into the existing position-tracked
+     * overlay, which is enough for a single badge per element today.
+     */
+    registerBadge(uid, spec) {
+      const entry = Registry.get(uid);
+      if (!entry) return null;
+
+      const badgeSpec = spec || {};
+      const badge = document.createElement('span');
+      badge.className = 'frontend-edit__badge frontend-edit__badge--' + (badgeSpec.position || 'top-right');
+      if (badgeSpec.element instanceof Element) {
+        badge.appendChild(badgeSpec.element);
+      } else if (badgeSpec.html) {
+        badge.innerHTML = badgeSpec.html;
+      }
+      if (typeof badgeSpec.onClick === 'function') {
+        badge.style.pointerEvents = 'auto';
+        badge.style.cursor = 'pointer';
+        badge.addEventListener('click', badgeSpec.onClick);
+      }
+
+      entry.overlay.appendChild(badge);
+      return badge;
+    },
+
+    /**
+     * Opens a backend URL in the version-appropriate container: the contextual
+     * sidebar (v14.2+, when enabled), the v13 iframe modal (via the export
+     * iframe_edit.js attaches to this namespace), or a new tab as a fallback.
+     * options: { target } where target is 'tab' to force a new tab.
+     *
+     * This is deliberately minimal (no link-interception policy, no close
+     * callback) - the full primitive with those is issue #209.
+     */
+    openBackendView(url, options) {
+      if (!UI.isValidUrl(url)) return false;
+      const opts = options || {};
+
+      if (opts.target === 'tab') {
+        window.open(url, '_blank');
+        return true;
+      }
+      if (window.FRONTEND_EDIT_CONTEXTUAL_EDITING && window.ContextualEdit && window.ContextualEdit.sidebar) {
+        window.ContextualEdit.open(url, null, false);
+        return true;
+      }
+      if (typeof window.XimaFrontendEdit?.openModal === 'function') {
+        window.XimaFrontendEdit.openModal(url, false);
+        return true;
+      }
+      window.open(url, '_blank');
+      return true;
+    }
+  };
+
+  // Merge onto window.XimaFrontendEdit rather than assigning: backend_stubs.js
+  // (loaded first when the v13 iframe modal is enabled) already sets internal
+  // helpers (IFRAME_ID, ensureReturnUrl, openWizardOverlay) on this namespace -
+  // those are not part of the public API but must survive.
+  window.XimaFrontendEdit = Object.assign(window.XimaFrontendEdit || {}, PublicApi);
+
+  /**
    * Data Service
    */
   const DataService = {
@@ -1278,7 +1452,7 @@
       const effectiveShowContextMenu = showContextMenu && hasMenuChildren && !contentElement.menu.url;
 
       // Create overlay with toolbar
-      const { toolbar } = OverlayManager.createOverlay(uid, targetElement, contentElement, effectiveShowContextMenu, enableOutline);
+      const { overlay, toolbar } = OverlayManager.createOverlay(uid, targetElement, contentElement, effectiveShowContextMenu, enableOutline);
 
       // Create dropdown if needed
       let dropdown = null;
@@ -1289,6 +1463,17 @@
       }
       // Hover highlighting is handled centrally by OverlayManager's pointer
       // tracking (no per-element mouseenter/leave needed).
+
+      // Register under both the DOM anchor uid and the record's own uid (they
+      // differ when Renderer.render() applied translation mapping) so the
+      // public API can resolve elements by either.
+      const domUid = Number(uid);
+      const recordUid = Number(contentElement.element.uid) || domUid;
+      const entry = { uid: recordUid, element: targetElement, payload: contentElement, overlay, toolbar, dropdown };
+      Registry.set(domUid, entry);
+      if (recordUid !== domUid) Registry.set(recordUid, entry);
+
+      Events.dispatch('xfe:element-rendered', { uid: recordUid, element: targetElement, payload: contentElement, overlay, toolbar, dropdown });
     },
 
     setupKebabEvents(toolbar, dropdown) {
@@ -1308,6 +1493,7 @@
           await Dropdown.position(kebabBtn, dropdown);
           const firstItem = dropdown.querySelector('[role="menuitem"]');
           if (firstItem) firstItem.focus();
+          Events.dispatch('xfe:dropdown-open', { uid: Number(toolbar.dataset.cid) });
         }
       });
     }
@@ -1820,6 +2006,10 @@
           DeleteHandler.init();
           DragReorder.init();
         }
+
+        // Fired unconditionally (even when frontend editing is disabled, with an
+        // empty element map) so consumers always get one reliable ready signal.
+        Events.dispatch('xfe:ready', { elements: Registry.snapshot() });
 
         Logger.log(`Frontend Edit initialization completed in ${Math.round(performance.now() - startTime)}ms`);
       } catch (error) {

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -785,6 +785,11 @@
 
   // ── Init ───────────────────────────────────────────────────────────
 
+  // Export for the public API's openBackendView() (frontend_edit.js) - the
+  // only way to reach this modal from outside this IIFE.
+  window.XimaFrontendEdit = window.XimaFrontendEdit || {};
+  window.XimaFrontendEdit.openModal = Modal.open.bind(Modal);
+
   LinkInterceptor.init();
   Logger.log('Modal edit system initialized');
 })();

--- a/Tests/Playwright/tests/public-api.spec.ts
+++ b/Tests/Playwright/tests/public-api.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
+const CONTENT_ELEMENT_UID = 2;
+
+type XfeLogEntry = {
+  name: string;
+  uid?: number;
+  hasElement?: boolean;
+  payloadUid?: number;
+  elementUids?: string[];
+};
+
+// Registered via addInitScript so the listeners exist before frontend_edit.js's
+// own script tag executes on navigation. Captures only serializable fields -
+// DOM elements/CustomEvent detail objects don't survive page.evaluate()'s
+// structured-clone round trip back to the test process.
+async function installXfeLogger(page: import('@playwright/test').Page): Promise<void> {
+  await page.addInitScript(() => {
+    (window as any).__xfeLog = [];
+    const capture = (name: string) => (e: Event) => {
+      const detail = (e as CustomEvent).detail || {};
+      (window as any).__xfeLog.push({
+        name,
+        uid: detail.uid,
+        hasElement: detail.element instanceof Element,
+        payloadUid: detail.payload?.element?.uid,
+        elementUids: detail.elements ? Object.keys(detail.elements) : undefined,
+      });
+    };
+    ['xfe:ready', 'xfe:element-rendered', 'xfe:dropdown-open', 'xfe:dropdown-close'].forEach((name) => {
+      document.addEventListener(name, capture(name));
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await installXfeLogger(page);
+});
+
+test('xfe:ready fires once with an element map, xfe:element-rendered fires per element', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await expect(hoverMenu.toolbar(CONTENT_ELEMENT_UID)).toHaveCount(1);
+
+  const log = await page.evaluate(() => (window as any).__xfeLog as XfeLogEntry[]);
+
+  const readyEvents = log.filter((e) => e.name === 'xfe:ready');
+  expect(readyEvents).toHaveLength(1);
+  expect(readyEvents[0].elementUids).toContain(String(CONTENT_ELEMENT_UID));
+
+  const renderedForUid = log.filter((e) => e.name === 'xfe:element-rendered' && e.uid === CONTENT_ELEMENT_UID);
+  expect(renderedForUid).toHaveLength(1);
+  expect(renderedForUid[0].hasElement).toBe(true);
+  expect(renderedForUid[0].payloadUid).toBe(CONTENT_ELEMENT_UID);
+});
+
+test('getElementInfo resolves the DOM element and payload for a uid', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const info = await page.evaluate((uid) => {
+    const result = (window as any).XimaFrontendEdit.getElementInfo(uid);
+    return result
+      ? { uid: result.uid, hasElement: result.element instanceof Element, ctype: result.payload?.element?.CType }
+      : null;
+  }, CONTENT_ELEMENT_UID);
+
+  expect(info?.uid).toBe(CONTENT_ELEMENT_UID);
+  expect(info?.hasElement).toBe(true);
+  expect(info?.ctype).toBeTruthy();
+
+  const unknown = await page.evaluate(() => (window as any).XimaFrontendEdit.getElementInfo(999999));
+  expect(unknown).toBeNull();
+});
+
+test('registerToolbarItem adds a clickable button to the hover toolbar', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    (window as any).__customClicked = false;
+    (window as any).XimaFrontendEdit.registerToolbarItem(uid, {
+      html: '<span>X</span>',
+      label: 'Custom action',
+      onClick: () => {
+        (window as any).__customClicked = true;
+      },
+    });
+  }, CONTENT_ELEMENT_UID);
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+
+  const customBtn = hoverMenu.toolbar(CONTENT_ELEMENT_UID).locator('.frontend-edit__btn--custom');
+  await expect(customBtn).toBeVisible();
+  await expect(customBtn).toHaveAttribute('aria-label', 'Custom action');
+
+  await customBtn.click();
+  expect(await page.evaluate(() => (window as any).__customClicked)).toBe(true);
+});
+
+test('registerBadge renders a persistent indicator independent of hover', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    (window as any).XimaFrontendEdit.registerBadge(uid, {
+      // Explicit size: an empty/unstyled inline span has a zero-area bounding
+      // box, which Playwright's toBeVisible() treats as not visible.
+      html: '<span class="dot" style="display:inline-block;width:8px;height:8px;background:red;border-radius:50%;"></span>',
+      position: 'top-left',
+    });
+  }, CONTENT_ELEMENT_UID);
+
+  const badge = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge`);
+  await expect(badge).toHaveCount(1);
+  await expect(badge).toHaveClass(/frontend-edit__badge--top-left/);
+
+  // Not hovering the element: the badge must stay visible, unlike the
+  // hover-gated toolbar/outline (opacity 0 until OverlayManager activates it).
+  await expect(badge).toBeVisible();
+});
+
+test('notify shows a toast notification', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate(() => {
+    (window as any).XimaFrontendEdit.notify({ title: 'Hello from a third party', message: 'World', severity: 'ok' });
+  });
+
+  const toast = page.locator('.frontend-edit__notification');
+  await expect(toast).toBeVisible();
+  await expect(toast.locator('.frontend-edit__notification-title')).toHaveText('Hello from a third party');
+});
+
+test('xfe:dropdown-open/close fire exactly once per interaction, not on every hover switch', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.openDropdown(CONTENT_ELEMENT_UID);
+  await expect(hoverMenu.dropdown(CONTENT_ELEMENT_UID)).toBeVisible();
+
+  // Hover away and back - exercises OverlayManager's pointer-driven
+  // Dropdown.closeAll() path, which must not re-fire the close event once
+  // the dropdown is already closed.
+  await page.mouse.move(0, 0);
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+
+  const log = await page.evaluate(() => (window as any).__xfeLog as XfeLogEntry[]);
+  const opens = log.filter((e) => e.name === 'xfe:dropdown-open' && e.uid === CONTENT_ELEMENT_UID);
+  const closes = log.filter((e) => e.name === 'xfe:dropdown-close' && e.uid === CONTENT_ELEMENT_UID);
+
+  expect(opens).toHaveLength(1);
+  expect(closes).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

- Expose a small, stable facade on `window.XimaFrontendEdit` for third-party extensions: `getElementInfo`, `notify`, `registerToolbarItem`, `registerBadge`, `openBackendView`
- Dispatch DOM `CustomEvent`s at defined lifecycle points: `xfe:ready`, `xfe:element-rendered`, `xfe:dropdown-open`/`xfe:dropdown-close`
- Merge onto `window.XimaFrontendEdit` rather than assigning, since `backend_stubs.js` already sets internal helpers on that namespace when the v13 iframe modal is enabled
- `registerBadge`/`openBackendView` are intentionally minimal-real for now — badge stacking and a full link-interception policy are separate, later issues (#211, #209)
- New documentation chapter "Extending the frontend UI"

## Changes

- `Resources/Public/JavaScript/frontend_edit.js` - Registry + Events helpers, public API surface, lifecycle event dispatch
- `Resources/Public/JavaScript/iframe_edit.js` - exports `Modal.open` onto the shared namespace so `openBackendView` can reach the v13 modal
- `Resources/Public/Css/FrontendEdit.css` - badge positioning styles
- `Tests/Playwright/tests/public-api.spec.ts` - E2E coverage for all facade methods and lifecycle events
- `Documentation/DeveloperCorner/JavaScriptApi.rst` - new developer documentation chapter

Closes #208

## Test plan

- [x] Playwright suite passes (`Tests/Playwright/tests/public-api.spec.ts`, full suite run for regressions)
- [ ] Manual smoke test on a v14.2+ instance with the contextual sidebar enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public JavaScript API for extending the frontend editing experience.
  - Added support for querying elements, displaying notifications, adding toolbar actions and badges, and opening backend views or modals.
  - Added lifecycle events for readiness, element rendering, and dropdown state changes.
  - Added persistent badge positioning options.

- **Documentation**
  - Added comprehensive JavaScript API documentation and a Developer Corner reference.

- **Tests**
  - Added end-to-end coverage for API methods, events, notifications, toolbar actions, badges, and dropdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->