### PR TITLE
feat: add marker-based content element detection as a fallback identification channel

### DIFF
--- a/.ddev/.setup/templates/config/sites/main/settings.yaml
+++ b/.ddev/.setup/templates/config/sites/main/settings.yaml
@@ -1,2 +1,3 @@
 frontendEdit.enableContextualEditing: true
 frontendEdit.enableDragAndDrop: true
+frontendEdit.markerBasedDetection: true

--- a/Classes/EventListener/ContentElementMarkerEventListener.php
+++ b/Classes/EventListener/ContentElementMarkerEventListener.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsExecutedEvent;
+
+use function sprintf;
+
+/**
+ * ContentElementMarkerEventListener.
+ *
+ * Wraps every rendered tt_content record in a pair of HTML comment markers, so the
+ * frontend can identify content elements without relying on the id="c{uid}" anchor.
+ *
+ * Activation happens purely through TypoScript: the sentinel key is set inside a
+ * condition (see Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript). This
+ * listener must never check the backend user itself -- TypoScript condition verdicts
+ * are part of the page cache identifier, PHP behaviour is not, so a check here would
+ * serve marker-laden output to anonymous visitors from the shared page cache.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[AsEventListener(identifier: 'xima-typo3-frontend-edit/frontend/content-element-marker')]
+final readonly class ContentElementMarkerEventListener
+{
+    /**
+     * stdWrap key signalling that markers are wanted. Unknown to the Core, therefore
+     * never executed as a stdWrap function -- it only carries the opt-in verdict.
+     *
+     * A dedicated key is required rather than writing markers via stdWrap.dataWrap:
+     * wrap-type properties are single scalars, so a site package setting the same key
+     * replaces ours without warning. bk2k/bootstrap-package does this through
+     * lib.dynamicContent's renderObj.stdWrap.dataWrap. A separate key survives the
+     * array_replace_recursive() inside ContentObjectRenderer::mergeTSRef().
+     */
+    private const SENTINEL_KEY = 'xfeMarkers';
+
+    private const TABLE = 'tt_content';
+
+    public function __invoke(AfterStdWrapFunctionsExecutedEvent $event): void
+    {
+        if (!($event->getConfiguration()[self::SENTINEL_KEY] ?? false)) {
+            return;
+        }
+
+        $content = $event->getContent();
+        if (null === $content || '' === $content) {
+            return;
+        }
+
+        $uid = (int) ($event->getContentObjectRenderer()->data['uid'] ?? 0);
+        if ($uid <= 0) {
+            return;
+        }
+
+        // Casting to int keeps the payload numeric, so it can never contain "--" or
+        // break the surrounding HTML comment.
+        $event->setContent(sprintf(
+            '<!--xfe:b:%1$s:%2$d-->%3$s<!--xfe:e:%1$s:%2$d-->',
+            self::TABLE,
+            $uid,
+            $content,
+        ));
+    }
+}

--- a/Configuration/Sets/XimaTypo3FrontendEdit/settings.definitions.yaml
+++ b/Configuration/Sets/XimaTypo3FrontendEdit/settings.definitions.yaml
@@ -18,6 +18,13 @@ settings:
     description: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.description.frontendEdit.enabled
     category: frontendEdit
 
+  frontendEdit.markerBasedDetection:
+    default: false
+    type: bool
+    label: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.frontendEdit.markerBasedDetection
+    description: LLL:EXT:xima_typo3_frontend_edit/Resources/Private/Language/locallang_sitesettings.xlf:settings.description.frontendEdit.markerBasedDetection
+    category: frontendEdit
+
   frontendEdit.colorScheme:
     default: 'auto'
     type: string

