### PR TITLE
feat: add generic open-backend-view primitive

### DIFF
--- a/Documentation/DeveloperCorner/JavaScriptApi.rst
+++ b/Documentation/DeveloperCorner/JavaScriptApi.rst
@@ -91,13 +91,33 @@ visible at a glance rather than only on hover. :code:`spec`:
 ------------------------------------
 
 Opens a backend URL in the version-appropriate container: the contextual
-sidebar (v14.2+, when enabled), the v13 iframe modal, or a new tab as a
-fallback. :code:`options.target = 'tab'` forces a new tab regardless of
-version.
+sidebar (v14.2+, when enabled and available), the v13 iframe modal, or a new
+tab as a fallback - no version checks needed in consumer code. The returnUrl
+flash-message deferral mechanism used by edit forms is applied automatically.
+:code:`options`:
+
+- ``target`` - :code:`'tab'` forces a new tab regardless of version
+- ``title`` - shown in the container's header
+- ``width`` - a CSS length (e.g. :code:`'600px'`, :code:`'50%'`); invalid values are ignored
+- ``onClose`` - called with :code:`{ reason }` when the container closes (:code:`reason` is :code:`'close'`, or :code:`'saved'` for the sidebar's own save flow)
+- ``reloadOnClose`` - reload the parent page on close (default :code:`true`)
+- ``linkPolicy`` - a rule or array of rules :code:`{ match: string | RegExp, action }`, evaluated against link clicks inside the embedded document. :code:`action` is one of:
+
+  - ``stay`` (default when nothing matches) - keep navigation inside the container, same as today's built-in behavior
+  - ``close`` - close the container
+  - ``ignore`` - swallow the click, do nothing
+  - ``external`` - open the link in a new tab
+
+  The policy only ever governs plain link clicks - the built-in save/close buttons of an actual edit form keep working exactly as before.
 
 ..  code-block:: javascript
 
-    window.XimaFrontendEdit.openBackendView(commentsBackendUrl, { target: 'tab' });
+    window.XimaFrontendEdit.openBackendView(commentsBackendUrl, {
+        title: 'Comments',
+        width: '480px',
+        linkPolicy: { match: '/typo3/module/web/layout', action: 'close' },
+        onClose: ({ reason }) => console.log('comments panel closed:', reason),
+    });
 
 Lifecycle events
 ==================

--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -21,6 +21,29 @@
     }
   }
 
+  // Resolves the linkPolicy action for a URL - see PublicApi.openBackendView
+  // in frontend_edit.js. First matching rule wins; no match returns null.
+  function matchLinkPolicy(rules, href) {
+    if (!Array.isArray(rules)) return null;
+    for (var i = 0; i < rules.length; i++) {
+      var rule = rules[i];
+      if (!rule || !rule.action) continue;
+      var isMatch = rule.match instanceof RegExp
+        ? rule.match.test(href)
+        : (typeof rule.match === 'string' && href.indexOf(rule.match) !== -1);
+      if (isMatch) return rule.action;
+    }
+    return null;
+  }
+
+  // Only a plain CSS length is accepted (no arbitrary CSS injection via the
+  // public API's `width` option) - a bare number is treated as pixels.
+  function sanitizeWidth(value) {
+    if (typeof value === 'number' && isFinite(value) && value > 0) return value + 'px';
+    if (typeof value === 'string' && /^\d+(\.\d+)?(px|%|vw|rem|em)$/.test(value.trim())) return value.trim();
+    return '';
+  }
+
   var ContextualEdit = {
     sidebar: null,
     iframe: null,
@@ -31,6 +54,11 @@
     hasSaved: false,
     savedRecordTitle: null,
     targetBlank: false,
+    // Set by open() only when called with options (PublicApi.openBackendView);
+    // stays null for the classic edit flow (frontend_edit.js/sticky_toolbar.js
+    // call open() with no 4th argument), so none of the behavior below ever
+    // engages for those.
+    view: null,
 
     init: function () {
       this.provideTopLevelStubs();
@@ -158,18 +186,66 @@
           }
         }
         this.enhanceIframeUI();
