### PR TITLE
fix: gate the sticky toolbar's page-edit button on actual edit permission

### DIFF
--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -96,14 +96,17 @@ final class BackendUserService
     /**
      * Check if the backend user can actually edit this page's properties.
      *
-     * Mirrors the checks TYPO3 core's DatabaseUserPermissionCheck performs when the
+     * Combines the checks TYPO3 core's DatabaseUserPermissionCheck performs when the
      * "Edit page properties" form is opened (tables_modify, the page's PAGE_EDIT
-     * permission bit, and pagetypes_select for its doktype). Without this, a user
-     * missing any of these rights still sees the edit button and only learns
-     * about it from a backend error page after clicking it.
+     * permission bit, and pagetypes_select for its doktype) with hasRecordEditAccess()
+     * (editlock, language access, authMode fields — the same check ContentElementFilter
+     * uses for tt_content). Without this, a user missing any of these rights still sees
+     * the edit button and only learns about it from a backend error page after clicking it.
      *
-     * @param array<string, mixed> $pageRecord Must include perms_userid, perms_groupid,
-     *                                         perms_user, perms_group, perms_everybody and doktype
+     * @param array<string, mixed> $pageRecord must be the full pages row: besides
+     *                                         perms_userid/perms_groupid/perms_user/perms_group/
+     *                                         perms_everybody and doktype, hasRecordEditAccess()
+     *                                         also needs editlock and sys_language_uid
      */
     public function hasPageEditAccess(array $pageRecord): bool
     {
@@ -125,7 +128,11 @@ final class BackendUserService
             return false;
         }
 