--- a/Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript
+++ b/Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript
@@ -1,0 +1,26 @@
+#
+# Marker-based content element detection (opt-in).
+#
+# Sets a sentinel key on the shared tt_content stdWrap configuration. The key is
+# unknown to the Core and therefore never executed as a stdWrap function -- it
+# only signals ContentElementMarkerEventListener to wrap the rendered element in
+# comment markers.
+#
+# Why a sentinel key instead of writing the markers here directly: wrap-type
+# stdWrap properties are single scalars, so any site package setting the same key
+# silently replaces ours. bk2k/bootstrap-package does exactly that via
+# lib.dynamicContent's renderObj.stdWrap.dataWrap. A separate key survives the
+# array_replace_recursive() in ContentObjectRenderer::mergeTSRef().
+#
+# Cache safety rests entirely on this condition: TypoScript condition verdicts are
+# part of the page cache identifier, so backend users and anonymous visitors get
+# separate cache entries natively. The listener itself must never check the backend
+# user, because PHP behaviour does not vary the cache identifier.
+#
+# The constant is quoted on purpose. A site setting of type bool with value false
+# flattens to an *empty* TypoScript constant, which would turn an unquoted
+# comparison into `[ == 1]`.
+#
+[backend.user.isLoggedIn && '{$frontendEdit.markerBasedDetection}' == '1']
+    tt_content.stdWrap.xfeMarkers = 1
+[END]

--- a/Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript
+++ b/Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript
@@ -21,6 +21,6 @@
 # flattens to an *empty* TypoScript constant, which would turn an unquoted
 # comparison into `[ == 1]`.
 #
-[backend.user.isLoggedIn && '{$frontendEdit.markerBasedDetection}' == '1']
+[backend.user.isLoggedIn && '{$frontendEdit.enabled}' == '1' && '{$frontendEdit.markerBasedDetection}' == '1']
     tt_content.stdWrap.xfeMarkers = 1
 [END]

--- a/Resources/Private/Language/de.locallang_sitesettings.xlf
+++ b/Resources/Private/Language/de.locallang_sitesettings.xlf
@@ -171,6 +171,15 @@
 				<target>Öffnet Formulare für Inhaltselemente und Seiteneigenschaften in einem Panel neben der Seite, anstatt zum Backend zu navigieren. Aktiviert außerdem den Assistenten für neue Inhaltselemente im Frontend. Die Darstellung wird automatisch gewählt: eine Sidebar ab TYPO3 v14.2, ein Slide-in-Modal in früheren Versionen. Diese Funktion ist experimentell und kann sich in zukünftigen Versionen ändern.</target>
 			</trans-unit>
 
+			<trans-unit id="settings.frontendEdit.markerBasedDetection">
+				<source>[Experimental] Enable marker-based element detection</source>
+				<target>[Experimentell] Marker-basierte Elementerkennung aktivieren</target>
+			</trans-unit>
+			<trans-unit id="settings.description.frontendEdit.markerBasedDetection">
+				<source>Wraps every rendered content element in invisible HTML comment markers, so elements become editable even when their template emits no id="c{uid}" anchor and no data-frontend-edit attribute. Markers are only rendered for logged-in backend users and are cached separately from anonymous output. HTML minifiers that strip comments disable this channel; the existing anchor and data-attribute detection then applies unchanged. Experimental.</source>
+				<target>Umschließt jedes gerenderte Inhaltselement mit unsichtbaren HTML-Kommentar-Markern. Dadurch werden Elemente auch dann bearbeitbar, wenn ihr Template keinen id="c{uid}"-Anker und kein data-frontend-edit-Attribut ausgibt. Marker werden ausschließlich für angemeldete Backend-Benutzer gerendert und getrennt von der anonymen Ausgabe zwischengespeichert. HTML-Minifier, die Kommentare entfernen, deaktivieren diesen Kanal; die bestehende Anker- und Datenattribut-Erkennung greift dann unverändert. Experimentell.</target>
+			</trans-unit>
+
 			<trans-unit id="settings.frontendEdit.enableDragAndDrop">
 				<source>[Experimental] Enable drag &amp; drop reordering</source>
 				<target>[Experimentell] Umsortieren per Drag &amp; Drop aktivieren</target>

--- a/Resources/Private/Language/locallang_sitesettings.xlf
+++ b/Resources/Private/Language/locallang_sitesettings.xlf
@@ -105,6 +105,13 @@
                 <source>Opens content element and page property edit forms in a panel next to the page instead of navigating to the backend. Also enables the New Content Element Wizard in the frontend. The presentation is chosen automatically: a sidebar on TYPO3 v14.2+, a slide-in modal on earlier versions. This feature is experimental and may change in future versions.</source>
             </trans-unit>
 
