### PR TITLE
feat: add persistent multi-badge slots and badge display-mode hook

### DIFF
--- a/Documentation/DeveloperCorner/JavaScriptApi.rst
+++ b/Documentation/DeveloperCorner/JavaScriptApi.rst
@@ -77,15 +77,43 @@ visible at a glance rather than only on hover. :code:`spec`:
 
 - ``html`` or ``element`` - the badge content (HTML string or a DOM element)
 - ``position`` - one of ``top-left``, ``top-right`` (default), ``bottom-left``, ``bottom-right``
+- ``id`` - when given, a later call with the same uid + id replaces this badge in place instead of adding a duplicate (useful since ``xfe:element-rendered`` can fire more than once for the same element)
 - ``onClick`` - click handler; the badge only receives pointer events when this is set
+
+Multiple badges registered for the same corner lay out in a row, in
+registration order, instead of overlapping - each corner is its own slot,
+created on first use.
 
 ..  code-block:: javascript
 
     window.XimaFrontendEdit.registerBadge(42, {
         html: '<span class="my-badge" title="3 comments">3</span>',
         position: 'top-left',
+        id: 'comment-count',
         onClick: () => openCommentsPanel(42),
     });
+
+``setBadgeMode(mode)``
+------------------------
+
+Sets a display-mode hook for badges: ``'subtle'`` (default) or ``'prominent'``,
+exposed as :code:`document.documentElement`'s :code:`data-xfe-badge-mode`
+attribute. The extension ships no badge content itself (see
+``registerBadge`` above), so it has no opinion on what "subtle" vs
+"prominent" should actually look like - write your own CSS against the
+attribute:
+
+..  code-block:: javascript
+
+    window.XimaFrontendEdit.setBadgeMode('prominent');
+
+..  code-block:: css
+    :caption: A consumer's own stylesheet
+
+    /* Small dot only, by default */
+    .my-badge-label { display: none; }
+    /* Full label once prominent mode is active */
+    [data-xfe-badge-mode="prominent"] .my-badge-label { display: inline; }
 
 ``openBackendView(url, options)``
 ------------------------------------

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -153,18 +153,32 @@
     opacity: 1;
 }
 