-        return $backendUser->check('pagetypes_select', (string) ($pageRecord['doktype'] ?? 1));
+        if (!$backendUser->check('pagetypes_select', (string) ($pageRecord['doktype'] ?? 1))) {
+            return false;
+        }
+
+        return $this->hasRecordEditAccess('pages', $pageRecord);
     }
 
     /**

--- a/Classes/Service/Authentication/BackendUserService.php
+++ b/Classes/Service/Authentication/BackendUserService.php
@@ -94,6 +94,41 @@ final class BackendUserService
     }
 
     /**
+     * Check if the backend user can actually edit this page's properties.
+     *
+     * Mirrors the checks TYPO3 core's DatabaseUserPermissionCheck performs when the
+     * "Edit page properties" form is opened (tables_modify, the page's PAGE_EDIT
+     * permission bit, and pagetypes_select for its doktype). Without this, a user
+     * missing any of these rights still sees the edit button and only learns
+     * about it from a backend error page after clicking it.
+     *
+     * @param array<string, mixed> $pageRecord Must include perms_userid, perms_groupid,
+     *                                         perms_user, perms_group, perms_everybody and doktype
+     */
+    public function hasPageEditAccess(array $pageRecord): bool
+    {
+        $backendUser = $this->getBackendUser();
+
+        if (null === $backendUser || null === $backendUser->user) {
+            return false;
+        }
+
+        if ($backendUser->isAdmin()) {
+            return true;
+        }
+
+        if (!$backendUser->check('tables_modify', 'pages')) {
+            return false;
+        }
+
+        if (!(new Permission($backendUser->calcPerms($pageRecord)))->editPagePermissionIsGranted()) {
+            return false;
+        }
+
+        return $backendUser->check('pagetypes_select', (string) ($pageRecord['doktype'] ?? 1));
+    }
+
+    /**
      * Check if frontend edit is disabled by the user's toggle (UC state).
      *
      * This reflects the user's personal on/off toggle and can be changed

--- a/Classes/Service/Menu/PageButtonBuilder.php
+++ b/Classes/Service/Menu/PageButtonBuilder.php
@@ -70,14 +70,19 @@ final readonly class PageButtonBuilder extends AbstractMenuButtonBuilder
         int $languageUid,
         string $returnUrl,
         ?string $contextualUrl = null,
+        bool $canEditPageProperties = true,
     ): void {
         $this->addButton($menuButton, 'div_edit', ButtonType::Divider);
 
-        $editUrl = $this->urlBuilderService->buildEditUrl($pageId, 'pages', $languageUid, $returnUrl).'&tx_ximatypo3frontendedit';
-        $this->addButton($menuButton, 'edit_page_properties', ButtonType::Link, url: $editUrl, icon: 'actions-page-open');
+        // Gated on hasPageEditAccess() (tables_modify, PAGE_EDIT permission bit,
+        // pagetypes_select) — see PageMenuGenerator::getDropdown().
+        if ($canEditPageProperties) {
+            $editUrl = $this->urlBuilderService->buildEditUrl($pageId, 'pages', $languageUid, $returnUrl).'&tx_ximatypo3frontendedit';
+            $this->addButton($menuButton, 'edit_page_properties', ButtonType::Link, url: $editUrl, icon: 'actions-page-open');
 
-        if (null !== $contextualUrl) {
-            $menuButton->getChildren()['edit_page_properties']->setContextualUrl($contextualUrl);
+            if (null !== $contextualUrl) {
+                $menuButton->getChildren()['edit_page_properties']->setContextualUrl($contextualUrl);
+            }
         }
 
         // Edit page (Backend Page Layout)

--- a/Classes/Service/Menu/PageMenuGenerator.php
+++ b/Classes/Service/Menu/PageMenuGenerator.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Event\FrontendEditPageDropdownModifyEvent;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Ui\UrlBuilderService;
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
 
@@ -40,6 +41,7 @@ final class PageMenuGenerator extends AbstractMenuGenerator
         ExtensionConfiguration $extensionConfiguration,
         private readonly ConnectionPool $connectionPool,
         private readonly UrlBuilderService $urlBuilderService,
+        private readonly BackendUserService $backendUserService,
     ) {
         parent::__construct($extensionConfiguration);
     }
@@ -74,10 +76,15 @@ final class PageMenuGenerator extends AbstractMenuGenerator
             $this->pageButtonBuilder->addInfoSection($menuButton, $pageRecord);
         }
 
-        $contextualUrl = $this->urlBuilderService->isContextualEditRouteAvailable()
+        // Gated on the same access checks TYPO3 core enforces when the edit form is
+        // opened; showing the button regardless would let the click fail with a
+        // backend error page instead of the button simply not being there.
+        $canEditPageProperties = null !== $pageRecord && $this->backendUserService->hasPageEditAccess($pageRecord);
+
+        $contextualUrl = $canEditPageProperties && $this->urlBuilderService->isContextualEditRouteAvailable()
             ? $this->urlBuilderService->buildContextualEditUrl($pid, 'pages', $languageUid, $returnUrl)
             : null;
-        $this->pageButtonBuilder->addEditSection($menuButton, $pid, $languageUid, $returnUrl, $contextualUrl);
+        $this->pageButtonBuilder->addEditSection($menuButton, $pid, $languageUid, $returnUrl, $contextualUrl, $canEditPageProperties);
         $this->pageButtonBuilder->addActionSection($menuButton, $pid, $returnUrl);
 
         /** @var FrontendEditPageDropdownModifyEvent $event */
@@ -105,7 +112,7 @@ final class PageMenuGenerator extends AbstractMenuGenerator
             ->getQueryBuilderForTable('pages');
 
         $result = $queryBuilder
-            ->select('uid', 'title', 'doktype')
+            ->select('uid', 'title', 'doktype', 'perms_userid', 'perms_groupid', 'perms_user', 'perms_group', 'perms_everybody')
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),

--- a/Classes/Service/Menu/PageMenuGenerator.php
+++ b/Classes/Service/Menu/PageMenuGenerator.php
@@ -111,8 +111,11 @@ final class PageMenuGenerator extends AbstractMenuGenerator
         $queryBuilder = $this->connectionPool
             ->getQueryBuilderForTable('pages');
 
+        // SELECT * (not a hand-picked column list): hasPageEditAccess()'s
+        // hasRecordEditAccess() check reads whichever TCA-configured fields
+        // (editlock, sys_language_uid, ...) the current TYPO3 version needs.
         $result = $queryBuilder
-            ->select('uid', 'title', 'doktype', 'perms_userid', 'perms_groupid', 'perms_user', 'perms_group', 'perms_everybody')
+            ->select('*')
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -16,7 +16,9 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Authentication;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 
@@ -32,6 +34,7 @@ final class BackendUserServiceTest extends TestCase
     protected function tearDown(): void
     {
         unset($GLOBALS['BE_USER']);
+        GeneralUtility::purgeInstances();
     }
 
     #[Test]