+            <trans-unit id="settings.frontendEdit.markerBasedDetection">
+                <source>[Experimental] Enable marker-based element detection</source>
+            </trans-unit>
+            <trans-unit id="settings.description.frontendEdit.markerBasedDetection">
+                <source>Wraps every rendered content element in invisible HTML comment markers, so elements become editable even when their template emits no id="c{uid}" anchor and no data-frontend-edit attribute. Markers are only rendered for logged-in backend users and are cached separately from anonymous output. HTML minifiers that strip comments disable this channel; the existing anchor and data-attribute detection then applies unchanged. Experimental.</source>
+            </trans-unit>
+
             <trans-unit id="settings.frontendEdit.enableDragAndDrop">
                 <source>[Experimental] Enable drag &amp; drop reordering</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/frontend_edit.js
+++ b/Resources/Public/JavaScript/frontend_edit.js
@@ -561,6 +561,159 @@
   };
 
   /**
+   * Marker Index - reads the paired HTML comment markers emitted by
+   * ContentElementMarkerEventListener (site setting frontendEdit.markerBasedDetection):
+   *
+   *   <!--xfe:b:tt_content:12-->...<!--xfe:e:tt_content:12-->
+   *
+   * Unlike the id="c{uid}" anchor this identifies elements deterministically and
+   * nests properly, so container structures form a real tree. A record rendered
+   * more than once yields several instances; consumers in 2.x use the first, since
+   * Registry and the AJAX response are keyed by uid.
+   *
+   * Absent markers are the normal case (feature off, or an HTML minifier stripped
+   * the comments) - every lookup then returns null and the caller falls back to the
+   * anchor / data-attribute channels.
+   */
+  const MarkerIndex = {
+    PATTERN: /^xfe:([be]):([a-z][a-z0-9_]*):(\d+)$/,
+
+    instances: [],
+    byUid: new Map(),
+    byElement: new Map(),
+
+    /**
+     * Single TreeWalker pass, stack-based pairing.
+     */
+    build(root) {
+      this.instances = [];
+      this.byUid = new Map();
+      this.byElement = new Map();
+
+      const scope = root || document.body;
+      if (!scope) return this;
+
+      const walker = document.createTreeWalker(scope, NodeFilter.SHOW_COMMENT);
+      const stack = [];
+      let node;
+
+      while ((node = walker.nextNode())) {
+        const match = (node.nodeValue || '').trim().match(this.PATTERN);
+        if (!match) continue;
+
+        const [, kind, table, uidString] = match;
+        const uid = parseInt(uidString, 10);
+        if (!(uid > 0)) continue;
+
+        if ('b' === kind) {
+          // Registered on the start marker, so instances come out in document
+          // order - end markers close inside-out and would reverse nested pairs.
+          const instance = {
+            table,
+            uid,
+            startNode: node,
+            endNode: null,
+            depth: stack.length,
+            parentInstance: stack.length > 0 ? stack[stack.length - 1] : null,
+            element: null
+          };
+          stack.push(instance);
+          this.instances.push(instance);
+          if (!this.byUid.has(uid)) this.byUid.set(uid, []);
+          this.byUid.get(uid).push(instance);
+          continue;
+        }
+
+        // End marker: find its start from the top of the stack. Anything above the
+        // match is a start whose end never arrived - a minifier removed it, or
+        // table foster-parenting moved it out of the pair. Those stay unresolved
+        // (element === null) rather than swallowing the rest of the document.
+        let matchAt = -1;
+        for (let i = stack.length - 1; i >= 0; i--) {
+          if (stack[i].uid === uid && stack[i].table === table) {
+            matchAt = i;
+            break;
+          }
+        }
+
+        if (matchAt < 0) continue;
+
+        const instance = stack[matchAt];
+        stack.length = matchAt;
+
+        instance.endNode = node;
+        instance.element = this.resolveElement(instance);
+
+        // First instance wins the element mapping, matching the uid-keyed lookups.
+        if (instance.element && !this.byElement.has(instance.element)) {
+          this.byElement.set(instance.element, instance);
+        }
+      }
+
+      if (this.instances.length > 0) {
+        Logger.log(`Marker index built: ${this.instances.length} instance(s)`, {
+          resolved: this.byElement.size
+        });
+      }
+
+      return this;
+    },
+
+    /**
+     * A marker pair delimits a range, but every consumer (overlay, hover hit-test,
+     * drag & drop) needs one concrete element - so only an unambiguous range, with
+     * exactly one element and nothing else in it, is accepted. Giving up falls back
+     * to the anchor channel, whereas a wrapper-less range would break hover and
+     * dragging silently, and reaching for the parent would put the toolbar on the
+     * surrounding column.
+     */
+    resolveElement(instance) {
+      const elements = [];
+      let hasLooseText = false;
+      let reachedEnd = false;
+
+      for (let node = instance.startNode.nextSibling; node; node = node.nextSibling) {
+        if (node === instance.endNode) {
+          reachedEnd = true;
+          break;
+        }
+        if (Node.ELEMENT_NODE === node.nodeType) {
+          elements.push(node);
+        } else if (Node.TEXT_NODE === node.nodeType && '' !== (node.nodeValue || '').trim()) {
+          hasLooseText = true;
+        }
+      }
+
+      // Markers are not siblings - the HTML parser relocated one of them.
+      if (!reachedEnd) return null;
+
+      return 1 === elements.length && !hasLooseText ? elements[0] : null;
+    },
+
+    /**
+     * The uid arrives as a string from Object.entries() over the AJAX response,
+     * while the index keys it numerically - Map lookups are type-strict, so it has
+     * to be normalised here.
+     *
+     * @returns {Element|null}
+     */
+    firstElementForUid(uid) {
+      const key = Number(uid);
+      if (!Number.isInteger(key)) return null;
+
+      const instances = this.byUid.get(key);
+      if (!instances) return null;
+
+      const resolved = instances.find(instance => instance.element);
+      return resolved ? resolved.element : null;
+    },
+
+    instanceForElement(element) {
+      return this.byElement.get(element) || null;
+    }
+  };
+
+  /**
    * Element Resolver - Handles anchor patterns and finds the actual content element
    */
   const ElementResolver = {
@@ -612,10 +765,18 @@
 
     /**
      * Locate the DOM anchor for a content element uid: the id="c{uid}"
-     * pattern first (existing behavior, unchanged), falling back to
+     * pattern first (existing behavior, unchanged), then
      * data-frontend-edit="tt_content:{uid}" - a direct target, since a
      * hand-placed data attribute is never an anchor-sibling placeholder the
-     * way an empty <a id="c123"></a> is.
+     * way an empty <a id="c123"></a> is - and render markers last.
+     *
+     * Markers come last on purpose. They only need to answer the case the other
+     * two cannot: an element carrying neither anchor nor attribute. Consulting
+     * them first would also re-target elements that already resolve today - where
+     * a marker wraps an outer frame while the anchor sits on an inner node, the
+     * toolbar would silently move - so the deterministic channel is additive here
+     * rather than authoritative. Marker precedence belongs with the switch to
+     * instance identity, which is a breaking change anyway.
      *
      * @returns {{element: Element, isDirectTarget: boolean}|null}
      */
@@ -625,6 +786,10 @@
 
       const dataElement = document.querySelector(`[data-frontend-edit="tt_content:${uid}"]`);
       if (dataElement) return { element: dataElement, isDirectTarget: true };
+
+      // Resolved to the real element already, never to an anchor placeholder.
+      const markerElement = MarkerIndex.firstElementForUid(uid);
+      if (markerElement) return { element: markerElement, isDirectTarget: true };
 
       return null;
     }
