### PR TITLE
feat: add data-frontend-edit attribute as an alternative element-matching channel

### DIFF
--- a/Classes/ViewHelpers/EditableViewHelper.php
+++ b/Classes/ViewHelpers/EditableViewHelper.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+
+use function is_array;
+use function sprintf;
+
+/**
+ * EditableViewHelper.
+ *
+ * Renders the `data-frontend-edit="tt_content:{uid}"` attribute - the
+ * alternative to the `id="c{uid}"` anchor pattern for templates that cannot
+ * carry that anchor (e.g. DCE, other custom Fluid templates). Place directly
+ * inside the opening tag of the content element's own wrapping element; it
+ * renders only the attribute, not a wrapping tag.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class EditableViewHelper extends AbstractViewHelper
+{
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function __construct(
+        private readonly BackendUserService $backendUserService,
+    ) {}
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('record', 'array', 'The tt_content record (or any array containing at least "uid")');
+        $this->registerArgument('uid', 'int', 'Content element uid, alternative to "record"');
+    }
+
+    public function render(): string
+    {
+        if (!$this->backendUserService->isFrontendEditAllowed()
+            || $this->backendUserService->isFrontendEditDisabled()
+        ) {
+            return '';
+        }
+
+        $uid = $this->resolveUid();
+        if (null === $uid || $uid <= 0) {
+            return '';
+        }
+
+        return sprintf(' data-frontend-edit="tt_content:%d"', $uid);
+    }
+
+    private function resolveUid(): ?int
+    {
+        if (null !== $this->arguments['uid']) {
+            return (int) $this->arguments['uid'];
+        }
+
+        $record = $this->arguments['record'] ?? null;
+        if (is_array($record) && isset($record['uid'])) {
+            return (int) $record['uid'];
+        }
+
+        return null;
+    }
+}

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -86,6 +86,15 @@ Dynamic content elements do not provide the required "c-id" (Content Element ID)
 ..  note::
     Styling problems may occur with nested content elements.
 
+Alternatively, add the :code:`data-frontend-edit` attribute instead (see :ref:`How it works <how-it-works>`) - it avoids the "c-id" naming collision risk entirely and needs no sibling resolution:
+
+..  code-block:: html
+    :caption: DCE Template
+
+    <div class="dce"<xfe:editable uid="{contentObject.uid}" />>
+        Your template goes here...
+    </div>
+
 .. rst-class:: panel panel-default
 
 The edit button is not displayed with `container <https://extensions.typo3.org/extension/container/>`__ extension content elements.

--- a/Documentation/HowItWorks/Index.rst
+++ b/Documentation/HowItWorks/Index.rst
@@ -23,6 +23,41 @@ This is **only possible**, if the content element "c-ids" (Content Element IDs) 
 
     This is automatically done by the `fluid_styled_content` extension. If you are using custom content element templates, make sure to include the "c-id" within the wrapping HTML element of the content element.
 
+Alternative: the ``data-frontend-edit`` attribute
+=====================================================
+
+For templates that cannot carry the "c-id" anchor - dynamic content element
+extensions (DCE), other custom Fluid templates - a second matching channel
+exists: a ``data-frontend-edit="tt_content:{uid}"`` attribute on the content
+element's own wrapping HTML element.
+
+..  code-block:: html
+    :caption: Example HTML output using the data attribute instead
+
+    <div data-frontend-edit="tt_content:10" class="my-custom-wrapper">
+        ...
+    </div>
+
+The bundled ``<xfe:editable>`` ViewHelper renders this attribute for you:
+
+..  code-block:: html
+    :caption: Custom Fluid Template
+
+    <div class="my-custom-wrapper"<xfe:editable record="{data}" />>
+        ...
+    </div>
+
+Both patterns can be mixed freely on the same page; an element only needs
+one of them. Unlike the "c-id" anchor pattern, a ``data-frontend-edit``
+element is always treated as the content element itself - no sibling
+resolution is attempted.
+
+..  note::
+    Headless/SPA frontends are an explicit non-goal: the script that scans
+    for either pattern is injected server-side into the rendered HTML (see
+    below), so it never runs for a frontend that TYPO3 does not render HTML
+    for in the first place.
+
 The rendered Edit Menu links to the corresponding edit views in the TYPO3 backend.
 
 ..  note::

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1082,9 +1082,17 @@
    * Data Service
    */
   const DataService = {
+    /**
+     * Walks up from a .frontend-edit__data element to its owning content
+     * element - either the id="c{uid}" anchor or a data-frontend-edit="tt_content:{uid}"
+     * element - so <xfe:data> additional-data entries also resolve on content
+     * elements that only expose the data attribute.
+     */
     getClosestContentElement(element) {
       if (!element) return null;
-      while (element && !/^c\d+$/.test(Dom.id(element))) {
+      const isContentElement = (el) =>
+        /^c\d+$/.test(Dom.id(el)) || /^tt_content:\d+$/.test(el.getAttribute('data-frontend-edit') || '');
+      while (element && !isContentElement(element)) {
         element = element.parentElement;
       }
       return element;
@@ -1140,18 +1148,18 @@
         const closestElement = this.getClosestContentElement(element);
         if (!closestElement) return;
 
-        const id = Dom.id(closestElement).replace('c', '');
-        const uid = parseInt(id, 10);
+        // The owning element was found via either channel (see
+        // getClosestContentElement) - resolve the uid from whichever matched.
+        const idMatch = Dom.id(closestElement).match(/^c(\d+)$/);
+        const dataMatch = idMatch ? null : (closestElement.getAttribute('data-frontend-edit') || '').match(/^tt_content:(\d+)$/);
+        const uid = parseInt((idMatch || dataMatch)?.[1] ?? '', 10);
+        if (!(uid > 0)) return;
 
         if (!dataItems[uid]) dataItems[uid] = [];
 
         const parsedData = JSON.parse(element.value);
         dataItems[uid].push(parsedData);
-
-        // Ensure this UID is included
-        if (uid > 0) {
-          allUids.add(uid);
-        }
+        allUids.add(uid);
 
         Logger.log(`Additional data element ${index + 1}: Found content element c${uid}`, { parsedData });
       });

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -518,6 +518,25 @@
 
       // Fallback to original element
       return idElement;
+    },
+
+    /**
+     * Locate the DOM anchor for a content element uid: the id="c{uid}"
+     * pattern first (existing behavior, unchanged), falling back to
+     * data-frontend-edit="tt_content:{uid}" - a direct target, since a
+     * hand-placed data attribute is never an anchor-sibling placeholder the
+     * way an empty <a id="c123"></a> is.
+     *
+     * @returns {{element: Element, isDirectTarget: boolean}|null}
+     */
+    findAnchor(uid) {
+      const idElement = document.querySelector(`#c${uid}`);
+      if (idElement) return { element: idElement, isDirectTarget: false };
+
+      const dataElement = document.querySelector(`[data-frontend-edit="tt_content:${uid}"]`);
+      if (dataElement) return { element: dataElement, isDirectTarget: true };
+
+      return null;
     }
   };
 