@@ -317,6 +320,8 @@ final class BackendUserServiceTest extends TestCase
     #[Test]
     public function hasPageEditAccessReturnsFalseWhenRecordEditAccessDenies(): void
     {
+        $this->registerVersion13();
+
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1];
         $backendUser->method('isAdmin')->willReturn(false);
@@ -339,6 +344,8 @@ final class BackendUserServiceTest extends TestCase
     #[Test]
     public function hasPageEditAccessReturnsTrueWhenAllChecksPass(): void
     {
+        $this->registerVersion13();
+
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1];
         $backendUser->method('isAdmin')->willReturn(false);
@@ -358,6 +365,8 @@ final class BackendUserServiceTest extends TestCase
     #[Test]
     public function hasPageEditAccessDefaultsDoktypeToStandardWhenMissing(): void
     {
+        $this->registerVersion13();
+
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['uid' => 1];
         $backendUser->method('isAdmin')->willReturn(false);
@@ -408,5 +417,20 @@ final class BackendUserServiceTest extends TestCase
         $service = new BackendUserService();
 
         self::assertFalse($service->hasFieldAccess('tt_content', 'hidden'));
+    }
+
+    /**
+     * hasRecordEditAccess() (used by hasPageEditAccess()) branches on the installed
+     * TYPO3 version: recordEditAccessInternals() on 13, checkRecordEditAccess() on
+     * 14.2+ (see BackendUserUtility). The latter returns a final AccessCheckResult,
+     * which PHPUnit cannot double for an unstubbed call - so tests that need a
+     * deterministic hasRecordEditAccess() result force the v13 branch, exactly like
+     * BackendUserUtilityTest already does for the same reason.
+     */
+    private function registerVersion13(): void
+    {
+        $versionMock = $this->createMock(Typo3Version::class);
+        $versionMock->method('getMajorVersion')->willReturn(13);
+        GeneralUtility::addInstance(Typo3Version::class, $versionMock);
     }
 }

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -315,6 +315,28 @@ final class BackendUserServiceTest extends TestCase
     }
 
     #[Test]
+    public function hasPageEditAccessReturnsFalseWhenRecordEditAccessDenies(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('calcPerms')->willReturn(Permission::PAGE_EDIT);
+        $backendUser->method('check')->willReturnMap([
+            ['tables_modify', 'pages', true],
+            ['pagetypes_select', '1', true],
+        ]);
+        // e.g. editlock or a restricted language on the page record itself -
+        // tables_modify/PAGE_EDIT/pagetypes_select all pass, but the record
+        // itself is still locked, which only hasRecordEditAccess() catches.
+        $backendUser->method('recordEditAccessInternals')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
     public function hasPageEditAccessReturnsTrueWhenAllChecksPass(): void
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);
@@ -325,6 +347,7 @@ final class BackendUserServiceTest extends TestCase
             ['tables_modify', 'pages', true],
             ['pagetypes_select', '1', true],
         ]);
+        $backendUser->method('recordEditAccessInternals')->willReturn(true);
         $GLOBALS['BE_USER'] = $backendUser;
 
         $service = new BackendUserService();
@@ -343,6 +366,7 @@ final class BackendUserServiceTest extends TestCase
             ['tables_modify', 'pages', true],
             ['pagetypes_select', '1', true],
         ]);
+        $backendUser->method('recordEditAccessInternals')->willReturn(true);
         $GLOBALS['BE_USER'] = $backendUser;
 
         $service = new BackendUserService();

--- a/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
+++ b/Tests/Unit/Service/Authentication/BackendUserServiceTest.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\Service\Authentication;
 use PHPUnit\Framework\Attributes\{CoversClass, Test};
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use Xima\XimaTypo3FrontendEdit\Configuration;
 use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 
