### PR TITLE
feat: add PSR-14 event for enriching editInformation payload with third-party data

### DIFF
--- a/Classes/Event/FrontendEditDataEnrichmentEvent.php
+++ b/Classes/Event/FrontendEditDataEnrichmentEvent.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Event;
+
+use InvalidArgumentException;
+
+use function array_key_exists;
+use function is_array;
+use function is_scalar;
+use function preg_match;
+use function sprintf;
+
+/**
+ * FrontendEditDataEnrichmentEvent.
+ *
+ * Dispatched once per editInformationAction request, before the per-element
+ * dropdown is built, with the full filtered content element list - so a
+ * listener backed by a database can resolve its data in a single query
+ * instead of being invoked once per element with no way to batch.
+ *
+ * Listeners attach namespaced, serializable data via addElementData(); it is
+ * merged into the JSON payload under element['_ext'][$namespace], and from
+ * there reaches the frontend in the `xfe:element-rendered` event's
+ * `detail.payload.element._ext` (see Documentation/DeveloperCorner/JavaScriptApi.rst).
+ * Namespacing prevents key collisions between listeners; core frontend-edit
+ * keys are never exposed under `_ext`.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class FrontendEditDataEnrichmentEvent
+{
+    final public const NAME = 'xima_typo3_frontend_edit.frontend_edit.data.enrichment';
+
+    /** @var array<int, array<string, mixed>> */
+    private array $elementData = [];
+
+    public function __construct(
+        /** @var array<int, array<string, mixed>> content element rows, keyed by uid */
+        protected readonly array $contentElements,
+        protected readonly int $pageId,
+        protected readonly int $languageUid,
+        protected readonly string $returnUrl,
+    ) {}
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getContentElements(): array
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getContentElementUids(): array
+    {
+        return array_map(intval(...), array_keys($this->contentElements));
+    }
+
+    public function getPageId(): int
+    {
+        return $this->pageId;
+    }
+
+    public function getLanguageUid(): int
+    {
+        return $this->languageUid;
+    }
+
+    public function getReturnUrl(): string
+    {
+        return $this->returnUrl;
+    }
+
+    /**
+     * @param array<string, mixed> $data must be serializable: scalar, null, or arrays thereof
+     *
+     * @throws InvalidArgumentException if $uid is not part of this request, $namespace
+     *                                  is not a lowercase identifier, or $data is not serializable
+     */
+    public function addElementData(int $uid, string $namespace, array $data): void
+    {
+        if (!array_key_exists($uid, $this->contentElements)) {
+            throw new InvalidArgumentException(sprintf('Unknown content element uid %d for this request', $uid), 1732000001);
+        }
+        if (1 !== preg_match('/^[a-z][a-z0-9_]*$/', $namespace)) {
+            throw new InvalidArgumentException(sprintf('Invalid data namespace "%s" - expected lowercase letters, digits and underscores, starting with a letter', $namespace), 1732000002);
+        }
+        $this->assertSerializable($data);
+
+        $this->elementData[$uid][$namespace] = $data;
+    }
+
+    /**
+     * @return array<string, mixed> namespace => data, empty when no listener attached anything for this uid
+     */
+    public function getElementData(int $uid): array
+    {
+        return $this->elementData[$uid] ?? [];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertSerializable(array $data): void
+    {
+        foreach ($data as $value) {
+            if (is_array($value)) {
+                $this->assertSerializable($value);
+                continue;
+            }
+            if (!is_scalar($value) && null !== $value) {
+                throw new InvalidArgumentException('Data enrichment values must be scalar, null, or arrays thereof', 1732000003);
+            }
+        }
+    }
+}

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -161,10 +161,12 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
             $elementsByUid[(int) $element['uid']] = $element;
         }
 