+        this.installLinkPolicy();
       } catch (e) {
         // Cross-origin, access error, or invalid URL
       }
     },
 
-    open: function (contextualUrl, uid, targetBlank) {
+    /**
+     * Applies the consumer-supplied linkPolicy (PublicApi.openBackendView) for
+     * a generic backend view. No-op when the sidebar was opened without one -
+     * which is always the case for the classic edit flow, so its own click
+     * handling (postMessage-based save/close) is entirely unaffected.
+     */
+    installLinkPolicy: function () {
+      if (!this.view || !this.view.linkPolicy) return;
+      try {
+        var doc = this.iframe.contentDocument;
+        if (!doc || doc._xfeLinkPolicyInstalled) return;
+        doc._xfeLinkPolicyInstalled = true;
+        var self = this;
+        doc.addEventListener('click', function (e) {
+          if (!self.view || !self.view.linkPolicy) return;
+          var link = e.target.closest ? e.target.closest('a[href]') : null;
+          if (!link) return;
+
+          var action = matchLinkPolicy(self.view.linkPolicy, link.href);
+          if (!action || action === 'stay') return;
+
+          e.preventDefault();
+          e.stopPropagation();
+          if (action === 'external') {
+            window.open(link.href, '_blank');
+          } else if (action === 'close') {
+            self.close();
+          }
+          // 'ignore' — already prevented, nothing further to do.
+        }, true);
+      } catch (e) {
+        log('Could not install link policy', { error: e.message }, 'warn');
+      }
+    },
+
+    open: function (contextualUrl, uid, targetBlank, options) {
       log('Opening contextual edit for uid ' + uid);
       this._triggerElement = document.activeElement;
       clearTimeout(this.resetTimeout);
       this.hasSaved = false;
       this.savedRecordTitle = null;
       this.targetBlank = targetBlank || false;
+
+      var opts = options || {};
+      this.view = (opts.title || opts.width || opts.onClose || opts.linkPolicy || opts.reloadOnClose !== undefined) ? {
+        onClose: typeof opts.onClose === 'function' ? opts.onClose : null,
+        linkPolicy: opts.linkPolicy ? (Array.isArray(opts.linkPolicy) ? opts.linkPolicy : [opts.linkPolicy]) : null,
+        reloadOnClose: opts.reloadOnClose !== false
+      } : null;
+
+      this.sidebar.setAttribute('aria-label', opts.title || 'Edit content');
+      this.iframe.setAttribute('title', opts.title || 'Edit content');
+      this.sidebar.style.width = sanitizeWidth(opts.width);
+
       this.closeButton.style.display = '';
       this.loader.classList.add('frontend-edit__sidebar-loader--visible');
       this.iframe.classList.remove('frontend-edit__sidebar-iframe--loaded');
@@ -188,12 +264,22 @@
       // Capture UID before destroying iframe
       var uid = this.hasSaved ? this.getEditedElementUid() : null;
 
+      // Captured now (not read from `this` below) so a fresh open() during
+      // the close sequence can't retroactively change which view's
+      // callback/reload-preference fires for THIS close.
+      var view = this.view;
+      this.view = null;
+
       // Destroy iframe immediately to prevent flash message consumption
       if (this.iframe) {
         this.iframe.src = 'about:blank';
         if (this.iframe.parentNode) {
           this.iframe.parentNode.removeChild(this.iframe);
         }
+      }
+
+      if (view && typeof view.onClose === 'function') {
+        view.onClose({ reason: this.hasSaved ? 'saved' : 'close' });
       }
 
       if (this.hasSaved) {
@@ -206,6 +292,11 @@
         } else {
           window.location.reload();
         }
+      } else if (view && view.reloadOnClose) {
+        // Only the generic-view path (view set by PublicApi.openBackendView)
+        // reaches here - the classic edit flow never sets `view`, so it keeps
+        // its existing "close without reloading" behavior unchanged.
+        window.location.reload();
       } else {
         document.body.classList.remove('frontend-edit__sidebar-active');
         this.recreateIframe();

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1199,12 +1199,18 @@
 
     /**
      * Opens a backend URL in the version-appropriate container: the contextual
-     * sidebar (v14.2+, when enabled), the v13 iframe modal (via the export
-     * iframe_edit.js attaches to this namespace), or a new tab as a fallback.
-     * options: { target } where target is 'tab' to force a new tab.
-     *
-     * This is deliberately minimal (no link-interception policy, no close
-     * callback) - the full primitive with those is issue #209.
+     * sidebar (v14.2+, when enabled and available), the v13 iframe modal (via
+     * the export iframe_edit.js attaches to this namespace), or a new tab as
+     * a fallback. options:
+     * - target: 'tab' forces a new tab regardless of version
+     * - title, width: container chrome (width accepts a CSS length, e.g. '600px')
+     * - onClose({ reason }): called when the container closes
+     * - reloadOnClose: reload the parent page on close (default true)
+     * - linkPolicy: a rule or array of rules `{ match: string|RegExp, action }`,
+     *   action one of 'stay' | 'close' | 'ignore' | 'external', evaluated
+     *   against link clicks inside the embedded document. Only 'stay' (the
+     *   default when no rule matches) is honored for the built-in save/close
+     *   buttons of an actual edit form - those keep working unchanged.
      */
     openBackendView(url, options) {
       if (!UI.isValidUrl(url)) return false;
@@ -1214,12 +1220,33 @@
         window.open(url, '_blank');
         return true;
       }
-      if (window.FRONTEND_EDIT_CONTEXTUAL_EDITING && window.ContextualEdit && window.ContextualEdit.sidebar) {
-        window.ContextualEdit.open(url, null, false);
+
+      // Apply the same returnUrl flash-deferral marker record_edit forms get
+      // (see backend_stubs.js/ensureReturnUrl) to every view opened through
+      // this primitive, not only edit forms.
+      const finalUrl = typeof window.XimaFrontendEdit?.ensureReturnUrl === 'function'
+        ? window.XimaFrontendEdit.ensureReturnUrl(url)
+        : url;
+      const containerOptions = {
+        title: opts.title,
+        width: opts.width,
+        onClose: opts.onClose,
+        linkPolicy: opts.linkPolicy,
+        reloadOnClose: opts.reloadOnClose,
+      };
+
+      // FRONTEND_EDIT_SIDEBAR_EDIT (not the broader "contextual editing
+      // enabled" setting) is the correct gate: it is only true when the
+      // contextual sidebar route is actually available (v14.2+). On v13 it
+      // stays false even with contextual editing enabled, so the iframe
+      // modal below handles it instead - see
+      // ResourceRendererService::addSettingsConfig().
+      if (window.FRONTEND_EDIT_SIDEBAR_EDIT === true && window.ContextualEdit && window.ContextualEdit.sidebar) {
+        window.ContextualEdit.open(finalUrl, null, false, containerOptions);
         return true;
       }
       if (typeof window.XimaFrontendEdit?.openModal === 'function') {
-        window.XimaFrontendEdit.openModal(url, false);
+        window.XimaFrontendEdit.openModal(finalUrl, containerOptions);
         return true;
       }
       window.open(url, '_blank');

--- a/Resources/Public/JavaScript/iframe_edit.js
+++ b/Resources/Public/JavaScript/iframe_edit.js
@@ -121,12 +121,43 @@
     return url;
   }
 
+  /**
+   * Resolves the linkPolicy action for a URL - see PublicApi.openBackendView
+   * in frontend_edit.js. First matching rule wins; no match returns null.
+   */
+  function matchLinkPolicy(rules, href) {
+    if (!Array.isArray(rules)) return null;
+    for (const rule of rules) {
+      if (!rule || !rule.action) continue;
+      const isMatch = rule.match instanceof RegExp
+        ? rule.match.test(href)
+        : (typeof rule.match === 'string' && href.includes(rule.match));
+      if (isMatch) return rule.action;
+    }
+    return null;
+  }
+
+  /**
+   * Only a plain CSS length is accepted (no arbitrary CSS injection via the
+   * public API's `width` option) - a bare number is treated as pixels.
+   */
+  function sanitizeWidth(value) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) return `${value}px`;
+    if (typeof value === 'string' && /^\d+(\.\d+)?(px|%|vw|rem|em)$/.test(value.trim())) return value.trim();
+    return '';
+  }
+
   // ── Modal ──────────────────────────────────────────────────────────
 
   const Modal = {
     element: null,
     iframe: null,
     closeTimer: null,
+    // Set by open() only when called with options (PublicApi.openBackendView);
+    // stays null for the classic edit/wizard flow via LinkInterceptor, which
+    // calls open(url) with no second argument - so none of the behavior below
+    // ever engages for those.
+    view: null,
 
     getOrCreate() {
       if (this.element) return this.element;
@@ -161,7 +192,7 @@
       return modal;
     },
 
-    open(url) {
+    open(url, options) {
       // Ensure the returnUrl carries tx_ximatypo3frontendedit_iframe=1
       // so the post-save redirect to the frontend URL does not consume the
       // flash message queue inside the iframe — the parent reload picks
@@ -189,15 +220,27 @@
       IframeHandler.overrideContentContainer(iframe);
       iframe.src = url;
 
+      const opts = options || {};
+      this.view = (opts.title || opts.width || opts.onClose || opts.linkPolicy || opts.reloadOnClose !== undefined) ? {
+        onClose: typeof opts.onClose === 'function' ? opts.onClose : null,
+        linkPolicy: opts.linkPolicy ? (Array.isArray(opts.linkPolicy) ? opts.linkPolicy : [opts.linkPolicy]) : null,
+        reloadOnClose: opts.reloadOnClose !== false,
+      } : null;
+
       // Keep the close button always reachable as an escape route (ESC and
       // backdrop click aren't discoverable if the TYPO3-native close fails
       // to render). Only hide the title text for edit forms, where the
-      // record title lives inside the iframe's own header.
-      const showTitle = /record\/(info|history)|move_element/.test(url);
+      // record title lives inside the iframe's own header - unless a
+      // consumer-supplied title should be shown instead.
+      const showTitle = !!opts.title || /record\/(info|history)|move_element/.test(url);
       const title = this.element.querySelector('.frontend-edit__modal-title');
       if (title) {
+        title.textContent = opts.title || '';
         title.style.display = showTitle ? '' : 'none';
       }
+
+      const panel = this.element.querySelector('.frontend-edit__modal-panel');
+      if (panel) panel.style.width = sanitizeWidth(opts.width);
 
       setTimeout(() => this.element.classList.add('frontend-edit__modal--open'), ANIMATION_DELAY_MS);
 
@@ -233,6 +276,12 @@
       Logger.log('Closing modal');
       this.element.classList.remove('frontend-edit__modal--open');
 
+      // Captured now (not read from `this` inside the timeout) so a fresh
+      // open() during the close animation can't retroactively change which
+      // view's callback/reload-preference fires for THIS close.
+      const view = this.view;
+      this.view = null;
+
       // Replace any previous pending cleanup with a fresh one so we never
       // have two racing timeouts. The callback also double-checks that the
       // modal is still closed before wiping the iframe, so a re-open()
@@ -246,6 +295,13 @@
         if (this.iframe) {
           this.iframe.src = 'about:blank';
           this.iframe.style.opacity = '0.5';
+        }
+        // Only the generic-view path (view set by PublicApi.openBackendView)
+        // reaches here - the classic edit/wizard flow never sets `view`, so
+        // it keeps its existing "close without reloading" behavior unchanged.
+        if (view) {
+          if (typeof view.onClose === 'function') view.onClose({ reason: 'close' });
+          if (view.reloadOnClose) window.location.reload();
         }
       }, ANIMATION_DURATION_MS);
     }
