### PR TITLE
fix: accessibility audit of the edit menu and sticky toolbar (#219)

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -4,6 +4,9 @@
        light and dark page layouts (the brown dialog color did not). */
     --xfe-dnd-accent: #2d7ff9;
     --xfe-toolbar-bg: rgba(50, 50, 50, 0.95);
+    /* Toolbar-button border: its own value because #767676 (the page outline
+       color) only reaches ~2.8:1 on the dark fill, below the 3:1 non-text target. */
+    --xfe-toolbar-border-color: #aaaaaa;
     --xfe-toolbar-text: #ffffff;
     --xfe-toolbar-btn-hover: rgba(255, 255, 255, 0.15);
     --xfe-bg-primary: #ffffff;
@@ -33,6 +36,8 @@
 /* Light theme (explicit) */
 [data-xfe-theme="light"] {
     --xfe-toolbar-bg: rgba(245, 245, 245, 0.95);
+    /* Light toolbar fill; #767676 clears 3:1 here, so reuse the outline value. */
+    --xfe-toolbar-border-color: #767676;
     --xfe-toolbar-text: #1a1a1a;
     --xfe-toolbar-btn-hover: rgba(0, 0, 0, 0.1);
     --xfe-bg-primary: #ffffff;
@@ -1021,7 +1026,7 @@
     line-height: 1;
     transition: background 0.15s ease, border-color 0.15s ease;
     border-radius: 4px;
-    border: 1px solid var(--xfe-outline-color);
+    border: 1px solid var(--xfe-toolbar-border-color);
     background: var(--xfe-toolbar-bg);
 }
 

--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -11,7 +11,7 @@
     --xfe-text-primary: #1a1a1a;
     --xfe-text-secondary: #666666;
     --xfe-border-color: #e0e0e0;
-    --xfe-outline-color: #aaaaaa;
+    --xfe-outline-color: #767676;
     --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.5);
     --xfe-dialog-bg: #ffffff;
@@ -40,7 +40,7 @@
     --xfe-text-primary: #1a1a1a;
     --xfe-text-secondary: #666666;
     --xfe-border-color: #e0e0e0;
-    --xfe-outline-color: #aaaaaa;
+    --xfe-outline-color: #767676;
     --xfe-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     --xfe-dialog-overlay-bg: rgba(0, 0, 0, 0.5);
     --xfe-dialog-bg: #ffffff;

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1016,6 +1016,16 @@
         }
       });
 
