### PR TITLE
fix: restore bk2k/bootstrap-package and b13/container to ddev install

### DIFF
--- a/.ddev/.setup/project.sh
+++ b/.ddev/.setup/project.sh
@@ -1,0 +1,14 @@
+# .ddev/.setup/project.sh — repo-owned customizations for `ddev install`.
+#
+# Sourced by utils.sh on every install; survives `ddev add-on get` upgrades
+# since it isn't managed by the add-on itself. See project.sh.example for the
+# full set of available hooks.
+
+# bk2k/bootstrap-package: themed sitepackage base for local dev.
+# b13/container: provides the tx_container_parent field and container CTypes
+# exercised by Tests/Acceptance/Fixtures/demo-content.sql and the frontend
+# drag & drop / container E2E coverage.
+ADDITIONAL_PACKAGES=(
+    'bk2k/bootstrap-package:*'
+    'b13/container:*'
+)


### PR DESCRIPTION
## Summary

- Create the missing `.ddev/.setup/project.sh` (repo-owned customizations, see `project.sh.example`) declaring `bk2k/bootstrap-package` and `b13/container` as `ADDITIONAL_PACKAGES`
- The ddev-typo3-multi-version-extension addon update (#262) moved project-specific composer packages out of the generic `install_composer_packages()` and into this repo-owned file, but the file itself was never created — so those two packages silently stopped being installed on every `ddev install`
- `b13/container` provides the `tx_container_parent` column and `container_2_columns` CType that `Tests/Acceptance/Fixtures/demo-content.sql` and the frontend drag & drop / container E2E coverage depend on; without it active, the E2E fixture import fails with `Unknown column 'tx_container_parent'` (see #261, #265)

## Changes

- `.ddev/.setup/project.sh` - new file, declares the two packages

## Test Plan

- [x] `ddev install 13` completes without error, `demo-content.sql` imports cleanly
- [x] `ddev install 14` completes without error, `demo-content.sql` imports cleanly
- [x] `vendor/bin/typo3 extension:list` shows `container` and `bootstrap_package` as active