### PR TITLE
feat: align sticky toolbar icons with content element edit buttons

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -577,6 +577,7 @@
     border-radius: 4px;
     color: var(--xfe-toolbar-text);
     cursor: pointer;
+    text-decoration: none;
     transition: background 0.15s ease, transform 0.1s ease;
     padding: 0;
 }

--- a/Resources/Public/JavaScript/sticky_toolbar.js
+++ b/Resources/Public/JavaScript/sticky_toolbar.js
@@ -18,7 +18,9 @@
   const ICONS = {
     edit: '<svg viewBox="0 0 24 24" fill="currentColor"><g transform="matrix(1,0,0,1,-180,-95)"><g transform="matrix(0.24,0,0,0.24,179.52,95.24)"><g transform="matrix(1.428572,0,0,1.428572,-22.285735,-21.000043)"><g transform="matrix(0.731827,0,0,0.731827,14.822171,13.071707)"><path d="M90.656,28.125C90.656,29.946 89.945,31.657 88.656,32.938L39.711,81.883C39.586,82 39.453,82.11 39.312,82.211L39.187,82.297C39.062,82.383 38.922,82.461 38.781,82.524L38.711,82.563C38.57,82.618 38.43,82.665 38.289,82.704L14.851,88.743C14.593,88.813 14.328,88.844 14.07,88.844C13.249,88.844 12.445,88.516 11.851,87.915C11.07,87.126 10.765,85.977 11.054,84.907L17.304,61.68C17.335,61.539 17.382,61.406 17.437,61.281L17.46,61.234C17.531,61.086 17.609,60.945 17.695,60.805L17.781,60.68C17.882,60.539 17.984,60.406 18.109,60.281L67.054,11.344C68.344,10.055 70.054,9.344 71.875,9.344C73.695,9.344 75.406,10.055 76.695,11.344L88.656,23.305C89.945,24.594 90.656,26.305 90.656,28.125ZM84.242,28.532C84.375,28.391 84.414,28.235 84.414,28.125C84.414,28.016 84.39,27.86 84.25,27.719L72.288,15.758C72.148,15.625 71.992,15.594 71.882,15.594C71.773,15.594 71.617,15.617 71.476,15.758L64.578,22.656L77.344,35.422L84.242,28.532ZM22.57,66.141L18.468,81.367L33.851,77.398L33.375,75L28.125,75C26.398,75 25,73.602 25,71.875L25,66.625L22.57,66.141ZM64.328,31.25L60.156,27.078L26.648,60.586L28.734,61C30.195,61.289 31.25,62.571 31.25,64.063L31.25,68.75L35.937,68.75C37.43,68.75 38.711,69.805 39.008,71.266L39.422,73.352L72.922,39.844L68.75,35.672L64.328,31.25Z"/></g><g transform="matrix(0.731827,0,0,0.731827,14.822171,13.071707)" opacity=".4"><path d="M68.75,35.672L39.711,64.711C39.101,65.32 38.297,65.625 37.5,65.625C36.703,65.625 35.899,65.32 35.289,64.711C34.07,63.492 34.07,61.508 35.289,60.289L64.328,31.25L68.75,35.672Z"/></g><g transform="matrix(4.166667,0,0,4.166667,-123,-1)" opacity=".4"><path d="M36,18L37,14L40,17L36,18Z"/></g></g></g></g></svg>',
     editOff: '<svg viewBox="0 0 24 24" fill="currentColor"><g transform="matrix(1,0,0,1,-180,-95)"><g transform="matrix(0.24,0,0,0.24,179.52,95.24)"><g transform="matrix(1.428572,0,0,1.428572,-22.285735,-21.000043)"><g transform="matrix(0.731827,0,0,0.731827,14.822171,13.071707)"><path d="M56.014,65.58L39.711,81.883C39.586,82 39.453,82.11 39.312,82.211L39.187,82.297C39.062,82.383 38.922,82.461 38.781,82.524L38.711,82.563C38.57,82.618 38.43,82.665 38.289,82.704L14.851,88.743C14.593,88.813 14.328,88.844 14.07,88.844C13.249,88.844 12.445,88.516 11.851,87.915C11.07,87.126 10.765,85.977 11.054,84.907L17.304,61.68C17.335,61.539 17.382,61.406 17.437,61.281L17.46,61.234C17.531,61.086 17.609,60.945 17.695,60.805L17.781,60.68C17.882,60.539 17.984,60.406 18.109,60.281L34.414,43.979L38.834,48.4L26.648,60.586L28.734,61C30.195,61.289 31.25,62.571 31.25,64.063L31.25,68.75L35.937,68.75C37.43,68.75 38.711,69.805 39.008,71.266L39.422,73.352L51.603,61.168L56.014,65.58ZM45.687,32.707L67.054,11.344C68.344,10.055 70.054,9.344 71.875,9.344C73.695,9.344 75.406,10.055 76.695,11.344L88.656,23.305C89.945,24.594 90.656,26.305 90.656,28.125C90.656,29.946 89.945,31.657 88.656,32.938L67.287,54.307L62.874,49.894L72.922,39.844L60.156,27.078L50.107,37.127L45.687,32.707ZM22.57,66.141L18.468,81.367L33.851,77.398L33.375,75L28.125,75C26.398,75 25,73.602 25,71.875L25,66.625L22.57,66.141ZM84.242,28.532C84.375,28.391 84.414,28.235 84.414,28.125C84.414,28.016 84.39,27.86 84.25,27.719L72.288,15.758C72.148,15.625 71.992,15.594 71.882,15.594C71.773,15.594 71.617,15.617 71.476,15.758L64.578,22.656L77.344,35.422L84.242,28.532Z"/></g><g transform="matrix(0.731827,0,0,0.731827,14.822171,13.071707)" opacity=".4"><path d="M54.279,41.299L64.328,31.25L68.75,35.672L58.701,45.721L54.279,41.299ZM47.428,56.994L39.711,64.711C39.101,65.32 38.297,65.625 37.5,65.625C36.703,65.625 35.899,65.32 35.289,64.711C34.07,63.492 34.07,61.508 35.289,60.289L43.006,52.572L47.428,56.994Z"/></g><g transform="matrix(4.166667,0,0,4.166667,-123,-1)" opacity=".4"><path d="M36,18L37,14L40,17L36,18Z"/></g><g transform="matrix(2.754669,-0.161996,-0.161996,2.754669,20.888651,17.888668)"><path d="M3.559,4.691C3.208,4.339 3.176,3.801 3.489,3.489C3.801,3.176 4.339,3.208 4.691,3.559L20.445,19.314C20.796,19.665 20.828,20.204 20.516,20.516C20.204,20.828 19.665,20.796 19.314,20.445L3.559,4.691Z"/></g></g></g></g></svg>',
-    kebab: '<svg viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="2.5" r="1.5"/><circle cx="8" cy="8" r="1.5"/><circle cx="8" cy="13.5" r="1.5"/></svg>'
+    kebab: '<svg viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="2.5" r="1.5"/><circle cx="8" cy="8" r="1.5"/><circle cx="8" cy="13.5" r="1.5"/></svg>',
+    // Matches the content element "Edit" button icon (frontend_edit.js ICONS.edit) for visual consistency.
+    pageEdit: '<svg viewBox="0 0 32 32" fill="currentColor"><path d="M4.834,29.665L25.007,29.665C26.561,29.663 27.839,28.385 27.841,26.831L27.841,16.157C27.841,15.608 27.39,15.157 26.841,15.157C26.292,15.157 25.841,15.608 25.841,16.157L25.841,26.831C25.84,27.288 25.464,27.664 25.007,27.665L4.834,27.665C4.377,27.664 4.001,27.288 4,26.831L4,7.651C4.001,7.194 4.377,6.818 4.834,6.817L16,6.817C16.549,6.817 17,6.366 17,5.817C17,5.268 16.549,4.817 16,4.817L4.834,4.817C3.28,4.819 2.002,6.097 2,7.651L2,26.831C2.002,28.385 3.28,29.663 4.834,29.665Z" fill-rule="nonzero"/><path d="M8.582,19.343L7.912,22.691C7.894,22.781 7.885,22.873 7.885,22.965C7.885,23.726 8.51,24.352 9.271,24.352C9.363,24.352 9.454,24.343 9.544,24.325L12.895,23.655C13.539,23.527 14.131,23.211 14.595,22.747L28.845,8.494C29.473,7.825 29.823,6.941 29.823,6.024C29.823,4.044 28.195,2.416 26.215,2.416C25.298,2.416 24.414,2.766 23.745,3.394L9.49,17.645C9.025,18.108 8.709,18.699 8.582,19.343ZM10.543,19.734C10.594,19.478 10.72,19.244 10.904,19.059L25.157,4.806C25.458,4.509 25.864,4.343 26.286,4.343C27.168,4.343 27.894,5.069 27.894,5.951C27.894,6.373 27.728,6.779 27.431,7.08L13.178,21.332C12.993,21.517 12.758,21.643 12.502,21.694L10.054,22.184L10.543,19.734Z" fill-rule="nonzero"/></svg>'
   };
 
   /**
@@ -119,7 +121,8 @@
     tooltips: {
       enable: 'Enable frontend editing mode',
       disable: 'Disable frontend editing mode',
-      pageOptions: 'Page options'
+      pageOptions: 'Page options',
+      editPage: 'Edit page settings'
     },
 
     init() {
@@ -181,15 +184,29 @@
 
     getToolbarHTML() {
       const toggleTooltip = this.isDisabled ? this.tooltips.enable : this.tooltips.disable;
-      const toggleIcon = this.isDisabled ? ICONS.editOff : ICONS.edit;
+      // Icon reflects the action a click will perform (like a mute button), not the current
+      // state: showing the plain pencil while editing is already on made it look like a
+      // generic "Edit" button, indistinguishable from the edit-page button next to it.
+      const toggleIcon = this.isDisabled ? ICONS.edit : ICONS.editOff;
 
       // Only show page menu when not disabled and data exists
       const showPageMenu = !this.isDisabled && this.pageMenuData && this.pageMenuData.children;
+      const editPageItem = showPageMenu ? this.pageMenuData.children.edit_page_properties : null;
 
       let html = `
         <button class="frontend-edit__sticky-btn frontend-edit__sticky-btn--toggle" data-tooltip="${this.escapeAttribute(toggleTooltip)}" type="button">
           ${toggleIcon}
         </button>`;
+
+      // Dedicated "Edit page settings" button, mirroring the content element Edit button
+      if (editPageItem && editPageItem.url && this.isValidUrl(editPageItem.url)) {
+        const targetBlankAttr = this.pageMenuData.targetBlank ? ' target="_blank"' : '';
+        html += `
+        <div class="frontend-edit__sticky-separator"></div>
+        <a class="frontend-edit__sticky-btn frontend-edit__sticky-btn--edit-page" href="${this.escapeAttribute(editPageItem.url)}" data-tooltip="${this.escapeAttribute(editPageItem.label || this.tooltips.editPage)}"${targetBlankAttr}>
+          ${ICONS.pageEdit}
+        </a>`;
+      }
 
       // Add page dropdown only when enabled (dropdown content added via DOM in createToolbar)
       if (showPageMenu) {
@@ -332,6 +349,23 @@
       const toggleBtn = this.container.querySelector('.frontend-edit__sticky-btn--toggle');
       toggleBtn.addEventListener('click', () => this.handleToggle());
       Tooltip.attach(toggleBtn);
+
+      // Edit page settings button (only if exists)
+      const editPageBtn = this.container.querySelector('.frontend-edit__sticky-btn--edit-page');
+      if (editPageBtn) {
+        Tooltip.attach(editPageBtn);
+
+        const editPageItem = this.pageMenuData?.children?.edit_page_properties;
+        if (editPageItem?.contextualUrl && this.isValidUrl(editPageItem.contextualUrl) && window.FRONTEND_EDIT_CONTEXTUAL_EDITING && window.ContextualEdit) {
+          const contextualUrl = editPageItem.contextualUrl;
+          const targetBlank = this.pageMenuData.targetBlank || false;
+          editPageBtn.addEventListener('click', (e) => {
+            if (e.ctrlKey || e.metaKey || e.shiftKey) return;
+            window.ContextualEdit.open(contextualUrl, null, targetBlank);
+            e.preventDefault();
+          });
+        }
+      }
 
       // Dropdown (only if exists)
       const dropdownContainer = this.container.querySelector('.frontend-edit__sticky-dropdown-container');
@@ -484,7 +518,7 @@
 
     updateVisualState() {
       const toggleBtn = this.container.querySelector('.frontend-edit__sticky-btn--toggle');
-      toggleBtn.innerHTML = this.isDisabled ? ICONS.editOff : ICONS.edit;
+      toggleBtn.innerHTML = this.isDisabled ? ICONS.edit : ICONS.editOff;
       toggleBtn.dataset.tooltip = this.isDisabled ? this.tooltips.enable : this.tooltips.disable;
       this.container.classList.toggle('frontend-edit__sticky-toolbar--disabled', this.isDisabled);
     }


### PR DESCRIPTION
## Summary

- Fixed the sticky page toolbar's toggle icon to reflect the click action instead of the current state, so it no longer looks like a generic edit button while frontend editing is active
- Added a dedicated "Edit page settings" button between the toggle and the options dropdown, using the same pencil icon as the content element edit button, for visual consistency across both toolbars

## Changes

- \`Resources/Public/JavaScript/sticky_toolbar.js\` - swap toggle icon per state, add page-edit button (incl. contextual-edit support) sourced from existing page menu data
- \`Resources/Public/Css/FrontendEdit.css\` - add \`text-decoration: none\` since the toolbar button class is now also used on an anchor element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated page settings link to the sticky toolbar when available.
  - Added page-edit and menu icons that clearly indicate available toolbar actions.
  - Added an “Edit page settings” tooltip with translated text.
  - Supports opening page settings in a new tab and contextual editing where applicable.

- **Style**
  - Standardized sticky toolbar button text styling for a consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->