+      // Roving focus (tabindex="-1" on every item) keeps Tab out of the menu
+      // by design (APG menu-button pattern) - but the menu must then close
+      // itself once focus actually leaves it, or it stays open with no
+      // visible focus inside.
+      dropdown.addEventListener('focusout', (e) => {
+        if (!dropdown.contains(e.relatedTarget)) {
+          Dropdown.closeAll();
+        }
+      });
+
       return dropdown;
     },
 

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -1021,6 +1021,12 @@
       // itself once focus actually leaves it, or it stays open with no
       // visible focus inside.
       dropdown.addEventListener('focusout', (e) => {
+        // If focus moves to a kebab trigger (the user clicking it to toggle the
+        // menu shut), leave the close decision to that button's click handler -
+        // closing here first would make the click read a closed menu and reopen it.
+        if (e.relatedTarget && e.relatedTarget.closest('.frontend-edit__btn--kebab')) {
+          return;
+        }
         if (!dropdown.contains(e.relatedTarget)) {
           Dropdown.closeAll();
         }

--- a/Resources/Public/JavaScript/sticky_toolbar.js
+++ b/Resources/Public/JavaScript/sticky_toolbar.js
@@ -415,6 +415,12 @@
         // itself once focus actually leaves it, or it stays open with no
         // visible focus inside.
         dropdown.addEventListener('focusout', (e) => {
+          // Focus moving to the trigger means the user is toggling the menu via
+          // that button; its click handler owns the open/close decision. Closing
+          // here first would let the click reopen an already-closed menu.
+          if (e.relatedTarget === menuBtn) {
+            return;
+          }
           if (!dropdown.contains(e.relatedTarget)) {
             closeDropdown();
           }

--- a/Resources/Public/JavaScript/sticky_toolbar.js
+++ b/Resources/Public/JavaScript/sticky_toolbar.js
@@ -196,10 +196,10 @@
         html += `
         <div class="frontend-edit__sticky-separator"></div>
         <div class="frontend-edit__sticky-dropdown-container">
-          <button class="frontend-edit__sticky-btn frontend-edit__sticky-btn--menu" data-tooltip="${this.escapeAttribute(this.tooltips.pageOptions)}" type="button">
+          <button class="frontend-edit__sticky-btn frontend-edit__sticky-btn--menu" data-tooltip="${this.escapeAttribute(this.tooltips.pageOptions)}" type="button" aria-haspopup="menu" aria-expanded="false">
             ${ICONS.kebab}
           </button>
-          <div class="frontend-edit__sticky-dropdown"></div>
+          <div class="frontend-edit__sticky-dropdown" role="menu"></div>
         </div>`;
       }
 
@@ -243,12 +243,14 @@
         if (item.type === 'divider') {
           element = document.createElement('div');
           element.className = `frontend-edit__divider ${this.escapeClassName(name)}`;
+          element.setAttribute('role', 'separator');
           const span = document.createElement('span');
           span.textContent = item.label || '';
           element.appendChild(span);
         } else if (item.type === 'info') {
           element = document.createElement('div');
           element.className = `frontend-edit__info ${this.escapeClassName(name)}`;
+          element.setAttribute('role', 'presentation');
           // Icons are trusted HTML from TYPO3 backend (IconFactory)
           if (item.icon) {
             const iconWrapper = document.createElement('span');
@@ -260,6 +262,8 @@
           element.appendChild(span);
         } else if (item.type === 'link') {
           element = document.createElement('a');
+          element.setAttribute('role', 'menuitem');
+          element.setAttribute('tabindex', '-1');
           // Validate URL to prevent javascript: protocol attacks
           if (item.url && this.isValidUrl(item.url)) {
             element.href = item.url;
@@ -278,6 +282,7 @@
               // Close the sticky toolbar dropdown
               const dropdown = document.querySelector('.frontend-edit__sticky-dropdown');
               if (dropdown) dropdown.classList.remove('frontend-edit__sticky-dropdown--visible');
+              document.querySelector('.frontend-edit__sticky-btn--menu')?.setAttribute('aria-expanded', 'false');
             });
           }
           // Icons are trusted HTML from TYPO3 backend (IconFactory)
@@ -343,20 +348,75 @@
         // (toolbar may have CSS transform which creates a new containing block)
         document.body.appendChild(dropdown);
 
+        const focusFirstItem = () => {
+          dropdown.querySelector('[role="menuitem"]')?.focus();
+        };
+
+        const closeDropdown = () => {
+          dropdown.classList.remove('frontend-edit__sticky-dropdown--visible');
+          menuBtn.setAttribute('aria-expanded', 'false');
+          // In case the menu closes again before its open-transition ran its
+          // course, so this doesn't fire late and re-focus an already-hidden item.
+          dropdown.removeEventListener('transitionend', focusFirstItem);
+        };
+
         menuBtn.addEventListener('click', async (e) => {
           e.stopPropagation();
           const isVisible = dropdown.classList.contains('frontend-edit__sticky-dropdown--visible');
           if (isVisible) {
-            dropdown.classList.remove('frontend-edit__sticky-dropdown--visible');
+            closeDropdown();
           } else {
             await this.positionDropdown(menuBtn, dropdown);
             dropdown.classList.add('frontend-edit__sticky-dropdown--visible');
+            menuBtn.setAttribute('aria-expanded', 'true');
+            // CSS transitions visibility together with opacity (so it only
+            // switches to hidden once the fade-out completes on close). The
+            // browser only treats the dropdown as focusable once that
+            // transition has actually run its course - a requestAnimationFrame
+            // still fires too early. Waiting for its own transitionend is what
+            // reliably works, and it self-adjusts to prefers-reduced-motion.
+            dropdown.addEventListener('transitionend', focusFirstItem, { once: true });
           }
         });
 
         document.addEventListener('click', (e) => {
           if (!dropdownContainer.contains(e.target) && !dropdown.contains(e.target)) {
-            dropdown.classList.remove('frontend-edit__sticky-dropdown--visible');
+            closeDropdown();
+          }
+        });
+
+        dropdown.addEventListener('keydown', (e) => {
+          const items = Array.from(dropdown.querySelectorAll('[role="menuitem"]'));
+          const idx = items.indexOf(document.activeElement);
+
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            items[idx < items.length - 1 ? idx + 1 : 0]?.focus();
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            items[idx > 0 ? idx - 1 : items.length - 1]?.focus();
+          } else if (e.key === 'Home') {
+            e.preventDefault();
+            items[0]?.focus();
+          } else if (e.key === 'End') {
+            e.preventDefault();
+            items[items.length - 1]?.focus();
+          } else if (e.key === 'Enter') {
+            e.preventDefault();
+            document.activeElement?.click?.();
+          } else if (e.key === 'Escape') {
+            closeDropdown();
+            menuBtn.focus();
+          }
+        });
+
+        // Roving focus (tabindex="-1" on every item) keeps Tab out of the menu
+        // by design (APG menu-button pattern) - but the menu must then close
+        // itself once focus actually leaves it, or it stays open with no
+        // visible focus inside.
+        dropdown.addEventListener('focusout', (e) => {
+          if (!dropdown.contains(e.relatedTarget)) {
+            closeDropdown();
           }
         });
 

--- a/Tests/Playwright/tests/edit-menu.spec.ts
+++ b/Tests/Playwright/tests/edit-menu.spec.ts
@@ -39,3 +39,24 @@ test('edit menu opens on hover with the default actions', async ({ page }) => {
   await expect(dropdown.locator('.hide')).toBeVisible();
   await expect(dropdown.locator('.delete')).toBeVisible();
 });
+
+test('the edit menu closes automatically once keyboard focus moves outside it', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.openDropdown(CONTENT_ELEMENT_UID);
+
+  const dropdown = hoverMenu.dropdown(CONTENT_ELEMENT_UID);
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.locator('[role="menuitem"]').first()).toBeFocused();
+
+  // Every menu item has tabindex="-1" (roving focus, APG menu-button pattern),
+  // so Tab never lands inside the menu - it must close itself via focusout
+  // once focus actually leaves, or it stays open with no focus indicator
+  // inside it.
+  await page.locator('a[href="/about-us"]').first().focus();
+
+  await expect(dropdown).toBeHidden();
+});

