### PR TITLE
docs: add a consolidated Setup requirements & limits chapter

### DIFF
--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -18,3 +18,4 @@ Learn what configuration options are available on the following pages:
     SiteSettings
     UserTSconfig
     ExtensionConfiguration
+    SetupRequirementsAndLimits

--- a/Documentation/Configuration/SetupRequirementsAndLimits.rst
+++ b/Documentation/Configuration/SetupRequirementsAndLimits.rst
@@ -1,0 +1,89 @@
+..  include:: /Includes.rst.txt
+
+..  _setup-requirements-and-limits:
+
+===================================
+Setup requirements & limits
+===================================
+
+A single reference for operational topics that affect whether - and how
+reliably - frontend editing works in a given setup. Several :ref:`FAQ <faq>`
+entries link here instead of repeating this content.
+
+Multi-domain setups
+======================
+
+Frontend editing needs an active TYPO3 backend session in the browser that
+is viewing the frontend. Whether that session is available depends on
+domain/cookie configuration:
+
+**Session cookie reach (``cookieDomain``)**
+
+The backend session cookie is only sent to the domain(s) it was issued for.
+If the frontend and backend live on different (sub)domains, set
+`cookieDomain <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Configuration/Typo3ConfVars/SYS.html#confval-globals-typo3-conf-vars-sys-cookiedomain>`__
+so the cookie is shared across them.
+
+**SameSite**
+
+A restrictive `cookieSameSite <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Configuration/Typo3ConfVars/SYS.html#confval-globals-typo3-conf-vars-sys-cookiesamesite>`__
+setting can also prevent the backend session cookie from being sent on the
+frontend request, with the same symptom as a cookie domain mismatch: the
+Edit Menu never appears, with no error visible in the frontend.
+
+**Cross-domain backend login**
+
+If sharing a cookie domain is not an option (fully separate domains, not
+subdomains of one another), use the
+`multisite_belogin <https://extensions.typo3.org/extension/multisite_belogin>`__
+extension, which provides backend login support across multiple domains
+without a shared cookie domain.
+
+**``returnUrl`` behavior**
+
+The ``returnUrl`` passed to backend edit routes is validated against the
+current request's host and the site's configured base hosts (including
+language bases); a foreign host is rejected rather than followed. In a
+cross-domain setup (frontend and backend on different domains), this can
+mean a ``returnUrl`` that legitimately points at the frontend domain gets
+treated as foreign to the backend request. If a strict referer header is
+also masking the real frontend host - see the :ref:`FAQ <faq>` entry on
+this - enable :ref:`forceReturnUrlGeneration <extconf-forceReturnUrlGeneration>`
+to generate the return URL from pid/language instead of trusting the
+request's own host.
+
+External caches (Varnish, CDN)
+==================================
+
+After a hide or delete action, the extension clears TYPO3's own page cache
+for the affected page - that part happens automatically. It has no way to
+purge an external cache layer (Varnish, a CDN) sitting in front of TYPO3,
+since that requires cache-tag/ban integration specific to that layer. If
+such a cache is in front of your site, the redirect after hide/delete may
+briefly show a stale version of the page until that external cache's own
+TTL or invalidation logic catches up.
+
+Anchor pattern requirement (and the headless/SPA non-goal)
+================================================================
+
+Matching a content element in the frontend HTML to its backend record
+requires either the ``id="c{uid}"`` anchor pattern or the
+``data-frontend-edit="{table}:{uid}"`` attribute to be present in the
+rendered markup - see :ref:`How it works <how-it-works>` for both patterns
+and how to add them to a custom template.
+
+Headless/SPA frontends are an explicit non-goal: the script that performs
+this matching is injected server-side into TYPO3's own rendered HTML (via a
+PSR-15 middleware). It never runs for a frontend that TYPO3 itself does not
+render HTML for - there is no client-side integration path for a
+JSON-API/decoupled frontend.
+
+Preview links (``ADMCMD_prev``)
+====================================
+
+A backend preview link (:literal:`ADMCMD_prev=...`) lets someone view a
+page - e.g. an unpublished draft - without a full backend login. No frontend
+editing UI is shown for such a viewer: there is no active backend user
+session behind an ``ADMCMD_prev`` link, and the extension's access checks
+require one. This is expected behavior, not a bug - a preview link is
+meant for reviewing content, not editing it.

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -31,7 +31,7 @@ Is the Frontend Edit site set included in your site configuration? Check the Sit
 
 **Content Element IDs**
 