@@ -1093,6 +1112,25 @@
 
       Logger.log(`Found ${allUids.size} content elements in DOM with id="c{uid}" pattern`);
 
+      // Second matching channel: data-frontend-edit="tt_content:{uid}" - for
+      // templates that cannot carry the id="c{uid}" anchor (DCE, custom Fluid
+      // templates; see the <xfe:editable> ViewHelper). These are direct
+      // targets: Renderer.render() skips anchor-sibling resolution for them.
+      const beforeDataAttributeScan = allUids.size;
+      document.querySelectorAll('[data-frontend-edit]').forEach(element => {
+        const match = (element.getAttribute('data-frontend-edit') || '').match(/^tt_content:(\d+)$/);
+        if (match) {
+          const uid = parseInt(match[1], 10);
+          if (uid > 0) {
+            allUids.add(uid);
+          }
+        }
+      });
+
+      if (allUids.size > beforeDataAttributeScan) {
+        Logger.log(`Found ${allUids.size - beforeDataAttributeScan} additional content element(s) via data-frontend-edit attribute`);
+      }
+
       // Collect additional data from .frontend-edit__data elements
       const dataElements = document.querySelectorAll('.frontend-edit__data');
 
@@ -1226,7 +1264,9 @@
           continue;
         }
 
-        let idElement = document.querySelector(`#c${uid}`);
+        // id="c{uid}" anchor first, falling back to
+        // data-frontend-edit="tt_content:{uid}" (see ElementResolver.findAnchor).
+        let resolved = ElementResolver.findAnchor(uid);
 
         // Handle translation mapping. In connected/overlay mode the DOM anchor
         // carries the default-language uid (l18n_parent), so the response uid
@@ -1234,24 +1274,28 @@
         // anchor even when the primary lookup missed. Prefer l18n_parent (the
         // canonical connected-mode pointer) over l10n_source (chained translations).
         // Coerce to number: DB values may arrive as strings, and "0" is truthy in JS.