--- a/Tests/Playwright/tests/edit-menu.spec.ts
+++ b/Tests/Playwright/tests/edit-menu.spec.ts
@@ -60,3 +60,25 @@ test('the edit menu closes automatically once keyboard focus moves outside it', 
 
   await expect(dropdown).toBeHidden();
 });
+
+test('clicking the kebab button while a menu item is focused closes the menu', async ({ page }) => {
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await hoverMenu.openDropdown(CONTENT_ELEMENT_UID);
+
+  const dropdown = hoverMenu.dropdown(CONTENT_ELEMENT_UID);
+  const kebab = hoverMenu.kebabButton(CONTENT_ELEMENT_UID);
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.locator('[role="menuitem"]').first()).toBeFocused();
+
+  // Clicking the trigger fires focusout (focus leaves the item) BEFORE click.
+  // If focusout closed the menu, the click handler would see a closed menu and
+  // reopen it — so the trigger must toggle the open menu shut, not flicker it.
+  await kebab.click();
+
+  await expect(dropdown).toBeHidden();
+  await expect(kebab).toHaveAttribute('aria-expanded', 'false');
+});

--- a/Tests/Playwright/tests/sticky-toolbar.spec.ts
+++ b/Tests/Playwright/tests/sticky-toolbar.spec.ts
@@ -86,4 +86,23 @@ test.describe('sticky toolbar', () => {
     await page.locator('a[href="/about-us"]').first().focus();
     await expect(dropdown).not.toHaveClass(/frontend-edit__sticky-dropdown--visible/);
   });