-Make sure that the content element "c-ids" (Content Element IDs) are available within your frontend template, e.g. "c908".
+Make sure that the content element "c-ids" (Content Element IDs) are available within your frontend template, e.g. "c908" - or use the ``data-frontend-edit`` attribute instead. See :ref:`How it works <how-it-works>` and :ref:`Setup requirements & limits <setup-requirements-and-limits>` (headless/SPA frontends are an explicit non-goal, for the same reason).
 
 **Content Element on current Page**
 
@@ -48,6 +48,8 @@ After closing the edit form, I am redirected to the wrong frontend location (e.g
 =======================================
 
 This could be caused by a strict referer header in your request. If the return url could not be determined correctly, you can force the url generation by pid and language in the extension setting: :code:`forceReturnUrlGeneration`.
+
+See :ref:`Setup requirements & limits <setup-requirements-and-limits>` for the full picture of how ``returnUrl`` is validated, especially in multi-domain setups.
 
 .. rst-class:: panel panel-default
 
@@ -68,6 +70,8 @@ You can have a look at the `cookieDomain` setting to set a more flexible domain 
 See https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Configuration/Typo3ConfVars/SYS.html#confval-globals-typo3-conf-vars-sys-cookiedomain
 
 Alternatively, you can use the `multisite_belogin <https://extensions.typo3.org/extension/multisite_belogin>`__ extension, which provides backend login support across multiple domains without requiring shared cookie domains.
+
+See :ref:`Setup requirements & limits <setup-requirements-and-limits>` for the full picture of multi-domain setups (including ``SameSite`` and ``returnUrl`` behavior).
 
 .. rst-class:: panel panel-default
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Edit content elements directly in the frontend without navigating to the backend
 * TYPO3 >= 13.4
 * PHP 8.2+
 
+See [Setup requirements & limits](https://docs.typo3.org/p/xima/xima-typo3-frontend-edit/main/en-us/Configuration/SetupRequirementsAndLimits.html) for multi-domain setups, external caches (Varnish/CDN), the content element anchor pattern requirement (and the headless/SPA non-goal), and preview links.
+
 ### Supports
 
 | **Version** | **TYPO3** | **PHP** |


### PR DESCRIPTION
## Summary

Bundles several operational topics that were scattered across FAQ entries or missing entirely into one new documentation chapter:

- **Multi-domain setups**: session cookie reach (`cookieDomain`), `SameSite`, cross-domain backend login (`multisite_belogin`), and `returnUrl` validation behavior
- **External caches**: TYPO3's own page cache is cleared after hide/delete, but the extension cannot purge an external Varnish/CDN layer in front of it - documented as an expected limitation, not a bug
- **Anchor pattern requirement**: both matching channels (`id="c{uid}"` and `data-frontend-edit`), and the headless/SPA non-goal, stated explicitly
- **Preview links** (`ADMCMD_prev`): no edit UI for a pure preview viewer with no backend session - expected behavior

## Changes

- `Documentation/Configuration/SetupRequirementsAndLimits.rst` - the new chapter
- `Documentation/Configuration/Index.rst` - added to the toctree
- `Documentation/FAQ/Index.rst` - the three relevant existing entries (wrong return location, cross-domain, content element IDs) now link to it instead of only repeating a subset of the same information
- `README.md` - Requirements section links to it

Closes #218

Stacked on #239 (#215) since this chapter documents the `data-frontend-edit` attribute introduced there.

## Test plan

- [x] Docs-only change; no code touched. Cross-referenced `:ref:` labels checked by hand against their target anchors (no automated Sphinx build in this repo's CGL tooling).