-/* Public API: persistent badge (PublicApi.registerBadge) - unlike the outline
-   and toolbar above, badges stay visible regardless of hover state. */
-.frontend-edit__badge {
+/* Public API: persistent badges (PublicApi.registerBadge) - unlike the
+   outline and toolbar above, badges stay visible regardless of hover state.
+   Each corner is its own slot; multiple badges in one corner lay out in a
+   row, in registration order, instead of overlapping. The slot itself never
+   intercepts pointer events - only individual interactive badges (onClick)
+   opt back in, scoped to the badge itself. */
+.frontend-edit__badge-slot {
     position: absolute;
+    display: flex;
+    align-items: center;
+    gap: 4px;
     pointer-events: none;
     z-index: 2;
 }
 
-.frontend-edit__badge--top-left { top: -6px; left: -6px; }
-.frontend-edit__badge--top-right { top: -6px; right: -6px; }
-.frontend-edit__badge--bottom-left { bottom: -6px; left: -6px; }
-.frontend-edit__badge--bottom-right { bottom: -6px; right: -6px; }
+/* Offset further than the toolbar-label/-actions pills (which sit at
+   top: 0 with a translateY(-50%) straddle) so a persistent badge doesn't
+   visually collide with them while the toolbar is visible on hover. */
+.frontend-edit__badge-slot--top-left { top: -14px; left: -6px; }
+.frontend-edit__badge-slot--top-right { top: -14px; right: -6px; }
+.frontend-edit__badge-slot--bottom-left { bottom: -6px; left: -6px; }
+.frontend-edit__badge-slot--bottom-right { bottom: -6px; right: -6px; }
+
+.frontend-edit__badge {
+    pointer-events: none;
+}
 
 /* Element: toolbar - invisible container for label and actions */
 .frontend-edit__toolbar {

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -62,6 +62,23 @@
   };
 
   /**
+   * Finds (or lazily creates) the badge slot for one corner of a content
+   * element's overlay - see PublicApi.registerBadge. The slot is a plain DOM
+   * child of the overlay, so it automatically inherits the overlay's
+   * position tracking (scroll, resize, nested elements) with no extra code.
+   */
+  function getBadgeSlot(overlay, position) {
+    const slotClass = 'frontend-edit__badge-slot--' + position;
+    let slot = Array.from(overlay.children).find(child => child.classList.contains(slotClass));
+    if (!slot) {
+      slot = document.createElement('div');
+      slot.className = 'frontend-edit__badge-slot ' + slotClass;
+      overlay.appendChild(slot);
+    }
+    return slot;
+  }
+
+  /**
    * Dispatches the public `xfe:*` lifecycle events (see PublicApi below) on
    * `document`, so third-party listeners can use standard event delegation.
    */
@@ -638,9 +655,12 @@
       const { x, y } = this.lastPointer;
       const el = document.elementFromPoint(x, y);
 
-      // While the cursor is over an overlay control (toolbar, insert button) or
-      // an open dropdown, keep the current highlight — same as Edit/More Actions.
-      if (el && el.closest('.frontend-edit__toolbar, .frontend-edit__insert-btn, .frontend-edit__dropdown')) {
+      // While the cursor is over an overlay control (toolbar, insert button,
+      // badge) or an open dropdown, keep the current highlight — same as
+      // Edit/More Actions. Without the badge here, hovering an interactive
+      // badge (registerBadge's onClick) would drop the outline/toolbar
+      // highlight the instant the cursor entered it.
+      if (el && el.closest('.frontend-edit__toolbar, .frontend-edit__insert-btn, .frontend-edit__dropdown, .frontend-edit__badge')) {
         return;
       }
 
@@ -1166,22 +1186,27 @@
 
     /**
      * Renders a persistent, hover-independent indicator on a content element's
-     * overlay. spec: { html | element, position, onClick }; position is one of
-     * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' (default 'top-right').
+     * overlay. spec: { html | element, position, id, onClick }:
+     * - position: one of 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+     *   (default 'top-right'). Multiple badges in the same corner stack in a
+     *   row, in registration order - each corner is its own slot, created on
+     *   first use (see getBadgeSlot below).
+     * - id: when given, a later registerBadge() call with the same uid+id
+     *   replaces this badge in place (same slot position) instead of adding a
+     *   duplicate - needed because xfe:element-rendered can fire more than
+     *   once for the same element (e.g. re-fetched data).
      * Returns the created badge, or null if the uid is unknown.
-     *
-     * This is deliberately minimal: stacking of multiple badges per element and
-     * a dedicated always-on-top badge layer are covered by a later iteration
-     * (issue #211); this appends directly into the existing position-tracked
-     * overlay, which is enough for a single badge per element today.
      */
     registerBadge(uid, spec) {
       const entry = Registry.get(uid);
       if (!entry) return null;
 
       const badgeSpec = spec || {};
+      const slot = getBadgeSlot(entry.overlay, badgeSpec.position || 'top-right');
+
       const badge = document.createElement('span');
-      badge.className = 'frontend-edit__badge frontend-edit__badge--' + (badgeSpec.position || 'top-right');
+      badge.className = 'frontend-edit__badge';
+      if (badgeSpec.id) badge.dataset.badgeId = String(badgeSpec.id);
       if (badgeSpec.element instanceof Element) {
         badge.appendChild(badgeSpec.element);
       } else if (badgeSpec.html) {
@@ -1193,8 +1218,29 @@
         badge.addEventListener('click', badgeSpec.onClick);
       }
 
-      entry.overlay.appendChild(badge);
+      // A fresh node (rather than mutating an existing one) means no stale
+      // event listeners survive a replace.
+      const existing = badgeSpec.id
+        ? Array.from(slot.children).find(child => child.dataset.badgeId === String(badgeSpec.id))
+        : null;
+      if (existing) {
+        existing.replaceWith(badge);
+      } else {
+        slot.appendChild(badge);
+      }
       return badge;
+    },
+
+    /**
+     * Sets the badge display-mode hook: 'subtle' (default) or 'prominent',
+     * exposed as document.documentElement's `data-xfe-badge-mode` attribute.
+     * The extension ships no badge content itself (see registerBadge), so it
+     * has no opinion on what "subtle" vs "prominent" should look like -
+     * consumer CSS reacts to this attribute, e.g.
+     * `[data-xfe-badge-mode="subtle"] .my-badge-label { display: none }`.
+     */
+    setBadgeMode(mode) {
+      document.documentElement.setAttribute('data-xfe-badge-mode', 'prominent' === mode ? 'prominent' : 'subtle');
     },
 
     /**

--- a/Tests/Playwright/tests/public-api.spec.ts
+++ b/Tests/Playwright/tests/public-api.spec.ts
@@ -120,13 +120,121 @@ test('registerBadge renders a persistent indicator independent of hover', async 
     });
   }, CONTENT_ELEMENT_UID);
 
-  const badge = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge`);
+  const overlay = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"]`);
+  const badge = overlay.locator('.frontend-edit__badge');
   await expect(badge).toHaveCount(1);
-  await expect(badge).toHaveClass(/frontend-edit__badge--top-left/);
+  await expect(overlay.locator('.frontend-edit__badge-slot--top-left')).toHaveCount(1);
 
   // Not hovering the element: the badge must stay visible, unlike the
   // hover-gated toolbar/outline (opacity 0 until OverlayManager activates it).
   await expect(badge).toBeVisible();
+});
+
+test('registerBadge: multiple badges in one corner stack instead of overlapping', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    const dot = (color: string) => `<span style="display:inline-block;width:8px;height:8px;background:${color};border-radius:50%;"></span>`;
+    (window as any).XimaFrontendEdit.registerBadge(uid, { html: dot('red'), position: 'top-right' });
+    (window as any).XimaFrontendEdit.registerBadge(uid, { html: dot('blue'), position: 'top-right' });
+  }, CONTENT_ELEMENT_UID);
+
+  const slot = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge-slot--top-right`);
+  const badges = slot.locator('.frontend-edit__badge');
+  await expect(badges).toHaveCount(2);
+
+  // Predictable layout, not overlapping: the second badge sits to the right
+  // of the first (the slot is a flex row).
+  const firstBox = await badges.nth(0).boundingBox();
+  const secondBox = await badges.nth(1).boundingBox();
+  expect(firstBox).not.toBeNull();
+  expect(secondBox).not.toBeNull();
+  expect(secondBox!.x).toBeGreaterThan(firstBox!.x);
+});
+
+test('registerBadge: a repeat call with the same id replaces the badge in place, not a duplicate', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    (window as any).XimaFrontendEdit.registerBadge(uid, { html: '<span>1</span>', id: 'comment-count', position: 'top-right' });
+    (window as any).XimaFrontendEdit.registerBadge(uid, { html: '<span>2</span>', id: 'comment-count', position: 'top-right' });
+  }, CONTENT_ELEMENT_UID);
+
+  const slot = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge-slot--top-right`);
+  await expect(slot.locator('.frontend-edit__badge')).toHaveCount(1);
+  await expect(slot.locator('.frontend-edit__badge')).toHaveText('2');
+});
+
+test('registerBadge: an interactive badge does not drop the toolbar highlight on hover', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    (window as any).XimaFrontendEdit.registerBadge(uid, {
+      html: '<span style="display:inline-block;width:12px;height:12px;">B</span>',
+      position: 'top-right',
+      onClick: () => {},
+    });
+  }, CONTENT_ELEMENT_UID);
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.hover(CONTENT_ELEMENT_UID);
+  const toolbar = hoverMenu.toolbar(CONTENT_ELEMENT_UID);
+  await expect(toolbar).toHaveCSS('opacity', '1');
+
+  const badge = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge`);
+  await badge.hover();
+  // Moving onto the interactive badge must not deactivate the overlay -
+  // the toolbar stays visible (see the updateActiveFromPointer guard fix).
+  await expect(toolbar).toHaveCSS('opacity', '1');
+});
+
+test('registerBadge: the badge slot stays aligned with its content element after scrolling', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.evaluate((uid) => {
+    (window as any).XimaFrontendEdit.registerBadge(uid, {
+      html: '<span style="display:inline-block;width:8px;height:8px;background:red;"></span>',
+      position: 'top-right',
+    });
+  }, CONTENT_ELEMENT_UID);
+
+  const element = page.locator(`#c${CONTENT_ELEMENT_UID}`);
+  const badge = page.locator(`.frontend-edit__overlay[data-cid="${CONTENT_ELEMENT_UID}"] .frontend-edit__badge`);
+
+  const offsetBefore = (await badge.boundingBox())!.y - (await element.boundingBox())!.y;
+
+  // The slot is a plain DOM child of the position-tracked overlay - no
+  // badge-specific scroll handling exists, so this proves that inherited
+  // tracking actually still applies after the CSS restructuring in this issue.
+  await page.mouse.wheel(0, 300);
+  await page.waitForTimeout(100); // OverlayManager's scroll handler is rAF-throttled
+
+  const offsetAfter = (await badge.boundingBox())!.y - (await element.boundingBox())!.y;
+  expect(Math.abs(offsetAfter - offsetBefore)).toBeLessThan(1);
+});
+
+test('setBadgeMode sets the data-xfe-badge-mode attribute for consumer CSS to key off', async ({ page }) => {
+  await page.goto('/');
+
+  expect(await page.evaluate(() => document.documentElement.getAttribute('data-xfe-badge-mode'))).toBeNull();
+
+  await page.evaluate(() => (window as any).XimaFrontendEdit.setBadgeMode('prominent'));
+  expect(await page.evaluate(() => document.documentElement.getAttribute('data-xfe-badge-mode'))).toBe('prominent');
+
+  await page.evaluate(() => (window as any).XimaFrontendEdit.setBadgeMode('subtle'));
+  expect(await page.evaluate(() => document.documentElement.getAttribute('data-xfe-badge-mode'))).toBe('subtle');
+
+  // Unknown values fall back to 'subtle' rather than setting garbage.
+  await page.evaluate(() => (window as any).XimaFrontendEdit.setBadgeMode('nonsense'));
+  expect(await page.evaluate(() => document.documentElement.getAttribute('data-xfe-badge-mode'))).toBe('subtle');
 });
 
 test('notify shows a toast notification', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Extends #208's minimal `registerBadge` (PR #235) into the real badge layer from #211: each corner of an element's overlay is now its own slot, so multiple badges in the same corner lay out in a predictable row instead of overlapping
- `registerBadge` gains an optional `id` - a later call with the same uid+id replaces the badge in place (same slot position) instead of adding a duplicate, since `xfe:element-rendered` can fire more than once for the same element
- New `setBadgeMode('subtle' | 'prominent')`, exposed as `data-xfe-badge-mode` on `<html>` - a pure hook with zero FE-side visual opinion (per the issue: "FE ships no badge content itself"), consumer CSS reacts to the attribute
- Fixes a real gap: hovering an interactive badge (`onClick`, already supported since #208) used to drop the outline/toolbar highlight the instant the cursor entered it - badges are now included in `updateActiveFromPointer`'s hover-bridge guard
- Badges get zero new position-tracking code - the slot is a plain DOM child of the already scroll/resize-tracked overlay, so it inherits tracking for free (verified with a dedicated scroll regression test)
- Nudged the top-corner slots further from the element (`-14px` vs the toolbar pill's `translateY(-50%)` straddle) to avoid visually colliding with the toolbar on hover

## Changes

- `Resources/Public/JavaScript/frontend_edit.js` - badge slots, id-replace, `setBadgeMode`, hover-guard fix
- `Resources/Public/Css/FrontendEdit.css` - slot layout (flex row per corner)
- `Tests/Playwright/tests/public-api.spec.ts` - stacking, id-replace, hover-guard, scroll-tracking, and `setBadgeMode` coverage
- `Documentation/DeveloperCorner/JavaScriptApi.rst` - documents `id`, stacking behavior, and `setBadgeMode`

Closes #211

Stacked on #236 (#209, which itself stacks on #235/#208) since this directly extends `registerBadge`, which only exists on that branch tree.

## Test plan

- [x] New/updated Playwright coverage passes on both v13 and v14
- [x] Full Playwright suite passes on both versions (no regressions)