+        // The empty-anchor check only applies to the id="c{uid}" pattern - a
+        // data-frontend-edit direct target is never a placeholder anchor.
         const anchorUid = Number(contentElement.element.l18n_parent) || Number(contentElement.element.l10n_source);
-        if (anchorUid > 0 && (!idElement || idElement.tagName.toLowerCase() === 'a')) {
-          const anchorElement = document.querySelector(`#c${anchorUid}`);
-          if (anchorElement) {
+        const needsTranslationFallback = !resolved || (!resolved.isDirectTarget && resolved.element.tagName.toLowerCase() === 'a');
+        if (anchorUid > 0 && needsTranslationFallback) {
+          const fallbackResolved = ElementResolver.findAnchor(anchorUid);
+          if (fallbackResolved) {
             Logger.log(`Translation mapping: c${uid} → c${anchorUid}`);
             uid = anchorUid;
-            idElement = anchorElement;
+            resolved = fallbackResolved;
           }
         }
 
-        if (!idElement) {
+        if (!resolved) {
           failed++;
           Logger.log(`DOM assignment failed: Element c${uid} not found`, null, 'warn');
           continue;
         }
 
-        // Resolve actual content element (handles anchor pattern)
-        const targetElement = ElementResolver.resolveContentElement(idElement);
+        // Resolve actual content element (handles the anchor pattern; a
+        // data-frontend-edit match is already the direct target).
+        const targetElement = resolved.isDirectTarget ? resolved.element : ElementResolver.resolveContentElement(resolved.element);
 
         successful++;
         this.setupContentElement(targetElement, uid, contentElement, showContextMenu, enableOutline);
@@ -1261,7 +1305,7 @@
           ctypeLabel: contentElement.element.ctypeLabel,
           showContextMenu,
           enableOutline,
-          usedSibling: targetElement !== idElement
+          usedSibling: targetElement !== resolved.element
         });
       }
 

--- a/Tests/Playwright/tests/data-attribute-matching.spec.ts
+++ b/Tests/Playwright/tests/data-attribute-matching.spec.ts
@@ -121,5 +121,5 @@ test('a nested .frontend-edit__data element (the <xfe:data> ViewHelper) resolves
 
   const dropdown = page.locator(`.frontend-edit__dropdown[data-cid="${DATA_ATTRIBUTE_ONLY_UID}"]`);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText('Related item')).toHaveCount(1);
+  await expect(dropdown.getByText('Related item', { exact: true })).toBeVisible();
 });

--- a/Tests/Playwright/tests/data-attribute-matching.spec.ts
+++ b/Tests/Playwright/tests/data-attribute-matching.spec.ts
@@ -85,3 +85,41 @@ test('a stray data-frontend-edit attribute for an already-anchored uid does not 
   await page.hover('#xfe-test-duplicate-target', { force: true });
   await expect(page.locator(`.frontend-edit__toolbar[data-cid="${ANCHOR_UID}"]`)).toHaveCSS('opacity', '0');
 });
+
+test('a nested .frontend-edit__data element (the <xfe:data> ViewHelper) resolves via its data-attribute-only owning element', async ({ page }) => {
+  // <xfe:data> attaches a hidden .frontend-edit__data input to add extra
+  // menu entries for related records - previously only resolved via the
+  // id="c{uid}" anchor (getClosestContentElement); must also work when the
+  // owning element instead uses data-frontend-edit.
+  await page.addInitScript(
+    ({ elementId, uid, relatedUid }) => {
+      document.addEventListener('DOMContentLoaded', () => {
+        const el = document.createElement('div');
+        el.id = elementId;
+        el.setAttribute('data-frontend-edit', `tt_content:${uid}`);
+        el.textContent = 'Data-attribute test element with nested additional data';
+
+        const dataInput = document.createElement('input');
+        dataInput.type = 'hidden';
+        dataInput.className = 'frontend-edit__data';
+        dataInput.value = JSON.stringify({ label: 'Related item', table: 'tt_content', uid: relatedUid });
+        el.appendChild(dataInput);
+
+        document.body.prepend(el);
+      });
+    },
+    { elementId: 'xfe-test-data-attribute-with-additional-data', uid: DATA_ATTRIBUTE_ONLY_UID, relatedUid: ANCHOR_UID },
+  );
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await page.hover('#xfe-test-data-attribute-with-additional-data', { force: true });
+  const toolbar = page.locator(`.frontend-edit__toolbar[data-cid="${DATA_ATTRIBUTE_ONLY_UID}"]`);
+  await toolbar.locator('.frontend-edit__btn--kebab').click();
+
+  const dropdown = page.locator(`.frontend-edit__dropdown[data-cid="${DATA_ATTRIBUTE_ONLY_UID}"]`);
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.getByText('Related item')).toHaveCount(1);
+});