@@ -487,6 +543,7 @@
           this._handleSaveClick.bind(this),
           this._handleFileSelectorClick.bind(this),
           this._handleNativeBrowserModalClick.bind(this),
+          this._handleLinkPolicyClick.bind(this),
           this._handleEditFormCloseClick.bind(this),
           this._handlePageLayoutNavClick.bind(this),
           this._handleFrontendLinkClick.bind(this),
@@ -535,6 +592,35 @@
       // TYPO3 form engine controls (link popup, element browser, etc.) open
       // their own Modal natively — don't interfere.
       return !!e.target.closest('.t3js-element-browser, a[href*="wizard/link"]');
+    },
+
+    /**
+     * Applies the consumer-supplied linkPolicy (PublicApi.openBackendView) for
+     * a generic backend view. No-op when the modal was opened without one -
+     * which is always the case for the classic edit/wizard flow, so those
+     * links keep falling through to the handlers below unchanged.
+     * 'stay' (including "no rule matched") intentionally does nothing here,
+     * letting the existing handlers decide - which already keep navigation
+     * inside the iframe for backend/frontend/wizard links today.
+     */
+    _handleLinkPolicyClick(e) {
+      const linkPolicy = Modal.view?.linkPolicy;
+      if (!linkPolicy) return false;
+      const link = e.target.closest('a[href]');
+      if (!link) return false;
+
+      const action = matchLinkPolicy(linkPolicy, link.href);
+      if (!action || action === 'stay') return false;
+
+      e.preventDefault();
+      e.stopPropagation();
+      if (action === 'external') {
+        window.open(link.href, '_blank');
+      } else if (action === 'close') {
+        Modal.close();
+      }
+      // 'ignore' — already prevented, nothing further to do.
+      return true;
     },
 
     _handleEditFormCloseClick(e) {

--- a/Tests/Playwright/tests/backend-view.spec.ts
+++ b/Tests/Playwright/tests/backend-view.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+import { resolveTypo3Version } from '../support/typo3/environment';
+
+// "About This Demo" text element on the Home page (Tests/Acceptance/Fixtures/demo-content.sql).
+const CONTENT_ELEMENT_UID = 2;
+
+// The ddev demo site sets frontendEdit.enableContextualEditing: true, so a
+// real backend edit URL (reused here purely as "some real backend URL" -
+// openBackendView doesn't care what it opens) is available via the edit
+// button. On v13 this must resolve to the iframe modal (see the
+// FRONTEND_EDIT_SIDEBAR_EDIT gate fix in PublicApi.openBackendView); on
+// v14.2+ it resolves to the contextual sidebar.
+async function getBackendUrl(page: import('@playwright/test').Page): Promise<string> {
+  const hoverMenu = new HoverMenu(page);
+  const href = await hoverMenu.editButton(CONTENT_ELEMENT_UID).getAttribute('href');
+  if (!href) throw new Error('edit button has no href');
+  return href;
+}
+
+test.beforeEach(async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+});
+
+test('openBackendView opens the v13 modal, not the sidebar, with a custom title and width', async ({ page }) => {
+  test.skip(resolveTypo3Version() !== '13', 'asserts the v13 iframe-modal path specifically');
+
+  const url = await getBackendUrl(page);
+  await page.evaluate((backendUrl) => {
+    (window as any).XimaFrontendEdit.openBackendView(backendUrl, { title: 'Custom title', width: '500px' });
+  }, url);
+
+  const modal = page.locator('.frontend-edit__modal');
+  await expect(modal).toHaveClass(/frontend-edit__modal--open/);
+  // Proves the FRONTEND_EDIT_SIDEBAR_EDIT gate fix: contextual editing is
+  // enabled in this environment, but on v13 the sidebar must never open.
+  await expect(page.locator('.frontend-edit__sidebar')).not.toHaveClass(/frontend-edit__sidebar--open/);
+
+  const title = page.locator('.frontend-edit__modal-title');
+  await expect(title).toHaveText('Custom title');
+  // Not asserting toBeVisible(): .frontend-edit__modal-header is currently
+  // display:none on main regardless of this element's own style (a
+  // pre-existing gap, already fixed on the separate, not-yet-merged
+  // feature/iframe-modal-expand-button branch). Assert our own contract -
+  // Modal.open() does not itself force the title hidden - instead.
+  expect(await title.evaluate((el) => (el as HTMLElement).style.display)).not.toBe('none');
+  await expect(page.locator('.frontend-edit__modal-panel')).toHaveCSS('width', '500px');
+});
+
+test('openBackendView: onClose fires and reloadOnClose:false does not reload the parent', async ({ page }) => {
+  test.skip(resolveTypo3Version() !== '13', 'exercises the v13 iframe-modal close path');
+
+  const url = await getBackendUrl(page);
+  await page.evaluate((backendUrl) => {
+    (window as any).__closeReasons = [];
+    (window as any).__marker = 'still-here';
+    (window as any).XimaFrontendEdit.openBackendView(backendUrl, {
+      title: 'X',
+      reloadOnClose: false,
+      onClose: (detail: { reason: string }) => (window as any).__closeReasons.push(detail.reason),
+    });
+  }, url);
+
+  await expect(page.locator('.frontend-edit__modal')).toHaveClass(/frontend-edit__modal--open/);
+  // Escape rather than clicking .frontend-edit__modal-close: that button
+  // lives inside .frontend-edit__modal-header, currently display:none on
+  // main regardless of this test (see the title assertion above) - Escape
+  // is a real, always-available close path (global keydown listener in
+  // iframe_edit.js's getOrCreate()).
+  await page.keyboard.press('Escape');
+
+  // Modal.close()'s cleanup (where onClose fires) runs after the CSS
+  // transition (ANIMATION_DURATION_MS = 300ms in iframe_edit.js).
+  await page.waitForTimeout(500);
+
+  expect(await page.evaluate(() => (window as any).__closeReasons)).toEqual(['close']);
+  // If a reload had happened, this fresh page load would not have the marker.
+  expect(await page.evaluate(() => (window as any).__marker)).toBe('still-here');
+});
+
+test('openBackendView: reloadOnClose defaults to true', async ({ page }) => {
+  test.skip(resolveTypo3Version() !== '13', 'exercises the v13 iframe-modal close path');
+
+  const url = await getBackendUrl(page);
+  await page.evaluate((backendUrl) => {
+    (window as any).__marker = 'still-here';
+    (window as any).XimaFrontendEdit.openBackendView(backendUrl, { title: 'X' });
+  }, url);
+
+  await expect(page.locator('.frontend-edit__modal')).toHaveClass(/frontend-edit__modal--open/);
+
+  // See the previous test for why Escape, not a click on the (currently
+  // hidden) close button.
+  await Promise.all([
+    page.waitForEvent('load'),
+    page.keyboard.press('Escape'),
+  ]);
+
+  // A fresh page load has no marker - proves the parent actually reloaded.
+  expect(await page.evaluate(() => (window as any).__marker)).toBeUndefined();
+});
+
+test('openBackendView: linkPolicy governs link clicks inside the embedded document', async ({ page }) => {
+  test.skip(resolveTypo3Version() !== '13', 'exercises the v13 iframe-modal link-policy hook');
+
+  const url = await getBackendUrl(page);
+  await page.evaluate((backendUrl) => {
+    (window as any).__marker = 'still-here';
+    (window as any).XimaFrontendEdit.openBackendView(backendUrl, {
+      title: 'X',
+      linkPolicy: [
+        { match: '#close-me', action: 'close' },
+        { match: '#external', action: 'external' },
+      ],
+    });
+  }, url);
+
+  const frame = page.frameLocator('.frontend-edit__modal iframe');
+
+  // Wait for the actual edit form to finish loading before touching its
+  // document - injecting into the transient about:blank/loading state would
+  // get wiped the moment the real navigation completes.
+  await expect(frame.locator('[name="_savedok"]')).toBeVisible();
+
+  // Inject deterministic test links instead of depending on which incidental
+  // links a real edit form happens to render.
+  await frame.locator('body').evaluate((body) => {
+    const close = document.createElement('a');
+    close.href = '#close-me';
+    close.textContent = 'close-me';
+    close.id = 'xfe-test-close-link';
+    body.appendChild(close);
+  });
+
+  await Promise.all([
+    page.waitForEvent('load'),
+    frame.locator('#xfe-test-close-link').click(),
+  ]);
+
+  // 'close' action closed the modal and (default reloadOnClose) reloaded -
+  // proven the same way as the reloadOnClose test above.
+  expect(await page.evaluate(() => (window as any).__marker)).toBeUndefined();
+});
+
+test('openBackendView opens the v14.2+ contextual sidebar, not the modal', async ({ page }) => {
+  test.skip(resolveTypo3Version() !== '14', 'asserts the v14.2+ sidebar path specifically');
+
+  const url = await getBackendUrl(page);
+  await page.evaluate((backendUrl) => {
+    (window as any).XimaFrontendEdit.openBackendView(backendUrl, { title: 'Custom title', width: '500px' });
+  }, url);
+
+  await expect(page.locator('.frontend-edit__sidebar')).toHaveClass(/frontend-edit__sidebar--open/);
+  // iframe_edit.js (the v13 modal) isn't even loaded on v14.2+ - the modal
+  // element never exists, let alone opens.
+  await expect(page.locator('.frontend-edit__modal')).toHaveCount(0);
+  await expect(page.locator('.frontend-edit__sidebar')).toHaveCSS('width', '500px');
+});