+
+  test('clicking the menu button while an item is focused closes the menu', async ({ page }) => {
+    await page.goto('/');
+
+    const menuBtn = page.locator('.frontend-edit__sticky-btn--menu');
+    const dropdown = page.locator('.frontend-edit__sticky-dropdown');
+    const items = dropdown.locator('[role="menuitem"]');
+
+    await menuBtn.click();
+    await expect(items.first()).toBeFocused();
+
+    // Clicking the trigger fires focusout (focus leaving the item to the button)
+    // BEFORE click. If focusout closed the menu, the click handler would read a
+    // closed menu and reopen it — the trigger must close the open menu instead.
+    await menuBtn.click();
+
+    await expect(dropdown).not.toHaveClass(/frontend-edit__sticky-dropdown--visible/);
+    await expect(menuBtn).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/Tests/Playwright/tests/sticky-toolbar.spec.ts
+++ b/Tests/Playwright/tests/sticky-toolbar.spec.ts
@@ -49,4 +49,41 @@ test.describe('sticky toolbar', () => {
 
     // afterEach re-enables it — no need to duplicate that here.
   });
+
+  test('the page options menu follows the APG menu-button pattern: aria-expanded, arrow-key navigation, Escape and focus-out all work', async ({ page }) => {
+    await page.goto('/');
+
+    const menuBtn = page.locator('.frontend-edit__sticky-btn--menu');
+    const dropdown = page.locator('.frontend-edit__sticky-dropdown');
+    const items = dropdown.locator('[role="menuitem"]');
+
+    await expect(menuBtn).toHaveAttribute('aria-haspopup', 'menu');
+    await expect(menuBtn).toHaveAttribute('aria-expanded', 'false');
+    await expect(dropdown).toHaveAttribute('role', 'menu');
+
+    // Opening focuses the first item - the roving tabindex="-1" on every item
+    // means Tab alone could never reach the menu otherwise.
+    await menuBtn.click();
+    await expect(menuBtn).toHaveAttribute('aria-expanded', 'true');
+    await expect(items.first()).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(items.nth(1)).toBeFocused();
+
+    await page.keyboard.press('ArrowUp');
+    await expect(items.first()).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(dropdown).not.toHaveClass(/frontend-edit__sticky-dropdown--visible/);
+    await expect(menuBtn).toHaveAttribute('aria-expanded', 'false');
+    await expect(menuBtn).toBeFocused();
+
+    // Re-open, then move focus out via keyboard (not a click) - the menu must
+    // close itself once focus actually leaves it, since Tab never lands on
+    // one of its own (tabindex="-1") items.
+    await menuBtn.click();
+    await expect(items.first()).toBeFocused();
+    await page.locator('a[href="/about-us"]').first().focus();
+    await expect(dropdown).not.toHaveClass(/frontend-edit__sticky-dropdown--visible/);
+  });
 });


### PR DESCRIPTION
## Summary

- Audited the content-element edit menu and the sticky toolbar's page-options menu against the APG "menu button" pattern (see the checklist posted on #219).
- Closes both menus when keyboard focus moves outside them (Tab) — previously they stayed open indefinitely, since every item uses roving `tabindex="-1"` so Tab never lands inside.
- Brings the sticky toolbar's page-options menu up to parity with the content-element menu: `role="menu"`/`menuitem`/`separator`/`presentation`, `aria-haspopup`/`aria-expanded`, arrow-key/Home/End/Enter navigation, Escape-closes-and-returns-focus, and focus-moves-to-first-item-on-open. It previously had none of this.
- Darkens the default/light theme's dashed-outline color (`#aaaaaa` → `#767676`) to meet WCAG 1.4.11's 3:1 non-text contrast minimum; the dark theme's outline color already passed and is unchanged.

## Changes

- `Resources/Public/Css/FrontendEdit.css` — outline color contrast fix.
- `Resources/Public/JavaScript/frontend_edit.js` — `focusout` handler closes the content-element dropdown once focus leaves it.
- `Resources/Public/JavaScript/sticky_toolbar.js` — full ARIA/keyboard parity for the page-options menu, plus a `transitionend`-driven focus-on-open (a `requestAnimationFrame` fires before the CSS-transitioned `visibility` change is actually focusable).
- `Tests/Playwright/tests/edit-menu.spec.ts`, `Tests/Playwright/tests/sticky-toolbar.spec.ts` — new coverage for the keyboard/focus behavior on both menus.

## Test plan

- [x] Unit suite (305 tests) and functional suite (69 tests) pass
- [x] PHPStan clean
- [x] New/updated Playwright specs pass on both TYPO3 v13 and v14
- [x] Full Playwright regression suite passes on both v13 and v14
- [x] TypeScript typecheck clean

Closes #219.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved dropdown menus with clearer keyboard navigation, focus handling, and screen-reader support.
  * Menus now close when focus moves outside them and restore focus appropriately.
  * Added ARIA menu semantics and expanded-state announcements.

* **UI Improvements**
  * Increased contrast for editing outlines and column insertion controls.

* **Bug Fixes**
  * Prevented edit menus from remaining open without a focused menu item.

* **Tests**
  * Added coverage for accessibility, keyboard interactions, focus behavior, and automatic closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->