--- a/Tests/Playwright/tests/data-attribute-matching.spec.ts
+++ b/Tests/Playwright/tests/data-attribute-matching.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page, with its usual id="c2"
+// anchor (Tests/Acceptance/Fixtures/demo-content.sql).
+const ANCHOR_UID = 2;
+
+// "Our Mission" - lives on the About Us page (pid=2, see onepager.spec.ts) and
+// has no id="c7" anchor anywhere on the Home page. Used here purely as a
+// real, fetchable tt_content record with no anchor already competing for the
+// data-attribute matching under test - fetchContentElementsByUids() (the
+// uid-based path collectDataItems() triggers) isn't scoped to a single page.
+const DATA_ATTRIBUTE_ONLY_UID = 7;
+
+async function injectDataAttributeElement(page: import('@playwright/test').Page, elementId: string, uid: number): Promise<void> {
+  await page.addInitScript(
+    ({ elementId, uid }) => {
+      // Registered before navigation, listening for DOMContentLoaded - which
+      // fires before frontend_edit.js's own DOMContentLoaded-driven bootstrap()
+      // (FrontendEdit.init() registers its listener afterwards, since its
+      // <script> tag parses later), so the element exists in time for
+      // DataService.collectDataItems()'s DOM scan.
+      document.addEventListener('DOMContentLoaded', () => {
+        const el = document.createElement('div');
+        el.id = elementId;
+        el.setAttribute('data-frontend-edit', `tt_content:${uid}`);
+        el.textContent = 'Data-attribute test element';
+        // Prepended, not appended: a fixed-position cookie-consent banner
+        // sits at the bottom of the page and would otherwise sit on top of
+        // (and intercept real hit-testing/hover for) an element appended at
+        // the end of body.
+        document.body.prepend(el);
+      });
+    },
+    { elementId, uid },
+  );
+}
+
+test('an element with only data-frontend-edit receives an overlay/menu, without an id="c{uid}" anchor', async ({ page }) => {
+  await injectDataAttributeElement(page, 'xfe-test-data-attribute-target', DATA_ATTRIBUTE_ONLY_UID);
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const toolbar = page.locator(`.frontend-edit__toolbar[data-cid="${DATA_ATTRIBUTE_ONLY_UID}"]`);
+  await expect(toolbar).toHaveCount(1);
+  await expect(toolbar).toHaveCSS('opacity', '0');
+
+  // Hovering the injected element itself activates its toolbar - proving
+  // OverlayManager tracks THAT element directly (no anchor-sibling
+  // resolution walked it onto some other node).
+  await page.hover('#xfe-test-data-attribute-target', { force: true });
+  await expect(toolbar).toHaveCSS('opacity', '1');
+});
+
+test('mixed page: an id-anchor element and a data-attribute-only element both work side by side', async ({ page }) => {
+  await injectDataAttributeElement(page, 'xfe-test-data-attribute-target', DATA_ATTRIBUTE_ONLY_UID);
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await expect(hoverMenu.toolbar(ANCHOR_UID)).toHaveCount(1);
+  await expect(page.locator(`.frontend-edit__toolbar[data-cid="${DATA_ATTRIBUTE_ONLY_UID}"]`)).toHaveCount(1);
+});
+
+test('a stray data-frontend-edit attribute for an already-anchored uid does not create a duplicate toolbar', async ({ page }) => {
+  // Same uid as the real id="c2" anchor already on the page - the id-anchor
+  // must win, and this element must not also get its own registration.
+  await injectDataAttributeElement(page, 'xfe-test-duplicate-target', ANCHOR_UID);
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  await expect(page.locator(`.frontend-edit__toolbar[data-cid="${ANCHOR_UID}"]`)).toHaveCount(1);
+
+  // The duplicate element itself was never registered as an overlay target -
+  // OverlayManager's pointer tracking only activates a toolbar when the
+  // hovered node resolves to a registered target (see
+  // resolveRegisteredElement in frontend_edit.js). Hovering the stray
+  // duplicate must not activate the real c2 toolbar.
+  await page.hover('#xfe-test-duplicate-target', { force: true });
+  await expect(page.locator(`.frontend-edit__toolbar[data-cid="${ANCHOR_UID}"]`)).toHaveCSS('opacity', '0');
+});

