### PR TITLE
fix: require ssch/typo3-rector >=3.15 for rector/rector 2.6.4 compatibility

### DIFF
--- a/Classes/Service/Ui/IconService.php
+++ b/Classes/Service/Ui/IconService.php
@@ -36,12 +36,10 @@ final class IconService
 
     public function getIcon(string $identifier): Icon
     {
-        if (!isset($this->iconCache[$identifier])) {
-            $this->iconCache[$identifier] = $this->iconFactory->getIcon(
-                $identifier,
-                IconSize::SMALL,
-            );
-        }
+        $this->iconCache[$identifier] ??= $this->iconFactory->getIcon(
+            $identifier,
+            IconSize::SMALL,
+        );
 
         return $this->iconCache[$identifier];
     }

--- a/Tests/CGL/composer.json
+++ b/Tests/CGL/composer.json
@@ -17,7 +17,7 @@
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"psr/http-message": "^1.0 || ^2.0",
 		"shipmonk/composer-dependency-analyser": "1.8.4",
-		"ssch/typo3-rector": "^2.10 || ^3.0",
+		"ssch/typo3-rector": "^2.10 || ^3.15",
 		"typo3/coding-standards": "^0.7 || ^0.8 || ^0.9"
 	},
 	"replace": {


### PR DESCRIPTION
## Summary

- Bump `ssch/typo3-rector` to `^2.10 || ^3.15` since [v3.15.1](https://github.com/sabbelasichon/typo3-rector/releases/tag/v3.15.1) replaces the container APIs that rector/rector 2.6.4 removed
- Without the bump, an unconstrained `ssch/typo3-rector` resolves to v3.15.0, which still crashes with `RectorConfig::bind()` undefined against rector/rector 2.6.4+

## Changes

- `Tests/CGL/composer.json` - require ssch/typo3-rector >=3.15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported development tooling version range to include newer 3.15 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->