@@ -646,6 +811,12 @@
      * Used to apply different toolbar positioning for nested elements
      */
     isNestedContentElement(targetElement) {
+      // Markers form a real tree, so their depth is authoritative where available.
+      // The id="c{uid}" walk below cannot see nesting for elements that carry only
+      // markers, and would report them as top-level.
+      const instance = MarkerIndex.instanceForElement(targetElement);
+      if (instance) return instance.depth > 0;
+
       let parent = targetElement.parentElement;
       while (parent) {
         // Check if parent has content element ID pattern
@@ -1387,6 +1558,26 @@
     collectDataItems() {
       const dataItems = {};
       const allUids = new Set();
+
+      // Primary channel: paired comment markers emitted during rendering (site
+      // setting frontendEdit.markerBasedDetection). Deterministic and independent
+      // of how the site's templates are built, so elements without an id="c{uid}"
+      // anchor and without a data attribute are found too. The channels below stay
+      // active and unchanged - allUids deduplicates, so no special casing needed.
+      const markerInstances = MarkerIndex.build().instances;
+      let markerUids = 0;
+      markerInstances.forEach(instance => {
+        if ('tt_content' === instance.table && !allUids.has(instance.uid)) {
+          allUids.add(instance.uid);
+          markerUids++;
+        }
+      });
+
+      if (markerInstances.length > 0) {
+        Logger.log(`Found ${markerUids} content element(s) via render markers`, {
+          instances: markerInstances.length
+        });
+      }
 
       // Scan DOM for all content elements by id="c{uid}" pattern
       // This enables editing content from other pages (onepager scenarios).

--- a/Tests/Playwright/tests/marker-matching.spec.ts
+++ b/Tests/Playwright/tests/marker-matching.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { HoverMenu } from '../support/frontend-edit/hover-menu';
+
+// "About This Demo" text element on the Home page, with its usual id="c2"
+// anchor (Tests/Acceptance/Fixtures/demo-content.sql).
+const ANCHOR_UID = 2;
+
+// "Our Mission" - lives on the About Us page and has no id="c7" anchor on the
+// Home page, so it is a real, fetchable tt_content record with nothing else
+// already competing for the marker matching under test. Same rationale as in
+// data-attribute-matching.spec.ts.
+const MARKER_ONLY_UID = 7;
+
+/**
+ * Places a marker pair around a synthetic element, mirroring what
+ * ContentElementMarkerEventListener emits during rendering. Registered before
+ * navigation and driven by DOMContentLoaded, which fires before
+ * frontend_edit.js's own bootstrap - so the nodes exist in time for
+ * MarkerIndex.build() inside DataService.collectDataItems().
+ */
+async function injectMarkerPair(
+  page: import('@playwright/test').Page,
+  elementId: string,
+  uid: number,
+): Promise<void> {
+  await page.addInitScript(
+    ({ elementId, uid }) => {
+      document.addEventListener('DOMContentLoaded', () => {
+        const begin = document.createComment(`xfe:b:tt_content:${uid}`);
+        const element = document.createElement('div');
+        element.id = elementId;
+        element.textContent = 'Marker test element';
+        const end = document.createComment(`xfe:e:tt_content:${uid}`);
+
+        // Prepended in reverse so the resulting order is begin, element, end.
+        // Prepended rather than appended because a fixed cookie-consent banner
+        // sits at the bottom of the page and would intercept hover hit-testing.
+        document.body.prepend(end);
+        document.body.prepend(element);
+        document.body.prepend(begin);
+      });
+    },
+    { elementId, uid },
+  );
+}
+
+test('the rendered page carries marker pairs for a logged-in backend user', async ({ page }) => {
+  await page.goto('/');
+  const html = await page.content();
+
+  // Proves the whole server-side chain: the TypoScript condition set the sentinel
+  // key, and the listener wrapped the element. The demo site renders content
+  // through bootstrap-package's lib.dynamicContent, which sets
+  // renderObj.stdWrap.dataWrap itself - so this simultaneously guards against the
+  // collision that made a dataWrap-based implementation silently emit nothing.
+  const beginMarkers = html.match(/<!--xfe:b:tt_content:\d+-->/g) ?? [];
+  const endMarkers = html.match(/<!--xfe:e:tt_content:\d+-->/g) ?? [];
+
+  expect(beginMarkers.length).toBeGreaterThan(0);
+  expect(endMarkers.length).toBe(beginMarkers.length);
+});
+
+test('an element with only marker comments receives an overlay/menu, without an id anchor or data attribute', async ({ page }) => {
+  await injectMarkerPair(page, 'xfe-test-marker-target', MARKER_ONLY_UID);
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const toolbar = page.locator(`.frontend-edit__toolbar[data-cid="${MARKER_ONLY_UID}"]`);
+  await expect(toolbar).toHaveCount(1);
+  await expect(toolbar).toHaveCSS('opacity', '0');
+
+  // Hovering the marked element activates its toolbar, proving the marker range
+  // resolved to THAT element rather than to some ancestor wrapper.
+  await page.hover('#xfe-test-marker-target', { force: true });
+  await expect(toolbar).toHaveCSS('opacity', '1');
+});
+
+test('an unbalanced marker is ignored and leaves the rest of the page working', async ({ page }) => {
+  // A begin marker whose end never arrives - what an HTML minifier or table
+  // foster-parenting produces. It must not swallow the document or throw.
+  await page.addInitScript(() => {
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.prepend(document.createComment('xfe:b:tt_content:4242'));
+    });
+  });
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (error) => consoleErrors.push(error.message));
+
+  const editInfoResponse = page.waitForResponse((response) => response.url().includes('/ajax/xima-frontend-edit/edit-information'));
+  await page.goto('/');
+  await editInfoResponse;
+
+  const hoverMenu = new HoverMenu(page);
+  await expect(hoverMenu.toolbar(ANCHOR_UID)).toHaveCount(1);
+  expect(consoleErrors).toEqual([]);
+});