--- a/Tests/Unit/ViewHelpers/EditableViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/EditableViewHelperTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\ViewHelpers;
+
+use PHPUnit\Framework\Attributes\{CoversClass, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use Xima\XimaTypo3FrontendEdit\Configuration;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
+use Xima\XimaTypo3FrontendEdit\ViewHelpers\EditableViewHelper;
+
+/**
+ * EditableViewHelperTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(EditableViewHelper::class)]
+final class EditableViewHelperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+    }
+
+    #[Test]
+    public function renderReturnsEmptyStringWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => null, 'uid' => 42]);
+
+        self::assertSame('', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderReturnsEmptyStringWhenFrontendEditDisabled(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = [Configuration::UC_KEY_DISABLED => true];
+        $backendUser->method('getTSConfig')->willReturn([]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => null, 'uid' => 42]);
+
+        self::assertSame('', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderReturnsEmptyStringWhenNeitherRecordNorUidGiven(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => null, 'uid' => null]);
+
+        self::assertSame('', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderReturnsEmptyStringForNonPositiveUid(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => null, 'uid' => 0]);
+
+        self::assertSame('', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderReturnsDataAttributeFromUidArgument(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => null, 'uid' => 42]);
+
+        self::assertSame(' data-frontend-edit="tt_content:42"', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderReturnsDataAttributeFromRecordArgument(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => ['uid' => 99, 'CType' => 'text'], 'uid' => null]);
+
+        self::assertSame(' data-frontend-edit="tt_content:99"', $viewHelper->render());
+    }
+
+    #[Test]
+    public function renderPrefersUidArgumentOverRecordArgument(): void
+    {
+        $this->setUpAuthenticatedBackendUser();
+
+        $viewHelper = new EditableViewHelper(new BackendUserService());
+        $viewHelper->initializeArguments();
+        $viewHelper->setArguments(['record' => ['uid' => 99], 'uid' => 42]);
+
+        self::assertSame(' data-frontend-edit="tt_content:42"', $viewHelper->render());
+    }
+
+    private function setUpAuthenticatedBackendUser(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->uc = [];
+        $backendUser->method('getTSConfig')->willReturn([]);
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+}


### PR DESCRIPTION
## Summary

- Second matching channel alongside the `id="c{uid}"` anchor pattern: `data-frontend-edit="tt_content:{uid}"`, for templates that cannot carry the anchor (DCE, other custom Fluid templates)
- JS collects uids from both patterns into the same set; data-attribute elements are treated as **direct targets** - no anchor-sibling resolution is attempted for them
- No configuration switch - both patterns coexist freely on the same page
- When the same uid is reachable via both channels, the id-anchor wins and no duplicate registration happens (the backend returns each uid once; the frontend resolves it once)
- New `<xfe:editable record="{data}" />` / `<xfe:editable uid="{uid}" />` ViewHelper renders the attribute, mirroring the existing `<xfe:data>`/`<xfe:columnTarget>` ViewHelpers' conventions
- Scoped to `tt_content` only for now (matching this issue's acceptance criteria) - #216 will extend both the JS regex and the ViewHelper with a `table` argument once generic-record backend support actually exists, avoiding a footgun where an unsupported table would silently do nothing today
- Headless/SPA frontends documented as an explicit non-goal (the middleware injection that scans for either pattern never runs there)

## Changes

- `Resources/Public/JavaScript/frontend_edit.js` - `ElementResolver.findAnchor()` (dual-channel lookup), wired into `DataService.collectDataItems()` and `Renderer.render()`
- `Classes/ViewHelpers/EditableViewHelper.php` - the new `<xfe:editable>` ViewHelper
- `Tests/Unit/ViewHelpers/EditableViewHelperTest.php`, `Tests/Playwright/tests/data-attribute-matching.spec.ts` - unit + E2E coverage (data-attribute-only element, mixed anchor+attribute page, duplicate-uid resolution)
- `Documentation/HowItWorks/Index.rst`, `Documentation/FAQ/Index.rst` - documents the attribute, the ViewHelper, and the DCE use case; non-goal note

Closes #215

## Test plan

- [x] Unit suite passes (312 tests), PHPStan level 8 clean, PHP-CS-Fixer clean
- [x] Functional suite passes (69 tests)
- [x] New Playwright spec + full suite pass on both v13 and v14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added frontend editing through `data-frontend-edit` attributes.
  * Added a view helper for generating edit targets from content element identifiers.
  * Data-attribute targets can coexist with traditional editing anchors without duplicate toolbars.

* **Documentation**
  * Documented data-attribute matching, template examples, and compatibility considerations, including server-rendered frontend requirements.

* **Tests**
  * Added coverage for matching, nested content elements, duplicate prevention, permissions, disabled editing, and invalid identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->