### PR TITLE
fix: use a native click for the linkPolicy embedded-document test

### DIFF
--- a/Tests/Playwright/tests/backend-view.spec.ts
+++ b/Tests/Playwright/tests/backend-view.spec.ts
@@ -134,9 +134,15 @@ test('openBackendView: linkPolicy governs link clicks inside the embedded docume
     body.appendChild(close);
   });
 
+  // A native .click() call, not a synthetic pointer click: CKEditor's
+  // inspector panel (auto-attached whenever BE/debug is on, as it is in this
+  // dev environment) docks over the form and can occlude the injected link
+  // at its screen coordinates - even Playwright's `force: true` still
+  // dispatches at those coordinates and would hit the inspector instead.
+  // Calling .click() on the element directly sidesteps hit-testing entirely.
   await Promise.all([
     page.waitForEvent('load'),
-    frame.locator('#xfe-test-close-link').click(),
+    frame.locator('#xfe-test-close-link').evaluate((el: HTMLElement) => el.click()),
   ]);
 
   // 'close' action closed the modal and (default reloadOnClose) reloaded -


### PR DESCRIPTION
## Summary

- Fix `openBackendView: linkPolicy governs link clicks inside the embedded document` (Tests/Playwright/tests/backend-view.spec.ts), which had become flaky/timing out
- Root cause: CKEditor's inspector panel is auto-attached to the editor instance whenever `BE/debug` is on (as it always is in this ddev dev environment) and docks directly over the edit form. Playwright's synthetic pointer click - even with `force: true` - still dispatches at the target element's screen coordinates, so the click was landing on the inspector's own "documentation" link instead of the test's injected `#xfe-test-close-link`
- Calling `.click()` on the DOM node directly (via `evaluate`) sidesteps coordinate-based hit-testing entirely and always reaches the intended element

## Changes

- `Tests/Playwright/tests/backend-view.spec.ts` - use `frame.locator(...).evaluate(el => el.click())` instead of `frame.locator(...).click()`

## Test Plan

- [x] Isolated test run 5x in a row locally: 5/5 pass (previously ~50% flaky even with `force: true`, reproducibly failing without it)
- [x] Full `tests/backend-view.spec.ts` suite: all pass
- [x] Full Playwright suite on TYPO3 13: 37 passed, 2 skipped, 0 failed
- [x] `npx tsc --noEmit`: clean