### PR DESCRIPTION
## Summary

- Extend `openBackendView(url, options)` (introduced in #208 / PR #235) into the real, generic primitive from #209: `title`, `width`, `onClose`, `reloadOnClose`, and a configurable `linkPolicy` (`stay`/`close`/`ignore`/`external` per URL pattern)
- **Fixes a gate bug from #208**: the minimal `openBackendView` picked the contextual sidebar whenever the *setting* was on, even on v13 (where the sidebar route doesn't exist but `ContextualEdit` still loads for the New Content Wizard). Now gated on `window.FRONTEND_EDIT_SIDEBAR_EDIT` (only true when the sidebar route is actually available), matching `iframe_edit.js`'s own existing gate
- Applies the same returnUrl flash-message-deferral marker that edit forms get to every view opened through this primitive, not only edit forms
- `linkPolicy` only ever governs plain link clicks inside the embedded document — the built-in save/close buttons of an actual edit form are untouched, by construction (checked earlier in the click-handler chain)
- Default behavior (no options passed) is byte-identical to before for every existing call site — `Modal.view`/`ContextualEdit.view` stay `null` unless the primitive is actually used with options

## Changes

- `Resources/Public/JavaScript/frontend_edit.js` - fix the sidebar/modal gate, wire `ensureReturnUrl`, forward the new options
- `Resources/Public/JavaScript/iframe_edit.js` - `Modal.open/close` gain title/width/onClose/linkPolicy handling; new `_handleLinkPolicyClick` in the click-handler chain
- `Resources/Public/JavaScript/contextual_edit.js` - `ContextualEdit.open/close` gain the same options; new `installLinkPolicy`
- `Tests/Playwright/tests/backend-view.spec.ts` - E2E coverage on both v13 (modal) and v14.2+ (sidebar), including a regression check that the gate fix actually routes to the right container
- `Documentation/DeveloperCorner/JavaScriptApi.rst` - documents the new options

Closes #209

Stacked on #235 (#208) since this extends that PR's `openBackendView` — based against that branch rather than `main`.

## Test plan

- [x] New Playwright spec passes on both v13 and v14 (`TYPO3_VERSION=14`)
- [x] Full Playwright suite passes on both versions (no regressions in existing edit/wizard/contextual-sidebar flows)