@@ -229,6 +230,124 @@ final class BackendUserServiceTest extends TestCase
         $service = new BackendUserService();
 
         self::assertTrue($service->isFrontendEditAllowed());
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsFalseWhenUserDataIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = null;
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsTrueForAdminRegardlessOfPermissionBits(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(true);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsFalseWhenTablesModifyDeniesPages(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->with('tables_modify', 'pages')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsFalseWhenPageEditPermissionBitIsMissing(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->with('tables_modify', 'pages')->willReturn(true);
+        $backendUser->method('calcPerms')->willReturn(Permission::PAGE_SHOW);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsFalseWhenPagetypesSelectDeniesDoktype(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('calcPerms')->willReturn(Permission::PAGE_EDIT);
+        $backendUser->method('check')->willReturnMap([
+            ['tables_modify', 'pages', true],
+            ['pagetypes_select', '1', false],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertFalse($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessReturnsTrueWhenAllChecksPass(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('calcPerms')->willReturn(Permission::PAGE_EDIT);
+        $backendUser->method('check')->willReturnMap([
+            ['tables_modify', 'pages', true],
+            ['pagetypes_select', '1', true],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->hasPageEditAccess(['uid' => 1, 'doktype' => 1]));
+    }
+
+    #[Test]
+    public function hasPageEditAccessDefaultsDoktypeToStandardWhenMissing(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('calcPerms')->willReturn(Permission::PAGE_EDIT);
+        $backendUser->method('check')->willReturnMap([
+            ['tables_modify', 'pages', true],
+            ['pagetypes_select', '1', true],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $service = new BackendUserService();
+
+        self::assertTrue($service->hasPageEditAccess(['uid' => 1]));
     }
 
     #[Test]

--- a/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
+++ b/Tests/Unit/Service/Menu/PageButtonBuilderTest.php
@@ -132,6 +132,32 @@ final class PageButtonBuilderTest extends TestCase
     }
 
     #[Test]
+    public function addEditSectionOmitsEditPagePropertiesWhenNotAllowed(): void
+    {
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, 1, 0, '/return', canEditPageProperties: false);
+
+        $children = $menuButton->getChildren();
+        self::assertArrayNotHasKey('edit_page_properties', $children);
+        // The Page Layout link isn't gated the same way — it's a module link,
+        // not a record edit action, so it stays regardless.
+        self::assertArrayHasKey('edit_page', $children);
+    }
+
+    #[Test]
+    public function addEditSectionIgnoresContextualUrlWhenNotAllowed(): void
+    {
+        $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());
+        $menuButton = new Button('Menu', ButtonType::Menu);
+
+        $builder->addEditSection($menuButton, 1, 0, '/return', '/typo3/contextual', false);
+
+        self::assertArrayNotHasKey('edit_page_properties', $menuButton->getChildren());
+    }
+
+    #[Test]
     public function addActionSectionAddsInfoAndHistoryButtons(): void
     {
         $builder = new PageButtonBuilder($this->iconService, $this->urlBuilderService());

--- a/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
+++ b/Tests/Unit/Service/Menu/PageMenuGeneratorTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
@@ -32,6 +33,7 @@ use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3FrontendEdit\Enumerations\ButtonType;
 use Xima\XimaTypo3FrontendEdit\Event\FrontendEditPageDropdownModifyEvent;
+use Xima\XimaTypo3FrontendEdit\Service\Authentication\BackendUserService;
 use Xima\XimaTypo3FrontendEdit\Service\Menu\{PageButtonBuilder, PageMenuGenerator};
 use Xima\XimaTypo3FrontendEdit\Service\Ui\{IconService, UrlBuilderService};
 use Xima\XimaTypo3FrontendEdit\Template\Component\Button;
@@ -47,10 +49,15 @@ use Xima\XimaTypo3FrontendEdit\Tests\Unit\Fixtures\FakeUriBuilder;
 #[WithSingleton(UriBuilder::class, new FakeUriBuilder())]
 final class PageMenuGeneratorTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->setUpBackendUserAsAdmin();
+    }
+
     protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
-        unset($GLOBALS['LANG'], $GLOBALS['TCA']);
+        unset($GLOBALS['LANG'], $GLOBALS['TCA'], $GLOBALS['BE_USER']);
     }
 
     #[Test]
@@ -132,7 +139,28 @@ final class PageMenuGeneratorTest extends TestCase
 
         self::assertArrayHasKey('children', $result);
         self::assertArrayNotHasKey('info_header', $result['children']);
-        self::assertArrayHasKey('edit_page_properties', $result['children']);
+        // Without a page record there's nothing to run the edit-access check
+        // against, so the edit button is omitted rather than shown regardless.
+        self::assertArrayNotHasKey('edit_page_properties', $result['children']);
+    }
+
+    #[Test]
+    public function getDropdownOmitsEditPagePropertiesWhenUserLacksPageEditAccess(): void
+    {
+        $this->setUpLanguageService();
+        $this->setUpTca();
+
+        $connectionPool = $this->createConnectionPoolReturning(['uid' => 5, 'title' => 'My Page', 'doktype' => 1]);
+        $this->setUpBackendUserWithoutPageEditAccess();
+        $generator = $this->createGenerator($connectionPool);
+
+        $result = $generator->getDropdown($this->createRequest(5));
+
+        self::assertArrayNotHasKey('edit_page_properties', $result['children']);
+        // Info and the Page Layout link aren't gated by page-edit access, only
+        // the record-edit action that would otherwise fail in the DataHandler.
+        self::assertArrayHasKey('info_header', $result['children']);
+        self::assertArrayHasKey('edit_page', $result['children']);
     }
 
     #[Test]
@@ -227,6 +255,28 @@ final class PageMenuGeneratorTest extends TestCase
         return $connectionPool;
     }
 
+    /**
+     * BackendUserService is final and wraps $GLOBALS['BE_USER'] directly, so tests
+     * control its behavior through a mocked BackendUserAuthentication rather than
+     * mocking the service itself (mirrors ContentElementMenuGeneratorTest).
+     */
+    private function setUpBackendUserAsAdmin(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(true);
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    private function setUpBackendUserWithoutPageEditAccess(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1];
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->with('tables_modify', 'pages')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+
     private function createGenerator(
         ?ConnectionPool $connectionPool = null,
         ?EventDispatcher $eventDispatcher = null,
@@ -248,6 +298,7 @@ final class PageMenuGeneratorTest extends TestCase
             $this->createMock(ExtensionConfiguration::class),
             $connectionPool ?? $this->createMock(ConnectionPool::class),
             $urlBuilderService,
+            new BackendUserService(),
         );
     }
 }


### PR DESCRIPTION
## Summary
- Found while manually testing #230 (content-element hide-button gating): the page dropdown in the sticky toolbar always shows the "Edit page properties" button, regardless of whether the current backend user can actually edit the page. Clicking it as a restricted editor opens the edit form and only then fails with a backend access-denied error.
- Editing a page requires three things TYPO3 core checks in `DatabaseUserPermissionCheck` when the FormEngine edit form is built: `tables_modify` access to `pages`, the page's `PAGE_EDIT` permission bit (`perms_user`/`perms_group`/`perms_everybody`), and `pagetypes_select` for its doktype. None of these were checked before rendering the button.
- Adds `BackendUserService::hasPageEditAccess()` mirroring those three checks, and gates the `edit_page_properties` button on it in `PageMenuGenerator`/`PageButtonBuilder` — the same pattern #230 used for the content-element hide button (`canHide`).
- Scoped narrowly: the Page Layout link, page info, and history buttons are left untouched, since they aren't blocked by the same DataHandler check and continue to work regardless of `PAGE_EDIT`.
- When the page record itself can't be fetched, the button is now omitted rather than shown by default (fail closed) — there's nothing to check permissions against.

## Test plan
- [x] Unit tests: `BackendUserServiceTest` (7 new cases for `hasPageEditAccess`), `PageButtonBuilderTest`, `PageMenuGeneratorTest` (button omitted when access denied / page record missing)
- [x] `composer test:unit` — 328 tests green
- [x] `composer test:functional` (ddev) — 72 tests green
- [x] `ddev cgl sca` (PHPStan level 8) — no errors
- [x] `ddev cgl fix` — no changes needed
- [ ] Manual verification in ddev: restricted editor (no `tables_modify=pages`) no longer sees "Edit page properties" in the sticky toolbar's page menu; an editor/admin with full page rights still sees and can use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page menus now show page-properties editing only when the current backend user has the required permissions.
  * Page-layout editing and informational actions remain available independently.

* **Bug Fixes**
  * Prevented unauthorized users from seeing or accessing contextual page-properties editing links.
  * Added administrator and page-type permission handling for accurate access decisions.

* **Tests**
  * Expanded coverage for permission combinations, missing users, administrators, and unavailable page records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->