### PR TITLE
fix: give the contextual editing sidebar the same header bar as the iframe modal

### DIFF
--- a/Resources/Public/Css/FrontendEdit.css
+++ b/Resources/Public/Css/FrontendEdit.css
@@ -1240,26 +1240,13 @@
     opacity: 1;
 }
 
-.frontend-edit__sidebar-close {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    z-index: 10006;
-    width: 32px;
-    height: 32px;
+.frontend-edit__sidebar-header {
     display: flex;
     align-items: center;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.1);
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    color: inherit;
-    padding: 0;
-}
-
-.frontend-edit__sidebar-close:hover {
-    background: rgba(0, 0, 0, 0.2);
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 8px 12px;
+    background: #21232b;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1362,7 +1349,8 @@
     background: #21232b;
 }
 
-.frontend-edit__modal-title {
+.frontend-edit__modal-title,
+.frontend-edit__sidebar-title {
     flex: 1;
     text-align: center;
     color: #fff;
@@ -1371,7 +1359,8 @@
 }
 
 .frontend-edit__modal-close,
-.frontend-edit__modal-expand {
+.frontend-edit__modal-expand,
+.frontend-edit__sidebar-close {
     width: 28px;
     height: 28px;
     background: transparent;
@@ -1383,6 +1372,7 @@
     align-items: center;
     justify-content: center;
     border-radius: 4px;
+    padding: 0;
     transition: background-color 0.2s ease;
 }
 
@@ -1396,12 +1386,14 @@
 }
 
 .frontend-edit__modal-close:hover,
-.frontend-edit__modal-expand:hover {
+.frontend-edit__modal-expand:hover,
+.frontend-edit__sidebar-close:hover {
     background: rgba(255, 255, 255, 0.1);
 }
 
 .frontend-edit__modal-close:focus-visible,
-.frontend-edit__modal-expand:focus-visible {
+.frontend-edit__modal-expand:focus-visible,
+.frontend-edit__sidebar-close:focus-visible {
     outline: 2px solid #fff;
     outline-offset: 2px;
     background: rgba(255, 255, 255, 0.1);

--- a/Resources/Public/JavaScript/contextual_edit.js
+++ b/Resources/Public/JavaScript/contextual_edit.js
@@ -109,14 +109,26 @@
       this.sidebar.setAttribute('aria-modal', 'true');
       this.sidebar.setAttribute('aria-label', 'Edit content');
 
-      // Close button
+      // Header bar - mirrors the iframe modal's header (see iframe_edit.js
+      // Modal.getOrCreate()) so both containers present the same chrome;
+      // without this, editing (sidebar) looked bare next to new content
+      // (modal), which always shows its header bar.
+      this.header = document.createElement('div');
+      this.header.className = 'frontend-edit__sidebar-header';
+
+      this.titleEl = document.createElement('span');
+      this.titleEl.className = 'frontend-edit__sidebar-title';
+      this.header.appendChild(this.titleEl);
+
       this.closeButton = document.createElement('button');
       this.closeButton.type = 'button';
       this.closeButton.className = 'frontend-edit__sidebar-close';
       this.closeButton.setAttribute('aria-label', 'Close editor');
       this.closeButton.innerHTML = CLOSE_ICON;
       this.closeButton.addEventListener('click', this.requestClose.bind(this));
-      this.sidebar.appendChild(this.closeButton);
+      this.header.appendChild(this.closeButton);
+
+      this.sidebar.appendChild(this.header);
 
       // Loading spinner
       this.loader = document.createElement('div');
@@ -244,6 +256,8 @@
 
       this.sidebar.setAttribute('aria-label', opts.title || 'Edit content');
       this.iframe.setAttribute('title', opts.title || 'Edit content');
+      this.titleEl.textContent = opts.title || '';
+      this.titleEl.style.display = opts.title ? '' : 'none';
       this.sidebar.style.width = sanitizeWidth(opts.width);
 
       this.closeButton.style.display = '';
@@ -383,9 +397,6 @@
             e.stopImmediatePropagation();
             self.requestClose();
           });
-
-          // Hide extension's own close button to avoid overlap
-          self.closeButton.style.display = 'none';
         } else {
           actionsBar.appendChild(saveCloseBtn);
         }


### PR DESCRIPTION
## Summary

- The v14.2+ contextual editing sidebar (used for editing existing content elements) had no header bar, only a floating close button, while the iframe modal (used for new content and on v13) always shows a dark header bar with expand/close controls — this made the two editing surfaces look inconsistent side by side.
- Added the same header bar to the sidebar (title + close button), reusing the modal's existing CSS via shared selectors instead of duplicating the styles.
- Removed the now-unneeded logic that hid the sidebar's own close button when the native form already had one — it was only needed because the button used to float directly over the iframe content; it now lives in its own header bar and no longer overlaps anything.

## Changes

- `Resources/Public/JavaScript/contextual_edit.js` - Add a header bar (title + close button) to the contextual editing sidebar; wire the title to the existing `openBackendView({ title })` option; drop the obsolete close-button-hiding workaround.
- `Resources/Public/Css/FrontendEdit.css` - Add `.frontend-edit__sidebar-header` and extend the existing modal title/close/expand selectors to cover the sidebar's equivalents, avoiding duplicated styles.

## Test plan

- [x] Verified via Playwright (v14) that the edit sidebar now shows the header bar, and the new-content modal continues to show its own
- [x] `edit-action`, `backend-view`, `iframe-modal-expand` Playwright suites pass on both v13 and v14