--- a/Tests/Unit/EventListener/ContentElementMarkerEventListenerTest.php
+++ b/Tests/Unit/EventListener/ContentElementMarkerEventListenerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_frontend_edit" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3FrontendEdit\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsExecutedEvent;
+use Xima\XimaTypo3FrontendEdit\EventListener\ContentElementMarkerEventListener;
+
+/**
+ * ContentElementMarkerEventListenerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ContentElementMarkerEventListener::class)]
+final class ContentElementMarkerEventListenerTest extends TestCase
+{
+    private ContentElementMarkerEventListener $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ContentElementMarkerEventListener();
+    }
+
+    #[Test]
+    public function contentIsUnchangedWhenSentinelKeyIsAbsent(): void
+    {
+        $event = $this->createEvent('<p>Text</p>', [], ['uid' => 12]);
+
+        ($this->subject)($event);
+
+        self::assertSame('<p>Text</p>', $event->getContent());
+    }
+
+    #[Test]
+    public function contentIsUnchangedWhenSentinelKeyIsFalsy(): void
+    {
+        $event = $this->createEvent('<p>Text</p>', ['xfeMarkers' => '0'], ['uid' => 12]);
+
+        ($this->subject)($event);
+
+        self::assertSame('<p>Text</p>', $event->getContent());
+    }
+
+    #[Test]
+    public function contentIsUnchangedWhenContentIsNull(): void
+    {
+        $event = $this->createEvent(null, ['xfeMarkers' => '1'], ['uid' => 12]);
+
+        ($this->subject)($event);
+
+        self::assertNull($event->getContent());
+    }
+
+    /**
+     * An empty element -- suppressed by stdWrap.required, or a plugin returning
+     * nothing -- must not produce an empty marker pair.
+     */
+    #[Test]
+    public function contentIsUnchangedWhenContentIsEmpty(): void
+    {
+        $event = $this->createEvent('', ['xfeMarkers' => '1'], ['uid' => 12]);
+
+        ($this->subject)($event);
+
+        self::assertSame('', $event->getContent());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[Test]
+    #[DataProvider('unusableRecordDataProvider')]
+    public function contentIsUnchangedWhenUidIsUnusable(array $data): void
+    {
+        $event = $this->createEvent('<p>Text</p>', ['xfeMarkers' => '1'], $data);
+
+        ($this->subject)($event);
+
+        self::assertSame('<p>Text</p>', $event->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function unusableRecordDataProvider(): iterable
+    {
+        yield 'no uid at all' => [[]];
+        yield 'uid zero' => [['uid' => 0]];
+        yield 'uid non numeric' => [['uid' => 'foo']];
+    }
+
+    #[Test]
+    public function contentIsWrappedInMarkerPair(): void
+    {
+        $event = $this->createEvent('<p>Text</p>', ['xfeMarkers' => '1'], ['uid' => 12]);
+
+        ($this->subject)($event);
+
+        self::assertSame(
+            '<!--xfe:b:tt_content:12--><p>Text</p><!--xfe:e:tt_content:12-->',
+            $event->getContent(),
+        );
+    }
+
+    #[Test]
+    public function uidIsCastToIntegerSoThePayloadStaysNumeric(): void
+    {
+        $event = $this->createEvent('<p>Text</p>', ['xfeMarkers' => '1'], ['uid' => '12']);
+
+        ($this->subject)($event);
+
+        self::assertSame(
+            '<!--xfe:b:tt_content:12--><p>Text</p><!--xfe:e:tt_content:12-->',
+            $event->getContent(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     * @param array<string, mixed> $data
+     */
+    private function createEvent(
+        ?string $content,
+        array $configuration,
+        array $data,
+    ): AfterStdWrapFunctionsExecutedEvent {
+        $contentObjectRenderer = $this->createMock(ContentObjectRenderer::class);
+        $contentObjectRenderer->data = $data;
+
+        return new AfterStdWrapFunctionsExecutedEvent($content, $configuration, $contentObjectRenderer);
+    }
+}


### PR DESCRIPTION
## Summary

- Add an opt-in channel that identifies content elements via invisible HTML comment markers (`<!--xfe:b:tt_content:12-->...<!--xfe:e:tt_content:12-->`), for templates that emit neither an `id="c{uid}"` anchor nor a `data-frontend-edit` attribute
- Markers are only rendered for logged-in backend users and are cached separately from anonymous output; an HTML minifier that strips comments simply disables the channel, falling back to the existing anchor/attribute detection unchanged
- Gate the feature behind the `frontendEdit.markerBasedDetection` site setting, additionally requiring `frontendEdit.enabled`
- Enable the setting in the local ddev site template for testing

## Changes

- `Classes/EventListener/ContentElementMarkerEventListener.php` - new PSR-14 listener wrapping rendered content elements in the marker comments
- `Configuration/Sets/XimaTypo3FrontendEdit/setup.typoscript` - registers the marker wrap, gated on `frontendEdit.enabled` and `frontendEdit.markerBasedDetection`
- `Configuration/Sets/XimaTypo3FrontendEdit/settings.definitions.yaml`, `Resources/Private/Language/*.xlf` - new experimental site setting
- `Resources/Public/JavaScript/frontend_edit.js` - `MarkerIndex` (single TreeWalker pass, stack-based pairing) resolves marker instances to elements and feeds anchor resolution and nesting detection
- `Tests/Unit/EventListener/ContentElementMarkerEventListenerTest.php`, `Tests/Playwright/tests/marker-matching.spec.ts` - unit and E2E coverage
- `.ddev/.setup/templates/config/sites/main/settings.yaml` - enable the setting in the local dev site

## Test Plan

- [ ] Enable `frontendEdit.markerBasedDetection` on a page whose template emits neither an anchor nor a data attribute and confirm the edit toolbar appears
- [ ] Confirm nested content elements (e.g. inside a container) report correct depth via the marker tree
- [ ] Confirm the existing anchor/data-attribute detection is unaffected when the setting is off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional marker-based detection for frontend editing.
  * Content elements can now be identified and made editable even without standard anchors or data attributes.
  * Added a setting to enable this experimental feature for logged-in backend users.
  * Existing detection methods remain available as a fallback.

* **Bug Fixes**
  * Improved handling of nested content elements and incomplete markers.

* **Tests**
  * Added coverage for marker matching, invalid content data, and frontend overlay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->