-        /* @var FrontendEditDataEnrichmentEvent */
-        return $this->eventDispatcher->dispatch(
+        /** @var FrontendEditDataEnrichmentEvent $event */
+        $event = $this->eventDispatcher->dispatch(
             new FrontendEditDataEnrichmentEvent($elementsByUid, $pid, $languageUid, $returnUrl),
         );
+
+        return $event;
     }
 
     /**

--- a/Classes/Service/Menu/ContentElementMenuGenerator.php
+++ b/Classes/Service/Menu/ContentElementMenuGenerator.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDropdownModifyEvent;
+use Xima\XimaTypo3FrontendEdit\Event\{FrontendEditDataEnrichmentEvent, FrontendEditDropdownModifyEvent};
 use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
@@ -90,6 +90,8 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
 
         $filteredElements = $this->contentElementFilter->filterContentElements($contentElements, $backendUser, $request);
 
+        $dataEnrichmentEvent = $this->dispatchDataEnrichmentEvent($filteredElements, $pid, $languageUid, $returnUrl);
+
         $enableScrollToElement = $this->settingsService->isEnableScrollToElement($request);
 
         // Remove existing URL fragment to prevent accumulation (e.g. page.html#c123#c456)
@@ -117,6 +119,8 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
                 continue;
             }
 
+            $this->applyElementDataEnrichment($contentElement, $dataEnrichmentEvent);
+
             $menuButton = $this->createMenuButton($contentElement, $languageUid, $pid, $returnUrlAnchor, $contentElementConfig, $request, $contextualUrl, $showInsertButtons);
             $this->handleAdditionalData($menuButton, $contentElement, $contentElementConfig, $data, $languageUid, $returnUrlAnchor);
 
@@ -141,6 +145,37 @@ final class ContentElementMenuGenerator extends AbstractMenuGenerator
         }
 
         return $this->renderMenuButtons($result);
+    }
+
+    /**
+     * Dispatched once with the full filtered list (not per element) so a
+     * listener backed by a database can resolve its data in a single query
+     * instead of being invoked N times with no way to batch.
+     *
+     * @param array<int, array<string, mixed>> $filteredElements
+     */
+    private function dispatchDataEnrichmentEvent(array $filteredElements, int $pid, int $languageUid, string $returnUrl): FrontendEditDataEnrichmentEvent
+    {
+        $elementsByUid = [];
+        foreach ($filteredElements as $element) {
+            $elementsByUid[(int) $element['uid']] = $element;
+        }
+
+        /* @var FrontendEditDataEnrichmentEvent */
+        return $this->eventDispatcher->dispatch(
+            new FrontendEditDataEnrichmentEvent($elementsByUid, $pid, $languageUid, $returnUrl),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $contentElement
+     */
+    private function applyElementDataEnrichment(array &$contentElement, FrontendEditDataEnrichmentEvent $event): void
+    {
+        $elementData = $event->getElementData((int) $contentElement['uid']);
+        if ([] !== $elementData) {
+            $contentElement['_ext'] = $elementData;
+        }
     }
 
     /**

--- a/Documentation/DeveloperCorner/Events.rst
+++ b/Documentation/DeveloperCorner/Events.rst
@@ -6,7 +6,7 @@
 PSR-14 Events
 =======================
 
-The extension provides two PSR-14 events to customize the Edit Menu and Toolbar.
+The extension provides three PSR-14 events to customize the Edit Menu and Toolbar.
 
 FrontendEditDropdownModifyEvent
 ===============================
@@ -144,3 +144,86 @@ Use the :code:`FrontendEditPageDropdownModifyEvent` to modify the Toolbar menu f
             $event->setMenuButton($menuButton);
         }
     }
+
+FrontendEditDataEnrichmentEvent
+================================
+
+Use the :code:`FrontendEditDataEnrichmentEvent` to attach structured, serializable
+data to content elements - e.g. a status color, an assignee, a comment count -
+which the frontend JavaScript can then render, for example via a
+:code:`registerBadge()` call. Since element data is delivered via the
+uncached :code:`editInformation` AJAX request, this is also the only cache-safe
+transport for volatile third-party data, and it rides along on the existing
+request without an extra roundtrip.
+
+The event is dispatched **once per request**, with the full filtered content
+element list - not once per element - so a listener backed by a database can
+resolve its data in a single query instead of being invoked N times with no
+way to batch.
+
+**Available methods:**
+
+- ``getContentElements()`` - Returns all content element rows for this request, keyed by uid (read-only)
+- ``getContentElementUids()`` - Returns just the uids, for a batched lookup
+- ``getPageId()`` / ``getLanguageUid()`` / ``getReturnUrl()`` - Request context
+- ``addElementData(int $uid, string $namespace, array $data)`` - Attaches data for one element under your namespace; :code:`$data` must be serializable (scalar, null, or arrays thereof)
+- ``getElementData(int $uid)`` - Returns the data attached so far for one element (namespace => data)
+
+Data attached via ``addElementData()`` is merged into the JSON payload under
+:code:`element['_ext'][$namespace]` - namespacing prevents key collisions
+between listeners, and :code:`_ext` is reserved for this purpose (core
+frontend-edit keys are never exposed under it). Namespaces must be lowercase
+letters, digits and underscores, starting with a letter (e.g. your extension key).
+
+**Example:**
+
+..  code-block:: php
+    :caption: Classes/EventListener/EnrichCommentDataListener.php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace Vendor\Package\EventListener;
+
+    use TYPO3\CMS\Core\Attribute\AsEventListener;
+    use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDataEnrichmentEvent;
+
+    #[AsEventListener(
+        identifier: 'my-extension/enrich-comment-data',
+    )]
+    class EnrichCommentDataListener
+    {
+        public function __construct(
+            protected readonly CommentRepository $commentRepository,
+        ) {}
+
+        public function __invoke(FrontendEditDataEnrichmentEvent $event): void
+        {
+            // One query for all elements on this page instead of N.
+            $counts = $this->commentRepository->countByContentElementUids(
+                $event->getContentElementUids(),
+            );
+
+            foreach ($counts as $uid => $count) {
+                $event->addElementData($uid, 'my_extension', [
+                    'color' => $count > 0 ? '#ff9800' : '#9e9e9e',
+                    'count' => $count,
+                ]);
+            }
+        }
+    }
+
+On the frontend, render it via ``registerBadge()`` when the element is rendered:
+
+..  code-block:: javascript
+
+    document.addEventListener('xfe:element-rendered', (event) => {
+        const { uid, payload } = event.detail;
+        const data = payload.element._ext?.my_extension;
+        if (!data) return;
+
+        window.XimaFrontendEdit.registerBadge(uid, {
+            html: `<span style="background:${data.color}">${data.count}</span>`,
+        });
+    });

--- a/Tests/Unit/Event/FrontendEditDataEnrichmentEventTest.php
+++ b/Tests/Unit/Event/FrontendEditDataEnrichmentEventTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Event;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDataEnrichmentEvent;
+
+/**
+ * FrontendEditDataEnrichmentEventTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(FrontendEditDataEnrichmentEvent::class)]
+final class FrontendEditDataEnrichmentEventTest extends TestCase
+{
+    #[Test]
+    public function eventNameConstantIsCorrect(): void
+    {
+        self::assertSame(
+            'xima_typo3_frontend_edit.frontend_edit.data.enrichment',
+            FrontendEditDataEnrichmentEvent::NAME,
+        );
+    }
+
+    #[Test]
+    public function constructorSetsPropertiesCorrectly(): void
+    {
+        $contentElements = [1 => ['uid' => 1, 'CType' => 'text']];
+        $event = new FrontendEditDataEnrichmentEvent($contentElements, 5, 0, '/return');
+
+        self::assertSame($contentElements, $event->getContentElements());
+        self::assertSame(5, $event->getPageId());
+        self::assertSame(0, $event->getLanguageUid());
+        self::assertSame('/return', $event->getReturnUrl());
+    }
+
+    #[Test]
+    public function getContentElementUidsReturnsAllUidsAsIntegers(): void
+    {
+        $contentElements = [1 => ['uid' => 1], 2 => ['uid' => 2], 42 => ['uid' => 42]];
+        $event = new FrontendEditDataEnrichmentEvent($contentElements, 5, 0, '/return');
+
+        self::assertSame([1, 2, 42], $event->getContentElementUids());
+    }
+
+    #[Test]
+    public function getElementDataReturnsEmptyArrayWhenNothingAttached(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        self::assertSame([], $event->getElementData(1));
+    }
+
+    #[Test]
+    public function addElementDataIsRetrievableUnderItsNamespace(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $event->addElementData(1, 'my_ext', ['color' => '#ff0000', 'count' => 3]);
+
+        self::assertSame(
+            ['my_ext' => ['color' => '#ff0000', 'count' => 3]],
+            $event->getElementData(1),
+        );
+    }
+
+    #[Test]
+    public function addElementDataKeepsNamespacesSeparate(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $event->addElementData(1, 'ext_one', ['a' => 1]);
+        $event->addElementData(1, 'ext_two', ['b' => 2]);
+
+        self::assertSame(
+            ['ext_one' => ['a' => 1], 'ext_two' => ['b' => 2]],
+            $event->getElementData(1),
+        );
+    }
+
+    #[Test]
+    public function addElementDataAcceptsNestedArraysAndScalarTypes(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $event->addElementData(1, 'ext', [
+            'string' => 'a',
+            'int' => 1,
+            'float' => 1.5,
+            'bool' => true,
+            'null' => null,
+            'nested' => ['deep' => ['value' => 1]],
+        ]);
+
+        self::assertSame(1, $event->getElementData(1)['ext']['nested']['deep']['value']);
+    }
+
+    #[Test]
+    public function addElementDataRejectsUnknownUid(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $this->expectException(InvalidArgumentException::class);
+        $event->addElementData(999, 'ext', ['a' => 1]);
+    }
+
+    #[Test]
+    public function addElementDataRejectsInvalidNamespace(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $this->expectException(InvalidArgumentException::class);
+        $event->addElementData(1, '_ext', ['a' => 1]);
+    }
+
+    #[Test]
+    public function addElementDataRejectsNonSerializableValues(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $this->expectException(InvalidArgumentException::class);
+        $event->addElementData(1, 'ext', ['object' => new stdClass()]);
+    }
+
+    #[Test]
+    public function addElementDataRejectsNonSerializableNestedValues(): void
+    {
+        $event = new FrontendEditDataEnrichmentEvent([1 => ['uid' => 1]], 5, 0, '/return');
+
+        $this->expectException(InvalidArgumentException::class);
+        $event->addElementData(1, 'ext', ['nested' => ['object' => new stdClass()]]);
+    }
+}

--- a/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Configuration;
-use Xima\XimaTypo3FrontendEdit\Event\FrontendEditDropdownModifyEvent;
+use Xima\XimaTypo3FrontendEdit\Event\{FrontendEditDataEnrichmentEvent, FrontendEditDropdownModifyEvent};
 use Xima\XimaTypo3FrontendEdit\Repository\ContentElementRepository;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Configuration\SettingsService;
@@ -251,9 +251,13 @@ final class ContentElementMenuGeneratorTest extends TestCase
 
         $replacementButton = new Button('replaced', \Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType::Link, '/replaced');
         $eventDispatcher = $this->createMock(EventDispatcher::class);
+        // getDropdown() also dispatches FrontendEditDataEnrichmentEvent - this
+        // callback must tolerate both event types, not just the one under test.
         $eventDispatcher->method('dispatch')->willReturnCallback(
-            static function (FrontendEditDropdownModifyEvent $event) use ($replacementButton): FrontendEditDropdownModifyEvent {
-                $event->setMenuButton($replacementButton);
+            static function (object $event) use ($replacementButton): object {
+                if ($event instanceof FrontendEditDropdownModifyEvent) {
+                    $event->setMenuButton($replacementButton);
+                }
 
                 return $event;
             },
@@ -265,6 +269,51 @@ final class ContentElementMenuGeneratorTest extends TestCase
 
         self::assertArrayHasKey(88, $result);
         self::assertSame('/replaced', $result[88]['menu']['url']);
+    }
+
+    #[Test]
+    public function getDropdownMergesDataEnrichmentEventDataIntoElement(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(88);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher->method('dispatch')->willReturnCallback(
+            static function (object $event): object {
+                if ($event instanceof FrontendEditDataEnrichmentEvent) {
+                    $event->addElementData(88, 'my_ext', ['color' => '#ff0000', 'count' => 3]);
+                }
+
+                return $event;
+            },
+        );
+
+        $generator = $this->createGenerator($connectionPool, $eventDispatcher);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertSame(['my_ext' => ['color' => '#ff0000', 'count' => 3]], $result[88]['element']['_ext']);
+    }
+
+    #[Test]
+    public function getDropdownOmitsExtKeyWhenNoListenerAttachedData(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $element = $this->createContentElementRecord(88);
+        $connectionPool = $this->createConnectionPoolReturning([$element]);
+
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown(1, '/return', 0, $this->createRequestMock());
+
+        self::assertArrayNotHasKey('_ext', $result[88]['element']);
     }
 
     private function createRequestMock(): ServerRequestInterface


### PR DESCRIPTION
## Summary

- New `FrontendEditDataEnrichmentEvent`, dispatched once per `editInformationAction` request with the full filtered content element list (not once per element), so a listener backed by a database can resolve its data in a single query instead of being invoked N times with no way to batch
- Listeners attach namespaced, serializable data via `addElementData(uid, namespace, data)`; it is merged into the JSON payload under `element['_ext'][namespace]`
- Namespacing prevents key collisions between listeners; namespaces must be lowercase identifiers, so `_ext` itself (and any other underscore-prefixed core key) can never be shadowed
- Values are validated recursively (scalar/null/array only) so they always survive `JsonResponse` serialization
- Page-level data bag intentionally **not** included — there's currently no AJAX transport for page-level data to the frontend; scoped out as a follow-up once #208's JS lifecycle events are merged

## Changes

- `Classes/Event/FrontendEditDataEnrichmentEvent.php` - the new event
- `Classes/Service/Menu/ContentElementMenuGenerator.php` - dispatches the event once per request, merges each element's enrichment data into `_ext` before the per-element `FrontendEditDropdownModifyEvent`
- `Tests/Unit/Event/FrontendEditDataEnrichmentEventTest.php`, `Tests/Unit/Service/Menu/ContentElementMenuGeneratorTest.php` - unit coverage (matches this repo's existing event-testing convention — no functional test needed, same as the two existing PSR-14 events)
- `Documentation/DeveloperCorner/Events.rst` - documents the new event with a full listener + frontend-consumption example

Closes #210

## Test plan

- [x] Unit suite passes (318 tests)
- [x] Functional suite passes (69 tests)
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Frontend edit menus can now display additional, extension-provided information for individual content elements.
  * Enrichment data is included only when available, keeping menu output unchanged otherwise.
  * Developers can provide contextual page, language, and return-link information for frontend editing integrations.

* **Documentation**
  * Added guidance and examples for enriching frontend edit menus and rendering custom badges.

* **Tests**
  * Added coverage for enrichment data handling, validation, and menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->